### PR TITLE
no_std support (WIP)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,19 @@ exclude = [
 
 [dependencies]
 byteorder = "1"
-bytes = "0.4"
+
+[dependencies.bytes]
+git = "https://github.com/chain/bytes.git"
+branch = "alloc"
+default-features = false
 
 [dev-dependencies]
 quickcheck = "0.4"
 prost-derive = { path = "prost-derive" }
 log = "0.3"
 env_logger = "0.4"
+
+[features]
+default = ["std"]
+alloc = ["bytes/nightly"]
+std = ["bytes/std"]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -832,8 +832,6 @@ pub mod hash_map {
 }
 
 pub mod btree_map {
-    #[cfg(feature = "alloc")]
-    use alloc::btree_map::BTreeMap;
     #[cfg(feature = "std")]
     use std::collections::BTreeMap;
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -2,10 +2,13 @@
 //!
 //! Meant to be used only from `Message` implementations.
 
-use std::cmp::min;
-use std::str;
-use std::u32;
-use std::usize;
+use core::cmp::min;
+use core::str;
+use core::u32;
+use core::usize;
+
+#[allow(unused_imports)]
+use prelude::*;
 
 use bytes::{
     Buf,
@@ -681,9 +684,7 @@ pub mod message {
 /// generic over `HashMap` and `BTreeMap`.
 macro_rules! map {
     ($map_ty:ident) => (
-        use std::collections::$map_ty;
-        use std::hash::Hash;
-
+        use core::hash::Hash;
         use ::encoding::*;
 
         /// Generic protobuf map encode function.
@@ -823,11 +824,19 @@ macro_rules! map {
     )
 }
 
+#[cfg(feature = "std")]
 pub mod hash_map {
+    use std::collections::HashMap;
+
     map!(HashMap);
 }
 
 pub mod btree_map {
+    #[cfg(feature = "alloc")]
+    use alloc::btree_map::BTreeMap;
+    #[cfg(feature = "std")]
+    use std::collections::BTreeMap;
+
     map!(BTreeMap);
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,5 @@
 //! Protobuf encoding and decoding errors.
 
-#[cfg(feature = "alloc")]
-use alloc::borrow::Cow;
-
 #[cfg(feature = "std")]
 use std::borrow::Cow;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,20 @@
 //! Protobuf encoding and decoding errors.
 
+#[cfg(feature = "alloc")]
+use alloc::borrow::Cow;
+
+#[cfg(feature = "std")]
 use std::borrow::Cow;
+
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt;
+use core::fmt;
+
+#[cfg(feature = "std")]
 use std::io;
+
+#[allow(unused_imports)]
+use prelude::*;
 
 /// A Protobuf message decoding error.
 ///
@@ -52,12 +63,14 @@ impl fmt::Display for DecodeError {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for DecodeError {
     fn description(&self) -> &str {
         &self.description
     }
 }
 
+#[cfg(feature = "std")]
 impl From<DecodeError> for io::Error {
     fn from(error: DecodeError) -> io::Error {
         io::Error::new(io::ErrorKind::InvalidData, error)
@@ -96,19 +109,23 @@ impl EncodeError {
     }
 }
 
+const ENCODE_ERROR_DESCRIPTION: &str = "failed to encode Protobuf message: insufficient buffer capacity";
+
 impl fmt::Display for EncodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(error::Error::description(self))?;
+        f.write_str(ENCODE_ERROR_DESCRIPTION)?;
         write!(f, " (required: {}, remaining: {})", self.required, self.remaining)
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for EncodeError {
     fn description(&self) -> &str {
-        "failed to encode Protobuf message: insufficient buffer capacity"
+        ENCODE_ERROR_DESCRIPTION
     }
 }
 
+#[cfg(feature = "std")]
 impl From<EncodeError> for io::Error {
     fn from(error: EncodeError) -> io::Error {
         io::Error::new(io::ErrorKind::InvalidInput, error)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,16 @@ pub mod encoding;
 pub use message::Message;
 pub use error::{DecodeError, EncodeError};
 
-/// Custom (internal-only) prelude for this module
+/// Custom (internal-only) prelude for this crate.
 mod prelude {
     #[cfg(feature = "alloc")]
     pub use alloc::boxed::Box;
+
+    #[cfg(feature = "alloc")]
+    pub use alloc::btree_map::BTreeMap;
+
+    #[cfg(feature = "alloc")]
+    pub use alloc::borrow::Cow;
 
     #[cfg(feature = "alloc")]
     pub use alloc::string::String;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,13 @@
 #![doc(html_root_url = "https://docs.rs/prost/0.1.1")]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "alloc", feature(alloc))]
+
+#[cfg(feature = "alloc")]
+#[macro_use] extern crate alloc;
+#[cfg(feature = "std")]
+extern crate core;
+
 extern crate byteorder;
 extern crate bytes;
 
@@ -15,3 +23,15 @@ pub mod encoding;
 
 pub use message::Message;
 pub use error::{DecodeError, EncodeError};
+
+/// Custom (internal-only) prelude for this module
+mod prelude {
+    #[cfg(feature = "alloc")]
+    pub use alloc::boxed::Box;
+
+    #[cfg(feature = "alloc")]
+    pub use alloc::string::String;
+
+    #[cfg(feature = "alloc")]
+    pub use alloc::vec::Vec;
+}

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,11 +1,14 @@
-use std::fmt::Debug;
-use std::usize;
+use core::fmt::Debug;
+use core::usize;
 
 use bytes::{Buf, BufMut, IntoBuf};
 
 use DecodeError;
 use EncodeError;
 use encoding::*;
+
+#[allow(unused_imports)]
+use prelude::*;
 
 /// A Protocol Buffers message.
 pub trait Message: Debug + Send + Sync {


### PR DESCRIPTION
Using an unmerged PR for bytes, and liballoc as the source for `Box`, `String`, `Vec`, and `BTreeMap`, the runtime bits of Prost can work with `no_std`