### PR TITLE
WIP: Custom Debug implementation

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -161,7 +161,7 @@ impl <'a> CodeGenerator<'a> {
 
         self.append_doc();
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, Debug, PartialEq, Message)]\n");
+        self.buf.push_str("#[derive(Clone, PartialEq, Message)]\n");
         self.push_indent();
         self.buf.push_str("pub struct ");
         self.buf.push_str(&to_upper_camel(&message_name));

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -354,7 +354,7 @@ impl <'a> CodeGenerator<'a> {
         self.path.pop();
 
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, Debug, Oneof, PartialEq)]\n");
+        self.buf.push_str("#[derive(Clone, Oneof, PartialEq)]\n");
         self.push_indent();
         self.buf.push_str("pub enum ");
         self.buf.push_str(&to_upper_camel(oneof.name()));

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -13,7 +13,7 @@ use field::{
     set_option,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum MapTy {
     HashMap,
     BTreeMap,
@@ -45,6 +45,7 @@ fn fake_scalar(ty: scalar::Ty) -> scalar::Field {
     }
 }
 
+#[derive(Clone)]
 pub struct Field {
     pub map_ty: MapTy,
     pub key_ty: scalar::Ty,

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -13,6 +13,7 @@ use field::{
     Label,
 };
 
+#[derive(Clone)]
 pub struct Field {
     pub label: Label,
     pub tag: u32,

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -134,10 +134,27 @@ impl Field {
     }
 
     /// Produces the fragment implementing debug for the given field.
-    pub fn debug(&self, name: &Ident, ident: Tokens) -> Tokens {
+    pub fn debug(&self, ident: Tokens) -> Tokens {
         match *self {
-            Field::Scalar(ref scalar) => scalar.debug(name, ident),
-            _ => quote!(builder.field(stringify!(#name), &#ident)),
+            Field::Scalar(ref scalar) => {
+                let wrapper = scalar.debug(&Ident::new("ScalarWrapper"));
+                quote! {
+                    {
+                        #wrapper
+                        ScalarWrapper(&#ident)
+                    }
+                }
+            },
+            Field::Map(ref map) => {
+                let wrapper = map.debug(&Ident::new("MapWrapper"));
+                quote! {
+                    {
+                        #wrapper
+                        MapWrapper(&#ident)
+                    }
+                }
+            },
+            _ => quote!(&#ident),
         }
     }
 

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -134,10 +134,10 @@ impl Field {
     }
 
     /// Produces the fragment implementing debug for the given field.
-    pub fn debug(&self, ident: &Ident) -> Tokens {
+    pub fn debug(&self, name: &Ident, ident: Tokens) -> Tokens {
         match *self {
-            Field::Scalar(ref scalar) => scalar.debug(ident),
-            _ => quote!(builder.field(stringify!(#ident), &self.#ident)),
+            Field::Scalar(ref scalar) => scalar.debug(name, ident),
+            _ => quote!(builder.field(stringify!(#name), &#ident)),
         }
     }
 

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -133,6 +133,14 @@ impl Field {
         }
     }
 
+    /// Produces the fragment implementing debug for the given field.
+    pub fn debug(&self, ident: &Ident) -> Tokens {
+        match *self {
+            Field::Scalar(ref scalar) => scalar.debug(ident),
+            _ => quote!(builder.field(stringify!(#ident), &self.#ident)),
+        }
+    }
+
     pub fn methods(&self, ident: &Ident) -> Option<Tokens> {
         match *self {
             Field::Scalar(ref scalar) => scalar.methods(ident),

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -17,6 +17,7 @@ use syn::{
 
 use error::*;
 
+#[derive(Clone)]
 pub enum Field {
     /// A scalar field.
     Scalar(scalar::Field),

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -12,6 +12,7 @@ use field::{
     set_option,
 };
 
+#[derive(Clone)]
 pub struct Field {
     pub ty: Ident,
     pub tags: Vec<u32>,

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -21,6 +21,7 @@ use field::{
 };
 
 /// A scalar protobuf field.
+#[derive(Clone)]
 pub struct Field {
     pub ty: Ty,
     pub kind: Kind,
@@ -515,6 +516,7 @@ impl fmt::Display for Ty {
 }
 
 /// Scalar protobuf field types.
+#[derive(Clone)]
 pub enum Kind {
     /// A plain proto3 scalar field.
     Plain(DefaultValue),
@@ -528,7 +530,7 @@ pub enum Kind {
     Packed,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum DefaultValue {
     Lit(Lit),
     Ident(Ident),

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -224,20 +224,20 @@ impl Field {
     }
 
     /// Returns a fragment for formatting the field `ident` in `Debug`.
-    pub fn debug(&self, ident: &Ident) -> Tokens {
+    pub fn debug(&self, name: &Ident, ident: Tokens) -> Tokens {
         if let Ty::Enumeration(ref ty) = self.ty {
             match self.kind {
                 Kind::Plain(_) |
                 Kind::Required(_) => quote! {
-                    match super::#ty::from_i32(self.#ident) {
-                        None => builder.field(stringify!(#ident), &self.#ident),
-                        Some(en) => builder.field(stringify!(#ident), &en),
+                    match super::#ty::from_i32(#ident) {
+                        None => builder.field(stringify!(#name), &#ident),
+                        Some(en) => builder.field(stringify!(#name), &en),
                     }
                 },
                 Kind::Optional(_) => quote! {
-                    match self.#ident.and_then(super::#ty::from_i32) {
-                        None => builder.field(stringify!(#ident), &self.#ident),
-                        Some(en) => builder.field(stringify!(#ident), &Some(en)),
+                    match #ident.and_then(super::#ty::from_i32) {
+                        None => builder.field(stringify!(#name), &#ident),
+                        Some(en) => builder.field(stringify!(#name), &Some(en)),
                     }
                 },
                 Kind::Repeated |
@@ -258,12 +258,12 @@ impl Field {
                                 builder.finish()
                             }
                         }
-                        builder.field(stringify!(#ident), &Wrapper(&self.#ident));
+                        builder.field(stringify!(#name), &Wrapper(&#ident))
                     }
                 }
             }
         } else {
-            quote!(builder.field(stringify!(#ident), &self.#ident))
+            quote!(builder.field(stringify!(#name), &#ident))
         }
     }
 

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -127,11 +127,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream> {
 
     let debugs = fields.iter()
                        .map(|&(ref field_ident, ref field)| {
-                           match *field {
-                                Field::Scalar(ref sc) => sc.debug(field_ident),
-                                _ => quote!(builder.field(stringify!(#field_ident),
-                                                          &self.#field_ident)),
-                           }
+                           field.debug(field_ident)
                        });
 
     let expanded = quote! {

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -125,6 +125,15 @@ fn try_message(input: TokenStream) -> Result<TokenStream> {
         }
     };
 
+    let debugs = fields.iter()
+                       .map(|&(ref field_ident, ref field)| {
+                           match *field {
+                                Field::Scalar(ref sc) => sc.debug(field_ident),
+                                _ => quote!(builder.field(stringify!(#field_ident),
+                                                          &self.#field_ident)),
+                           }
+                       });
+
     let expanded = quote! {
         #[allow(non_snake_case, unused_attributes)]
         mod #module {
@@ -164,6 +173,14 @@ fn try_message(input: TokenStream) -> Result<TokenStream> {
                     #ident {
                         #(#default)*
                     }
+                }
+            }
+
+            impl ::std::fmt::Debug for #ident {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    let mut builder = f.debug_struct(stringify!(#ident));
+                    #(#debugs;)*
+                    builder.finish()
                 }
             }
 

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -1,5 +1,5 @@
 /// The version number of protocol compiler.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Version {
     #[prost(int32, optional, tag="1")]
     pub major: ::std::option::Option<i32>,
@@ -13,7 +13,7 @@ pub struct Version {
     pub suffix: ::std::option::Option<String>,
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct CodeGeneratorRequest {
     /// The .proto files that were explicitly listed on the command-line.  The
     /// code generator should generate code only for these files.  Each file's
@@ -44,7 +44,7 @@ pub struct CodeGeneratorRequest {
     pub compiler_version: ::std::option::Option<Version>,
 }
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct CodeGeneratorResponse {
     /// Error message.  If non-empty, code generation failed.  The plugin process
     /// should exit with status code zero even if it reports an error in this way.
@@ -61,7 +61,7 @@ pub struct CodeGeneratorResponse {
 }
 pub mod code_generator_response {
     /// Represents a single generated file.
-    #[derive(Clone, Debug, PartialEq, Message)]
+    #[derive(Clone, PartialEq, Message)]
     pub struct File {
         /// The file name, relative to the output directory.  The name must not
         /// contain "." or ".." components and must be relative, not be absolute (so,

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1,12 +1,12 @@
 /// The protocol compiler can output a FileDescriptorSet containing the .proto
 /// files it parses.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag="1")]
     pub file: ::std::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag="1")]
@@ -47,7 +47,7 @@ pub struct FileDescriptorProto {
     pub syntax: ::std::option::Option<String>,
 }
 /// Describes a message type.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct DescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -73,7 +73,7 @@ pub struct DescriptorProto {
     pub reserved_name: ::std::vec::Vec<String>,
 }
 pub mod descriptor_proto {
-    #[derive(Clone, Debug, PartialEq, Message)]
+    #[derive(Clone, PartialEq, Message)]
     pub struct ExtensionRange {
         #[prost(int32, optional, tag="1")]
         pub start: ::std::option::Option<i32>,
@@ -85,7 +85,7 @@ pub mod descriptor_proto {
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
-    #[derive(Clone, Debug, PartialEq, Message)]
+    #[derive(Clone, PartialEq, Message)]
     pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -95,14 +95,14 @@ pub mod descriptor_proto {
         pub end: ::std::option::Option<i32>,
     }
 }
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
 /// Describes a field within a message.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -190,7 +190,7 @@ pub mod field_descriptor_proto {
     }
 }
 /// Describes a oneof.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -198,7 +198,7 @@ pub struct OneofDescriptorProto {
     pub options: ::std::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -208,7 +208,7 @@ pub struct EnumDescriptorProto {
     pub options: ::std::option::Option<EnumOptions>,
 }
 /// Describes a value within an enum.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -218,7 +218,7 @@ pub struct EnumValueDescriptorProto {
     pub options: ::std::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -228,7 +228,7 @@ pub struct ServiceDescriptorProto {
     pub options: ::std::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -279,7 +279,7 @@ pub struct MethodDescriptorProto {
 //   If this turns out to be popular, a web service will be set up
 //   to automatically assign option numbers.
 
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct FileOptions {
     /// Sets the Java package where classes generated from this .proto will be
     /// placed.  By default, the proto package is used, but this is often
@@ -390,7 +390,7 @@ pub mod file_options {
         LiteRuntime = 3,
     }
 }
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct MessageOptions {
     /// Set true to use the old proto1 MessageSet wire format for extensions.
     /// This is provided for backwards-compatibility with the MessageSet wire
@@ -450,7 +450,7 @@ pub struct MessageOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct FieldOptions {
     /// The ctype option instructs the C++ code generator to use a different
     /// representation of the field than it normally would.  See the specific
@@ -539,13 +539,13 @@ pub mod field_options {
         JsNumber = 2,
     }
 }
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
@@ -561,7 +561,7 @@ pub struct EnumOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct EnumValueOptions {
     /// Is this enum value deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -573,7 +573,7 @@ pub struct EnumValueOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct ServiceOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -590,7 +590,7 @@ pub struct ServiceOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct MethodOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -628,7 +628,7 @@ pub mod method_options {
 /// options protos in descriptor objects (e.g. returned by Descriptor::options(),
 /// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 /// in them.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag="2")]
     pub name: ::std::vec::Vec<uninterpreted_option::NamePart>,
@@ -653,7 +653,7 @@ pub mod uninterpreted_option {
     /// extension (denoted with parentheses in options specs in .proto files).
     /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
     /// "foo.(bar.baz).qux".
-    #[derive(Clone, Debug, PartialEq, Message)]
+    #[derive(Clone, PartialEq, Message)]
     pub struct NamePart {
         #[prost(string, required, tag="1")]
         pub name_part: String,
@@ -666,7 +666,7 @@ pub mod uninterpreted_option {
 
 /// Encapsulates information about the original source file from which a
 /// FileDescriptorProto was generated.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct SourceCodeInfo {
     /// A Location identifies a piece of source code in a .proto file which
     /// corresponds to a particular definition.  This information is intended
@@ -715,7 +715,7 @@ pub struct SourceCodeInfo {
     pub location: ::std::vec::Vec<source_code_info::Location>,
 }
 pub mod source_code_info {
-    #[derive(Clone, Debug, PartialEq, Message)]
+    #[derive(Clone, PartialEq, Message)]
     pub struct Location {
         /// Identifies which part of the FileDescriptorProto was defined at this
         /// location.
@@ -807,7 +807,7 @@ pub mod source_code_info {
 /// Describes the relationship between generated code and its original source
 /// file. A GeneratedCodeInfo message is associated with only one generated
 /// source file, but may contain references to different source .proto files.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
@@ -815,7 +815,7 @@ pub struct GeneratedCodeInfo {
     pub annotation: ::std::vec::Vec<generated_code_info::Annotation>,
 }
 pub mod generated_code_info {
-    #[derive(Clone, Debug, PartialEq, Message)]
+    #[derive(Clone, PartialEq, Message)]
     pub struct Annotation {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
@@ -915,7 +915,7 @@ pub mod generated_code_info {
 ///       "value": "1.212s"
 ///     }
 ///
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Any {
     /// A URL/resource name whose content describes the type of the
     /// serialized protocol buffer message.
@@ -947,7 +947,7 @@ pub struct Any {
 }
 /// `SourceContext` represents information about the source of a
 /// protobuf element, like the file in which it is defined.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
@@ -955,7 +955,7 @@ pub struct SourceContext {
     pub file_name: String,
 }
 /// A protocol buffer message type.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Type {
     /// The fully qualified message name.
     #[prost(string, tag="1")]
@@ -977,7 +977,7 @@ pub struct Type {
     pub syntax: i32,
 }
 /// A single field of a message type.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Field {
     /// The field type.
     #[prost(enumeration="field::Kind", tag="1")]
@@ -1069,7 +1069,7 @@ pub mod field {
     }
 }
 /// Enum type definition.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Enum {
     /// Enum type name.
     #[prost(string, tag="1")]
@@ -1088,7 +1088,7 @@ pub struct Enum {
     pub syntax: i32,
 }
 /// Enum value definition.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct EnumValue {
     /// Enum value name.
     #[prost(string, tag="1")]
@@ -1102,7 +1102,7 @@ pub struct EnumValue {
 }
 /// A protocol buffer option, which can be attached to a message, field,
 /// enumeration, etc.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Option {
     /// The option's name. For protobuf built-in options (options defined in
     /// descriptor.proto), this is the short name. For example, `"map_entry"`.
@@ -1134,7 +1134,7 @@ pub enum Syntax {
 /// sometimes simply referred to as "APIs" in other contexts, such as the name of
 /// this message itself. See https://cloud.google.com/apis/design/glossary for
 /// detailed terminology.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
@@ -1181,7 +1181,7 @@ pub struct Api {
     pub syntax: i32,
 }
 /// Method represents a method of an API interface.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Method {
     /// The simple name of this method.
     #[prost(string, tag="1")]
@@ -1283,7 +1283,7 @@ pub struct Method {
 ///       }
 ///       ...
 ///     }
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
     #[prost(string, tag="1")]
@@ -1353,7 +1353,7 @@ pub struct Mixin {
 /// microsecond should be expressed in JSON format as "3.000001s".
 ///
 ///
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
@@ -1570,7 +1570,7 @@ pub struct Duration {
 ///
 /// Note that oneof type names ("test_oneof" in this case) cannot be used in
 /// paths.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag="1")]
@@ -1584,7 +1584,7 @@ pub struct FieldMask {
 /// with the proto support for the language.
 ///
 /// The JSON representation for `Struct` is JSON object.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map="string, message", tag="1")]
@@ -1596,7 +1596,7 @@ pub struct Struct {
 /// variants, absence of any variant indicates an error.
 ///
 /// The JSON representation for `Value` is JSON value.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Value {
     /// The kind of value.
     #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
@@ -1629,7 +1629,7 @@ pub mod value {
 /// `ListValue` is a wrapper around a repeated field of values.
 ///
 /// The JSON representation for `ListValue` is JSON array.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct ListValue {
     /// Repeated field of dynamically typed values.
     #[prost(message, repeated, tag="1")]
@@ -1722,7 +1722,7 @@ pub enum NullValue {
 /// to obtain a formatter capable of generating timestamps in this format.
 ///
 ///
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1604,7 +1604,7 @@ pub struct Value {
 }
 pub mod value {
     /// The kind of value.
-    #[derive(Clone, Debug, Oneof, PartialEq)]
+    #[derive(Clone, Oneof, PartialEq)]
     pub enum Kind {
         /// Represents a null value.
         #[prost(enumeration="super::NullValue", tag="1")]

--- a/tests/src/debug.rs
+++ b/tests/src/debug.rs
@@ -1,0 +1,82 @@
+//! Tests for our own Debug implementation.
+//!
+//! The tests check against expected output. This may be a bit fragile, but it is likely OK for
+//! actual use.
+
+// Borrow some types from other places.
+use ::message_encoding::{Basic, BasicEnumeration};
+
+/// Some real-life message
+#[test]
+fn basic() {
+    let mut basic = Basic::default();
+    assert_eq!(format!("{:?}", basic),
+               "Basic { \
+                    int32: 0, \
+                    bools: [], \
+                    string: \"\", \
+                    optional_string: None, \
+                    enumeration: ZERO, \
+                    enumeration_map: {}, \
+                    string_map: {}, \
+                    enumeration_btree_map: {}, \
+                    string_btree_map: {}, \
+                    oneof: None \
+                }");
+    basic.enumeration_map.insert(0, BasicEnumeration::TWO as i32);
+    basic.enumeration = 42;
+    assert_eq!(format!("{:?}", basic),
+               "Basic { \
+                    int32: 0, \
+                    bools: [], \
+                    string: \"\", \
+                    optional_string: None, \
+                    enumeration: 42, \
+                    enumeration_map: {0: TWO}, \
+                    string_map: {}, \
+                    enumeration_btree_map: {}, \
+                    string_btree_map: {}, \
+                    oneof: None \
+                }");
+}
+
+/*
+FIXME: Doesn't work yet due to https://github.com/danburkert/prost/issues/56
+
+/// A special case with a tuple struct
+#[test]
+fn tuple_struct() {
+    #[derive(Clone, PartialEq, Message)]
+    struct NewType(
+        #[prost(enumeration="BasicEnumeration", tag="5")]
+        i32,
+    );
+    assert_eq!(format!("{:?}", NewType(BasicEnumeration::TWO as i32)), "NewType(TWO)");
+    assert_eq!(format!("{:?}", NewType(42)), "NewType(42)");
+}
+*/
+
+#[derive(Clone, PartialEq, Oneof)]
+pub enum OneofWithEnum {
+    #[prost(int32, tag="8")]
+    Int(i32),
+    #[prost(string, tag="9")]
+    String(String),
+    #[prost(enumeration="BasicEnumeration", tag="10")]
+    Enumeration(i32),
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct MessageWithOneof {
+    #[prost(oneof="OneofWithEnum", tags="8, 9, 10")]
+    of: Option<OneofWithEnum>,
+}
+
+/// Enumerations inside oneofs
+#[test]
+fn oneof_with_enum() {
+    let msg = MessageWithOneof {
+        of: Some(OneofWithEnum::Enumeration(BasicEnumeration::TWO as i32))
+    };
+    assert_eq!(format!("{:?}", msg), "MessageWithOneof { of: Some(Enumeration(TWO)) }");
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -11,6 +11,7 @@ pub mod packages;
 pub mod unittest;
 
 #[cfg(test)] mod bootstrap;
+#[cfg(test)] mod debug;
 #[cfg(test)] mod message_encoding;
 
 pub mod protobuf_test_messages {

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -282,7 +282,7 @@ pub struct Compound {
     pub message_btree_map: ::std::collections::BTreeMap<i32, Basic>,
 }
 
-#[derive(Clone, Debug, PartialEq, Oneof)]
+#[derive(Clone, PartialEq, Oneof)]
 pub enum BasicOneof {
     #[prost(int32, tag="8")]
     Int(i32),

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -2,7 +2,7 @@ use prost::Message;
 
 use check_message;
 
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct RepeatedFloats {
     #[prost(float, tag="11")]
     pub single_float: f32,
@@ -28,7 +28,7 @@ fn check_scalar_types() {
 }
 
 /// A protobuf message which contains all scalar types.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct ScalarTypes {
     #[prost(int32, tag="001")]
     pub int32: i32,
@@ -189,7 +189,7 @@ pub struct ScalarTypes {
 }
 
 /// A prost message with default value.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct DefaultValues {
     #[prost(int32, tag="1", default="42")]
     pub int32: i32,
@@ -231,7 +231,7 @@ pub enum BasicEnumeration {
     THREE = 3,
 }
 
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Basic {
     #[prost(int32, tag="1")]
     pub int32: i32,
@@ -264,7 +264,7 @@ pub struct Basic {
     pub oneof: Option<BasicOneof>,
 }
 
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, Message)]
 pub struct Compound {
     #[prost(message, optional, tag="1")]
     pub optional_message: Option<Basic>,


### PR DESCRIPTION
This is my first attempt to https://github.com/danburkert/prost/issues/49. I plan to:

* Add similar support for the OneOf containers
* Do some cleanups and code deduplication (it feels some bits are quite similar, but I'm not sure if I'll able to make something usable of it).

However, I'd like some feedback to know early if I'm doing it completely wrong (like, in a wrong place). Also, an idea how to test this would be nice. I did test it manually in my own downstream project, but something automated (in addition to the fact the debug implementation compiles) would be nice ‒ but parsing how it looks formatted seems a bit overkill.

Also, it's a bit unfortunate, but it would be a breaking change in the sense the user can no longer do `#[derive(Debug)]` on manually written structs as that collides. Should I add some attribute to enable the debug implementation and default to the old behaviour, or is this OK?