### PR TITLE
Add optional serde derives in prost-build

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -21,6 +21,10 @@ prost = { version = "0.2", path = ".." }
 prost-types = { version = "0.2", path = "../prost-types" }
 tempdir = "0.3"
 
+[features]
+# We don't actually need serde because it's just text generation
+serde-1 = []
+
 [build-dependencies]
 curl = "0.4"
 tempdir = "0.3"

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -161,7 +161,14 @@ impl <'a> CodeGenerator<'a> {
 
         self.append_doc();
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, Debug, PartialEq, Message)]\n");
+
+        self.buf.push_str("#[derive(Clone, Debug, PartialEq, Message");
+        #[cfg(feature="serde-1")]
+        {
+            self.buf.push_str(", Serialize, Deserialize");
+        }
+        self.buf.push_str(")]\n");
+
         self.push_indent();
         self.buf.push_str("pub struct ");
         self.buf.push_str(&to_upper_camel(&message_name));
@@ -353,7 +360,14 @@ impl <'a> CodeGenerator<'a> {
         self.path.pop();
 
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, Debug, Oneof, PartialEq)]\n");
+        
+        self.buf.push_str("#[derive(Clone, Debug, Oneof, PartialEq");
+        #[cfg(feature="serde-1")]
+        {
+            self.buf.push_str(", Serialize, Deserialize");
+        }
+        self.buf.push_str(")]\n");
+
         self.push_indent();
         self.buf.push_str("pub enum ");
         self.buf.push_str(&to_upper_camel(oneof.name()));
@@ -406,7 +420,14 @@ impl <'a> CodeGenerator<'a> {
 
         self.append_doc();
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]\n");
+
+        self.buf.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration");
+        #[cfg(feature="serde-1")]
+        {
+            self.buf.push_str(", Serialize, Deserialize");
+        }
+        self.buf.push_str(")]\n");
+
         self.push_indent();
         self.buf.push_str("pub enum ");
         self.buf.push_str(&to_upper_camel(desc.name()));

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -105,6 +105,33 @@
 //! If `PROTOC` and `PROTOC_INCLUDE` are not found in the environment, then a pre-compiled `protoc`
 //! binary will be downloaded and cached in the target directory. Pre-compiled `protoc` binaries
 //! exist for Linux, macOS, and Windows systems.
+//! 
+//! ## Using `serde` derives
+//! 
+//! If you wish to use `serde` to serialize structs containing `prost`-generated structs, you may activate
+//! the `serde-1` feature like so:
+//! 
+//! ```toml
+//! [build-dependencies]
+//! prost-build = {version=<prost-version>, features=["serde-1"]}
+//! ```
+//! 
+//! This will automatically `#[derive(Serialize,Deserialize)]` on all `prost`-generated structs and enums.
+//! 
+//! Like all uses of these `serde` features, this assumes that 
+//! 
+//! ```rust,ignore
+//! extern crate serde;
+//! #[macro_use]
+//! extern crate serde_derive;
+//! ```
+//! 
+//! Is in your crate root, and requires a dependency (**not** a `build-dependency`) on version 
+//! `^1` of those crates.
+//! 
+//! Note that this does **not** allow serializing into or deserializing from the Protobuf wire 
+//! format with `serde`, it merely allows you to use `serde` to (de)serialize the generated types
+//! in alternate formats.
 
 extern crate heck;
 extern crate itertools;


### PR DESCRIPTION
This documents and enables a feature gate that allows
the prost-generated structs to be serialized by serde-compatible
encoders and decoders.

This does not and is not intended to make prost "serde-compatible",
simply to ease the use of serde on user structs that may wish to
contain decoded messages.