### PR TITLE
Add support for recursive `oneof` fields

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -378,11 +378,12 @@ impl <'a> CodeGenerator<'a> {
             self.push_indent();
             let ty = self.resolve_type(&field);
 
-            let boxed = field.label == Some(Label::LabelRepeated as i32)
+            let repeated = field.label == Some(Label::LabelRepeated as i32);
+            let boxed = !repeated
                     && type_ == Type::TypeMessage
                     && self.message_graph.is_nested(field.type_name(), msg_name);
 
-            debug!("    oneof: {:?}, type: {:?}, boxed: {}", field.name(), ty, boxed);
+            debug!("    oneof: {:?}, type: {:?}:{:?}, boxed: {}", field.name(), ty, type_, boxed);
 
             if boxed {
                 self.buf.push_str(&format!("{}(Box<{}>),\n", to_upper_camel(field.name()), ty));

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -212,7 +212,7 @@ impl <'a> CodeGenerator<'a> {
 
             for (idx, oneof) in message.oneof_decl.into_iter().enumerate() {
                 let idx = idx as i32;
-                self.append_oneof(oneof, idx, oneof_fields.remove(&idx).unwrap());
+                self.append_oneof(&fq_message_name, oneof, idx, oneof_fields.remove(&idx).unwrap());
             }
 
             self.pop_mod();
@@ -343,6 +343,7 @@ impl <'a> CodeGenerator<'a> {
     }
 
     fn append_oneof(&mut self,
+                    msg_name: &str,
                     oneof: OneofDescriptorProto,
                     idx: i32,
                     fields: Vec<(FieldDescriptorProto, usize)>) {
@@ -363,7 +364,8 @@ impl <'a> CodeGenerator<'a> {
         self.depth += 1;
         for (field, idx) in fields {
             // TODO(danburkert/prost#19): support groups.
-            if field.type_() == Type::TypeGroup { continue; }
+            let type_ = field.type_();
+            if type_ == Type::TypeGroup { continue; }
 
             self.path.push(idx as i32);
             self.append_doc();
@@ -375,7 +377,17 @@ impl <'a> CodeGenerator<'a> {
 
             self.push_indent();
             let ty = self.resolve_type(&field);
-            self.buf.push_str(&format!("{}({}),\n", to_upper_camel(field.name()), ty));
+
+            let boxed = type_ == Type::TypeMessage
+                    && self.message_graph.is_nested(field.type_name(), msg_name);
+
+            debug!("    oneof: {:?}, type: {:?}", field.name(), ty);
+
+            if boxed {
+                self.buf.push_str(&format!("{}(Box<{}>),\n", to_upper_camel(field.name()), ty));
+            } else {
+                self.buf.push_str(&format!("{}({}),\n", to_upper_camel(field.name()), ty));
+            }
         }
         self.depth -= 1;
         self.path.pop();

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -232,7 +232,7 @@ impl <'a> CodeGenerator<'a> {
                  && type_ == Type::TypeMessage
                  && self.message_graph.is_nested(field.type_name(), msg_name);
 
-        debug!("    field: {:?}, type: {:?}", field.name(), ty);
+        debug!("    field: {:?}, type: {:?}, boxed: {}", field.name(), ty, boxed);
 
         self.append_doc();
         self.push_indent();
@@ -378,10 +378,11 @@ impl <'a> CodeGenerator<'a> {
             self.push_indent();
             let ty = self.resolve_type(&field);
 
-            let boxed = type_ == Type::TypeMessage
+            let boxed = field.label == Some(Label::LabelRepeated as i32)
+                    && type_ == Type::TypeMessage
                     && self.message_graph.is_nested(field.type_name(), msg_name);
 
-            debug!("    oneof: {:?}, type: {:?}", field.name(), ty);
+            debug!("    oneof: {:?}, type: {:?}, boxed: {}", field.name(), ty, boxed);
 
             if boxed {
                 self.buf.push_str(&format!("{}(Box<{}>),\n", to_upper_camel(field.name()), ty));

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -378,15 +378,12 @@ impl <'a> CodeGenerator<'a> {
             self.push_indent();
             let ty = self.resolve_type(&field);
 
-            // NOTE: Unfortunately, `is_nested` doesn't know whether the reference is
-            // through a list or a map, so this may box variants when not strictly
-            // necessary to ensure that the size of the enum can be known at compile-time.
-            let nested = type_ == Type::TypeMessage
-                && self.message_graph.is_nested(field.type_name(), msg_name);
+            let boxed = type_ == Type::TypeMessage
+                     && self.message_graph.is_nested(field.type_name(), msg_name);
 
-            debug!("    oneof: {:?}, type: {:?}, nested: {}", field.name(), ty, nested);
+            debug!("    oneof: {:?}, type: {:?}, boxed: {}", field.name(), ty, boxed);
 
-            if nested {
+            if boxed {
                 self.buf.push_str(&format!("{}(Box<{}>),\n", to_upper_camel(field.name()), ty));
             } else {
                 self.buf.push_str(&format!("{}({}),\n", to_upper_camel(field.name()), ty));

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -48,7 +48,8 @@ impl MessageGraph {
         let msg_index = self.get_or_insert_index(msg_name.clone());
 
         for field in &msg.field {
-            if field.type_() == field_descriptor_proto::Type::TypeMessage {
+            if field.type_() == field_descriptor_proto::Type::TypeMessage
+                && field.label() != field_descriptor_proto::Label::LabelRepeated {
                 let field_index = self.get_or_insert_index(field.type_name.clone().unwrap());
                 self.graph.add_edge(msg_index, field_index, ());
             }

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1620,10 +1620,10 @@ pub mod value {
         BoolValue(bool),
         /// Represents a structured value.
         #[prost(message, tag="5")]
-        StructValue(super::Struct),
+        StructValue(Box<super::Struct>),
         /// Represents a repeated `Value`.
         #[prost(message, tag="6")]
-        ListValue(super::ListValue),
+        ListValue(Box<super::ListValue>),
     }
 }
 /// `ListValue` is a wrapper around a repeated field of values.

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1620,10 +1620,10 @@ pub mod value {
         BoolValue(bool),
         /// Represents a structured value.
         #[prost(message, tag="5")]
-        StructValue(Box<super::Struct>),
+        StructValue(super::Struct),
         /// Represents a repeated `Value`.
         #[prost(message, tag="6")]
-        ListValue(Box<super::ListValue>),
+        ListValue(super::ListValue),
     }
 }
 /// `ListValue` is a wrapper around a repeated field of values.

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -31,4 +31,7 @@ fn main() {
 
     prost_build.compile_protos(&["src/nesting.proto"],
                                &["src"]).unwrap();
+
+    prost_build.compile_protos(&["src/recursive_oneof.proto"],
+                               &["src"]).unwrap();
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -38,6 +38,10 @@ pub mod nesting {
     include!(concat!(env!("OUT_DIR"), "/nesting.rs"));
 }
 
+pub mod recursive_oneof {
+    include!(concat!(env!("OUT_DIR"), "/recursive_oneof.rs"));
+}
+
 use std::error::Error;
 
 use bytes::{Buf, IntoBuf};
@@ -216,6 +220,18 @@ mod tests {
             b: Some(Box::new(B::default())),
             repeated_b: Vec::<B>::new(),
             map_b: BTreeMap::<i32, B>::new(),
+        };
+    }
+
+    #[test]
+    fn test_recursive_oneof() {
+        use recursive_oneof::{a, A, B, C};
+        let _ = A {
+            kind: Some(a::Kind::B(Box::new(B {
+                a: Some(Box::new(A {
+                    kind: Some(a::Kind::C(C {}))
+                }))
+            })))
         };
     }
 }

--- a/tests/src/recursive_oneof.proto
+++ b/tests/src/recursive_oneof.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package recursive_oneof;
+
+message A {
+    oneof kind {
+        A a = 1;
+        B b = 2;
+        C c = 3;
+    }
+}
+
+message B {
+    A a = 1;
+}
+
+message C {}


### PR DESCRIPTION
Currently, `oneof`s that reference a parent type result in compile errors.

By replicating the `boxed` check in field generation, oneofs may be recursive.

Fixes danburkert/prost#46