### PR TITLE
Upgrade itertools to 0.7

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -13,7 +13,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 bytes = "0.4"
 env_logger = "0.4"
 heck = "0.3"
-itertools = "0.6"
+itertools = "0.7"
 log = "0.3"
 multimap = { version = "0.4", default-features = false }
 petgraph = "0.4"


### PR DESCRIPTION
That matches the version in prost-derive to not depend on two version of the itertools crate.