### PR TITLE
Benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ rust:
 script:
   - cargo build --verbose --all
   - cargo test --verbose --all
+  - cargo bench --benches --verbose --all

--- a/benches/varint.rs
+++ b/benches/varint.rs
@@ -1,45 +1,40 @@
 #![feature(test)]
 
-extern crate proto;
+extern crate prost;
 extern crate test;
 extern crate bytes;
 
 use test::Bencher;
 
-use bytes::{
-    BytesMut,
-    IntoBuf,
-};
+use bytes::IntoBuf;
 
-use proto::field::{
+use prost::encoding::{
     encode_varint,
     decode_varint,
-    varint_width
 };
 
 macro_rules! varint_bench {
-    ($encode_name:ident, $decode_name:ident, $expected_bytes:expr, $encode:expr) => {
+    ($encode_name:ident, $decode_name:ident, $encode:expr) => {
         #[bench]
         fn $encode_name(b: &mut Bencher) {
-            let mut buf = BytesMut::with_capacity(4096);
+            let mut buf = Vec::with_capacity(100 * 10);
             b.iter(|| {
                 buf.clear();
                 $encode(&mut buf);
                 test::black_box(&buf[..]);
             });
-            assert_eq!(buf.len(), $expected_bytes);
             b.bytes = 100 * 8;
         }
         #[bench]
         fn $decode_name(b: &mut Bencher) {
-            let mut buf = BytesMut::with_capacity(4096);
+            let mut buf = Vec::with_capacity(100 * 10);
             $encode(&mut buf);
-            let buf = buf.freeze();
+            let buf = &buf[..];
 
             let mut values = [0u64; 100];
 
             b.iter(|| {
-                let mut buf = buf.clone().into_buf();
+                let mut buf = buf.into_buf();
                 for i in 0..100 {
                     values[i] = decode_varint(&mut buf).unwrap();
                 }
@@ -51,7 +46,7 @@ macro_rules! varint_bench {
 }
 
 /// Benchmark encoding and decoding 100 varints of mixed width (average 5.5 bytes).
-varint_bench!(encode_varint_mixed, decode_varint_mixed, 550, |ref mut buf| {
+varint_bench!(encode_varint_mixed, decode_varint_mixed, |ref mut buf| {
     for width in 0..10 {
         let exponent = width * 7;
         for offset in 0..10 {
@@ -61,14 +56,14 @@ varint_bench!(encode_varint_mixed, decode_varint_mixed, 550, |ref mut buf| {
 });
 
 /// Benchmark encoding and decoding 100 small (1 byte) varints.
-varint_bench!(encode_varint_small, decode_varint_small, 100, |ref mut buf| {
+varint_bench!(encode_varint_small, decode_varint_small, |ref mut buf| {
     for value in 0..100 {
         encode_varint(value, buf);
     }
 });
 
 /// Benchmark encoding and decoding 100 medium (5 byte) varints.
-varint_bench!(encode_varint_medium, decode_varint_medium, 500, |ref mut buf| {
+varint_bench!(encode_varint_medium, decode_varint_medium, |ref mut buf| {
     let start = 1 << 28;
     for value in start..start + 100 {
         encode_varint(value, buf);
@@ -76,7 +71,7 @@ varint_bench!(encode_varint_medium, decode_varint_medium, 500, |ref mut buf| {
 });
 
 /// Benchmark encoding and decoding 100 large (10 byte) varints.
-varint_bench!(encode_varint_large, decode_varint_large, 1000, |ref mut buf| {
+varint_bench!(encode_varint_large, decode_varint_large, |ref mut buf| {
     let start = 1 << 63;
     for value in start..start + 100 {
         encode_varint(value, buf);

--- a/benches/varint.rs
+++ b/benches/varint.rs
@@ -9,12 +9,13 @@ use test::Bencher;
 use bytes::IntoBuf;
 
 use prost::encoding::{
-    encode_varint,
     decode_varint,
+    encode_varint,
+    encoded_len_varint,
 };
 
 macro_rules! varint_bench {
-    ($encode_name:ident, $decode_name:ident, $encode:expr) => {
+    ($encode_name:ident, $decode_name:ident, $encoded_len_name: ident, $encode:expr) => {
         #[bench]
         fn $encode_name(b: &mut Bencher) {
             let mut buf = Vec::with_capacity(100 * 10);
@@ -42,11 +43,32 @@ macro_rules! varint_bench {
             });
             b.bytes = 100 * 8;
         }
+        #[bench]
+        fn $encoded_len_name(b: &mut Bencher) {
+            let mut values = [0u64; 100];
+            {
+                let mut buf = Vec::with_capacity(100 * 10);
+                $encode(&mut buf);
+                let mut buf = (&buf[..]).into_buf();
+                for i in 0..100 {
+                    values[i] = decode_varint(&mut buf).unwrap();
+                }
+            }
+
+            b.iter(|| {
+                let mut sum = 0;
+                for &value in values.iter() {
+                    sum += encoded_len_varint(value);
+                }
+                test::black_box(sum);
+            });
+            b.bytes = 100 * 8;
+        }
     }
 }
 
 /// Benchmark encoding and decoding 100 varints of mixed width (average 5.5 bytes).
-varint_bench!(encode_varint_mixed, decode_varint_mixed, |ref mut buf| {
+varint_bench!(encode_varint_mixed, decode_varint_mixed, encoded_len_varint_mixed, |ref mut buf| {
     for width in 0..10 {
         let exponent = width * 7;
         for offset in 0..10 {
@@ -56,14 +78,14 @@ varint_bench!(encode_varint_mixed, decode_varint_mixed, |ref mut buf| {
 });
 
 /// Benchmark encoding and decoding 100 small (1 byte) varints.
-varint_bench!(encode_varint_small, decode_varint_small, |ref mut buf| {
+varint_bench!(encode_varint_small, decode_varint_small, encoded_len_varint_small, |ref mut buf| {
     for value in 0..100 {
         encode_varint(value, buf);
     }
 });
 
 /// Benchmark encoding and decoding 100 medium (5 byte) varints.
-varint_bench!(encode_varint_medium, decode_varint_medium, |ref mut buf| {
+varint_bench!(encode_varint_medium, decode_varint_medium, encoded_len_varint_medium, |ref mut buf| {
     let start = 1 << 28;
     for value in start..start + 100 {
         encode_varint(value, buf);
@@ -71,7 +93,7 @@ varint_bench!(encode_varint_medium, decode_varint_medium, |ref mut buf| {
 });
 
 /// Benchmark encoding and decoding 100 large (10 byte) varints.
-varint_bench!(encode_varint_large, decode_varint_large, |ref mut buf| {
+varint_bench!(encode_varint_large, decode_varint_large, encoded_len_varint_large, |ref mut buf| {
     let start = 1 << 63;
     for value in start..start + 100 {
         encode_varint(value, buf);

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -140,16 +140,9 @@ fn decode_varint_slow<B>(buf: &mut B) -> Result<u64, DecodeError> where B: Buf {
 /// The returned value will be between 1 and 10, inclusive.
 #[inline]
 pub fn encoded_len_varint(value: u64) -> usize {
-         if value < 1 <<  7 { 1 }
-    else if value < 1 << 14 { 2 }
-    else if value < 1 << 21 { 3 }
-    else if value < 1 << 28 { 4 }
-    else if value < 1 << 35 { 5 }
-    else if value < 1 << 42 { 6 }
-    else if value < 1 << 49 { 7 }
-    else if value < 1 << 56 { 8 }
-    else if value < 1 << 63 { 9 }
-    else { 10 }
+    // Based on [VarintSize64][1].
+    // [1]: https://github.com/google/protobuf/blob/3.3.x/src/google/protobuf/io/coded_stream.h#L1301-L1309
+    ((((value | 1).leading_zeros() ^ 63) * 9 + 73) / 64) as usize
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1000,6 +1000,8 @@ mod test {
             encode_varint(value, &mut buf);
             assert_eq!(buf, encoded);
 
+            assert_eq!(encoded_len_varint(value), encoded.len());
+
             let roundtrip_value = decode_varint(&mut encoded.into_buf()).expect("decoding failed");
             assert_eq!(value, roundtrip_value);
 


### PR DESCRIPTION
This series of patches improves/adds varint encoding/decoding/encoded-len microbenchmarks, and ports over optimizations from the cpp protobuf library. Performance improvement numbers are included in the individual commit messages.

Fixes #4 

CC @overvenus