### PR TITLE
Remove [replace] of curl. Fix in windows-separate-dir merged into master branch of curl-rust.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,3 @@ env_logger = "0.4"
 
 [replace]
 "bytes:0.4.4" = { git = "https://github.com/danburkert/bytes", branch = "take-bytes-index-oob" }
-"curl:0.4.7" = { git = "https://github.com/alexcrichton/curl-rust", branch = "windows-separate-dir" }


### PR DESCRIPTION
`cargo build` was failing with: 

```
error: failed to load source for a dependency on `curl`

Caused by:
  Unable to update https://github.com/alexcrichton/curl-rust?branch=windows-separate-dir

Caused by:
  failed to find branch `windows-separate-dir`

```
Checked out curl-rust and the fix was merged: https://github.com/alexcrichton/curl-rust/pull/175