### PR TITLE
Use heck for ident conversions

### DIFF
--- a/prost-codegen/Cargo.toml
+++ b/prost-codegen/Cargo.toml
@@ -12,6 +12,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 [dependencies]
 bytes = "0.4"
 env_logger = "0.4"
+heck = "0.2"
 itertools = "0.6"
 log = "0.3"
 multimap = "0.3"

--- a/prost-codegen/src/code_generator.rs
+++ b/prost-codegen/src/code_generator.rs
@@ -22,9 +22,9 @@ use google::protobuf::{
 use google::protobuf::field_descriptor_proto::{Label, Type};
 use google::protobuf::source_code_info::Location;
 use ident::{
-    camel_to_snake,
+    to_snake,
     match_field,
-    snake_to_upper_camel,
+    to_upper_camel,
 };
 use message_graph::MessageGraph;
 use CodeGeneratorConfig;
@@ -34,7 +34,7 @@ pub fn module(file: &FileDescriptorProto) -> Module {
     file.package()
         .split('.')
         .filter(|s| !s.is_empty())
-        .map(camel_to_snake)
+        .map(to_snake)
         .collect()
 }
 
@@ -248,7 +248,7 @@ impl <'a> CodeGenerator<'a> {
         self.buf.push_str("\")]\n");
         self.push_indent();
         self.buf.push_str("pub ");
-        self.buf.push_str(&camel_to_snake(field.name()));
+        self.buf.push_str(&to_snake(field.name()));
         self.buf.push_str(": ");
         if repeated { self.buf.push_str("Vec<"); }
         else if optional { self.buf.push_str("Option<"); }
@@ -292,7 +292,7 @@ impl <'a> CodeGenerator<'a> {
                                    field.number()));
         self.push_indent();
         self.buf.push_str(&format!("pub {}: ::std::collections::{}<{}, {}>,\n",
-                                   camel_to_snake(field.name()), rust_ty, key_ty, value_ty));
+                                   to_snake(field.name()), rust_ty, key_ty, value_ty));
     }
 
     fn append_oneof_field(&mut self,
@@ -300,15 +300,15 @@ impl <'a> CodeGenerator<'a> {
                           oneof: &OneofDescriptorProto,
                           fields: &[(FieldDescriptorProto, usize)]) {
         let name = format!("{}::{}",
-                           camel_to_snake(message_name),
-                           snake_to_upper_camel(oneof.name()));
+                           to_snake(message_name),
+                           to_upper_camel(oneof.name()));
         self.append_doc();
         self.push_indent();
         self.buf.push_str(&format!("#[prost(oneof=\"{}\", tags=\"{}\")]\n",
                                    name,
                                    fields.iter().map(|&(ref field, _)| field.number()).join(", ")));
         self.push_indent();
-        self.buf.push_str(&format!("pub {}: Option<{}>,\n", camel_to_snake(oneof.name()), name));
+        self.buf.push_str(&format!("pub {}: Option<{}>,\n", to_snake(oneof.name()), name));
     }
 
     fn append_oneof(&mut self,
@@ -325,7 +325,7 @@ impl <'a> CodeGenerator<'a> {
         self.buf.push_str("#[derive(Clone, Debug, Oneof, PartialEq)]\n");
         self.push_indent();
         self.buf.push_str("pub enum ");
-        self.buf.push_str(&snake_to_upper_camel(oneof.name()));
+        self.buf.push_str(&to_upper_camel(oneof.name()));
         self.buf.push_str(" {\n");
 
         self.path.push(2);
@@ -341,7 +341,7 @@ impl <'a> CodeGenerator<'a> {
 
             self.push_indent();
             let ty = self.resolve_type(&field);
-            self.buf.push_str(&format!("{}({}),\n", snake_to_upper_camel(field.name()), ty));
+            self.buf.push_str(&format!("{}({}),\n", to_upper_camel(field.name()), ty));
         }
         self.depth -= 1;
         self.path.pop();
@@ -437,7 +437,7 @@ impl <'a> CodeGenerator<'a> {
     fn append_enum_value(&mut self, value: EnumValueDescriptorProto) {
         self.append_doc();
         self.push_indent();
-        self.buf.push_str(&snake_to_upper_camel(value.name()));
+        self.buf.push_str(&to_upper_camel(value.name()));
         self.buf.push_str(" = ");
         self.buf.push_str(&value.number().to_string());
         self.buf.push_str(",\n");
@@ -490,7 +490,7 @@ impl <'a> CodeGenerator<'a> {
     fn push_mod(&mut self, module: &str) {
         self.push_indent();
         self.buf.push_str("pub mod ");
-        self.buf.push_str(&camel_to_snake(module));
+        self.buf.push_str(&to_snake(module));
         self.buf.push_str(" {\n");
 
         self.package.push_str(".");
@@ -543,7 +543,7 @@ impl <'a> CodeGenerator<'a> {
         }
 
         local_path.map(|_| "super".to_string())
-                  .chain(ident_path.map(camel_to_snake))
+                  .chain(ident_path.map(to_snake))
                   .chain(Some(ident_type.to_string()).into_iter())
                   .join("::")
     }

--- a/prost-codegen/src/ident.rs
+++ b/prost-codegen/src/ident.rs
@@ -1,30 +1,11 @@
 //! Utility functions for working with identifiers.
 
+use heck::{CamelCase, SnakeCase};
+
 /// Converts a camelCase or SCREAMING_SNAKE_CASE identifier to lower_snake case
 /// Rust field identifier.
-pub fn camel_to_snake(camel: &str) -> String {
-    // protoc does not allow non-ascii identifiers.
-    let len = camel.as_bytes().iter().skip(1).filter(|&&c| is_uppercase(c)).count() + camel.len();
-    let mut snake = Vec::with_capacity(len);
-
-    let mut break_on_cap = false;
-    for &c in camel.as_bytes().iter() {
-        if is_uppercase(c) {
-            if break_on_cap {
-                snake.push(b'_');
-            }
-            snake.push(to_lowercase(c));
-            break_on_cap = false;
-        } else if c == b'_' {
-            snake.push(b'_');
-            break_on_cap = false;
-        } else {
-            snake.push(c);
-            break_on_cap = true;
-        }
-    }
-
-    let mut ident = String::from_utf8(snake).expect(&format!("non-utf8 identifier: {}", camel));
+pub fn to_snake(s: &str) -> String {
+    let mut ident = s.to_snake_case();
 
     // Add a trailing underscore if the identifier matches a Rust keyword
     // (https://doc.rust-lang.org/grammar.html#keywords).
@@ -45,22 +26,8 @@ pub fn camel_to_snake(camel: &str) -> String {
 }
 
 /// Converts a snake_case identifier to UpperCamel case Rust type identifier.
-pub fn snake_to_upper_camel(snake: &str) -> String {
-    let mut ident = String::with_capacity(snake.len());
-
-    if snake.is_empty() {
-        return ident;
-    }
-
-    for fragment in snake.split('_') {
-        if fragment.is_empty() {
-            ident.push('_');
-        } else {
-            let (first, rest) = fragment.split_at(1);
-            ident.push_str(&first.to_uppercase());
-            ident.push_str(&rest.to_lowercase());
-        }
-    }
+pub fn to_upper_camel(s: &str) -> String {
+    let mut ident = s.to_camel_case();
 
     // Add a trailing underscore if the identifier matches a Rust keyword
     // (https://doc.rust-lang.org/grammar.html#keywords).
@@ -104,73 +71,63 @@ pub fn match_field(matcher: &str, msg: &str, field: &str) -> bool {
     }
 }
 
-/// Returns true if the character is an upper-case ASCII character.
-#[inline]
-fn is_uppercase(c: u8) -> bool {
-    c >= b'A' && c <= b'Z'
-}
-
-/// Converts an upper-case ASCII character to lower-case.
-#[inline]
-fn to_lowercase(c: u8) -> u8 {
-    debug_assert!(is_uppercase(c));
-    c + 32
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_camel_to_snake() {
-        assert_eq!("foo_bar", &camel_to_snake("FooBar"));
-        assert_eq!("foo_bar_baz", &camel_to_snake("FooBarBAZ"));
-        assert_eq!("foo_bar_baz", &camel_to_snake("FooBArBAZ"));
-        assert_eq!("foo_bar_bazle_e", &camel_to_snake("FooBArBAZleE"));
-        assert_eq!("while_", &camel_to_snake("While"));
-        assert_eq!("fuzz_buster", &camel_to_snake("FUZZ_BUSTER"));
-        assert_eq!("foo_bar_baz", &camel_to_snake("foo_bar_baz"));
-        assert_eq!("fuzz_buster", &camel_to_snake("FUZZ_buster"));
-        assert_eq!("_fuzz", &camel_to_snake("_FUZZ"));
-        assert_eq!("_fuzz", &camel_to_snake("_fuzz"));
-        assert_eq!("_fuzz", &camel_to_snake("_Fuzz"));
-        assert_eq!("fuzz_", &camel_to_snake("FUZZ_"));
-        assert_eq!("fuzz_", &camel_to_snake("fuzz_"));
-        assert_eq!("fuzz_", &camel_to_snake("Fuzz_"));
-        assert_eq!("fuz_z_", &camel_to_snake("FuzZ_"));
+    fn test_to_snake() {
+        assert_eq!("foo_bar", &to_snake("FooBar"));
+        assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ"));
+        assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ"));
+        assert_eq!("xml_http_request", &to_snake("XMLHttpRequest"));
+        assert_eq!("while_", &to_snake("While"));
+        assert_eq!("fuzz_buster", &to_snake("FUZZ_BUSTER"));
+        assert_eq!("foo_bar_baz", &to_snake("foo_bar_baz"));
+        assert_eq!("fuzz_buster", &to_snake("FUZZ_buster"));
+        assert_eq!("fuzz", &to_snake("_FUZZ"));
+        assert_eq!("fuzz", &to_snake("_fuzz"));
+        assert_eq!("fuzz", &to_snake("_Fuzz"));
+        assert_eq!("fuzz", &to_snake("FUZZ_"));
+        assert_eq!("fuzz", &to_snake("fuzz_"));
+        assert_eq!("fuzz", &to_snake("Fuzz_"));
+        assert_eq!("fuz_z", &to_snake("FuzZ_"));
 
         // From test_messages_proto3.proto.
-        assert_eq!("fieldname1", &camel_to_snake("fieldname1"));
-        assert_eq!("field_name2", &camel_to_snake("field_name2"));
-        assert_eq!("_field_name3", &camel_to_snake("_field_name3"));
-        assert_eq!("field__name4_", &camel_to_snake("field__name4_"));
-        assert_eq!("field0name5", &camel_to_snake("field0name5"));
-        assert_eq!("field_0_name6", &camel_to_snake("field_0_name6"));
-        assert_eq!("field_name7", &camel_to_snake("fieldName7"));
-        assert_eq!("field_name8", &camel_to_snake("FieldName8"));
-        assert_eq!("field_name9", &camel_to_snake("field_Name9"));
-        assert_eq!("field_name10", &camel_to_snake("Field_Name10"));
-        assert_eq!("field_name11", &camel_to_snake("FIELD_NAME11"));
-        assert_eq!("field_name12", &camel_to_snake("FIELD_name12"));
-        assert_eq!("__field_name13", &camel_to_snake("__field_name13"));
-        assert_eq!("__field_name14", &camel_to_snake("__Field_name14"));
-        assert_eq!("field__name15", &camel_to_snake("field__name15"));
-        assert_eq!("field__name16", &camel_to_snake("field__Name16"));
-        assert_eq!("field_name17__", &camel_to_snake("field_name17__"));
-        assert_eq!("field_name18__", &camel_to_snake("Field_name18__"));
+        assert_eq!("fieldname1", &to_snake("fieldname1"));
+        assert_eq!("field_name2", &to_snake("field_name2"));
+        assert_eq!("field_name3", &to_snake("_field_name3"));
+        assert_eq!("field_name4", &to_snake("field__name4_"));
+        assert_eq!("field0name5", &to_snake("field0name5"));
+        assert_eq!("field_0_name6", &to_snake("field_0_name6"));
+        assert_eq!("field_name7", &to_snake("fieldName7"));
+        assert_eq!("field_name8", &to_snake("FieldName8"));
+        assert_eq!("field_name9", &to_snake("field_Name9"));
+        assert_eq!("field_name10", &to_snake("Field_Name10"));
+
+        // TODO(withoutboats/heck#3)
+        //assert_eq!("field_name11", &to_snake("FIELD_NAME11"));
+        assert_eq!("field_name12", &to_snake("FIELD_name12"));
+        assert_eq!("field_name13", &to_snake("__field_name13"));
+        assert_eq!("field_name14", &to_snake("__Field_name14"));
+        assert_eq!("field_name15", &to_snake("field__name15"));
+        assert_eq!("field_name16", &to_snake("field__Name16"));
+        assert_eq!("field_name17", &to_snake("field_name17__"));
+        assert_eq!("field_name18", &to_snake("Field_name18__"));
     }
 
     #[test]
-    fn test_snake_to_upper_camel() {
-        assert_eq!("", &snake_to_upper_camel(""));
-        assert_eq!("F", &snake_to_upper_camel("F"));
-        assert_eq!("Foo", &snake_to_upper_camel("FOO"));
-        assert_eq!("FooBar", &snake_to_upper_camel("FOO_BAR"));
-        assert_eq!("_FooBar", &snake_to_upper_camel("_FOO_BAR"));
-        assert_eq!("FooBar_", &snake_to_upper_camel("FOO_BAR_"));
-        assert_eq!("_FooBar_", &snake_to_upper_camel("_FOO_BAR_"));
-        assert_eq!("Fuzzbuster", &snake_to_upper_camel("fuzzBuster"));
-        assert_eq!("Self_", &snake_to_upper_camel("self"));
+    fn test_to_upper_camel() {
+        assert_eq!("", &to_upper_camel(""));
+        assert_eq!("F", &to_upper_camel("F"));
+        assert_eq!("Foo", &to_upper_camel("FOO"));
+        assert_eq!("FooBar", &to_upper_camel("FOO_BAR"));
+        assert_eq!("FooBar", &to_upper_camel("_FOO_BAR"));
+        assert_eq!("FooBar", &to_upper_camel("FOO_BAR_"));
+        assert_eq!("FooBar", &to_upper_camel("_FOO_BAR_"));
+        assert_eq!("FuzzBuster", &to_upper_camel("fuzzBuster"));
+        assert_eq!("FuzzBuster", &to_upper_camel("FuzzBuster"));
+        assert_eq!("Self_", &to_upper_camel("self"));
     }
 
     #[test]

--- a/prost-codegen/src/lib.rs
+++ b/prost-codegen/src/lib.rs
@@ -8,6 +8,7 @@ extern crate log;
 
 extern crate bytes;
 extern crate env_logger;
+extern crate heck;
 extern crate itertools;
 extern crate multimap;
 extern crate petgraph;


### PR DESCRIPTION
This is a breaking change, because heck is aggressive about pruning
prefix and suffix underscores, whereas the previous algorithm was not.
This needs to wait for withoutboats/heck#3 to be resolved, because
identifiers like `FIELD_NAME11` are recommended according to the
[Protobuf style guide][1].

[1]: https://developers.google.com/protocol-buffers/docs/style