### PR TITLE
Allow generation of attributes on messages and fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ generated code examples above.
     int32`, `repeated sint32`, `repeated sfixed32`, and their packed
     counterparts.
 
+  But it is possible to place `serde` derive tags onto the generated types, so
+  the same structure can support both `prost` and `Serde`.
+
 2. **Looks like a lot of field annotations. Can those be simplified?**
 
   Probably. Effort has not yet been spent on reducing the number of annotations.

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -162,6 +162,7 @@ impl <'a> CodeGenerator<'a> {
         self.append_doc();
         self.push_indent();
         self.buf.push_str("#[derive(Clone, PartialEq, Message)]\n");
+        self.append_container_attributes(&fq_message_name);
         self.push_indent();
         self.buf.push_str("pub struct ");
         self.buf.push_str(&to_upper_camel(&message_name));
@@ -183,7 +184,10 @@ impl <'a> CodeGenerator<'a> {
         for (idx, oneof) in message.oneof_decl.iter().enumerate() {
             let idx = idx as i32;
             self.path.push(idx);
-            self.append_oneof_field(&message_name, oneof, oneof_fields.get_vec(&idx).unwrap());
+            self.append_oneof_field(&message_name,
+                                    &fq_message_name,
+                                    oneof,
+                                    oneof_fields.get_vec(&idx).unwrap());
             self.path.pop();
         }
         self.path.pop();
@@ -216,6 +220,30 @@ impl <'a> CodeGenerator<'a> {
             }
 
             self.pop_mod();
+        }
+    }
+
+    fn append_container_attributes(&mut self, msg_name: &str) {
+        assert_eq!(b'.', msg_name.as_bytes()[0]);
+        for &(ref matcher, ref attribute) in &self.config.container_attributes {
+            // We abuse the field matcher to match only whole message paths, since the ~~~ field is
+            // illegal. This saves code and hopefuly doesn't have any strange side effects.
+            if match_field(matcher, msg_name, "~~~") {
+                self.push_indent();
+                self.buf.push_str(attribute);
+                self.buf.push('\n');
+            }
+        }
+    }
+
+    fn append_field_attributes(&mut self, msg_name: &str, field_name: &str) {
+        assert_eq!(b'.', msg_name.as_bytes()[0]);
+        for &(ref matcher, ref attribute) in &self.config.field_attributes {
+            if match_field(matcher, msg_name, field_name) {
+                self.push_indent();
+                self.buf.push_str(attribute);
+                self.buf.push('\n');
+            }
         }
     }
 
@@ -277,6 +305,7 @@ impl <'a> CodeGenerator<'a> {
         }
 
         self.buf.push_str("\")]\n");
+        self.append_field_attributes(msg_name, field.name());
         self.push_indent();
         self.buf.push_str("pub ");
         self.buf.push_str(&to_snake(field.name()));
@@ -321,6 +350,7 @@ impl <'a> CodeGenerator<'a> {
                                    key_tag,
                                    value_tag,
                                    field.number()));
+        self.append_field_attributes(msg_name, field.name());
         self.push_indent();
         self.buf.push_str(&format!("pub {}: ::std::collections::{}<{}, {}>,\n",
                                    to_snake(field.name()), rust_ty, key_ty, value_ty));
@@ -328,6 +358,7 @@ impl <'a> CodeGenerator<'a> {
 
     fn append_oneof_field(&mut self,
                           message_name: &str,
+                          fq_message_name: &str,
                           oneof: &OneofDescriptorProto,
                           fields: &[(FieldDescriptorProto, usize)]) {
         let name = format!("{}::{}",
@@ -338,6 +369,7 @@ impl <'a> CodeGenerator<'a> {
         self.buf.push_str(&format!("#[prost(oneof=\"{}\", tags=\"{}\")]\n",
                                    name,
                                    fields.iter().map(|&(ref field, _)| field.number()).join(", ")));
+        self.append_field_attributes(fq_message_name, oneof.name());
         self.push_indent();
         self.buf.push_str(&format!("pub {}: ::std::option::Option<{}>,\n", to_snake(oneof.name()), name));
     }
@@ -355,6 +387,7 @@ impl <'a> CodeGenerator<'a> {
 
         self.push_indent();
         self.buf.push_str("#[derive(Clone, Oneof, PartialEq)]\n");
+        self.append_container_attributes(msg_name);
         self.push_indent();
         self.buf.push_str("pub enum ");
         self.buf.push_str(&to_upper_camel(oneof.name()));
@@ -374,6 +407,7 @@ impl <'a> CodeGenerator<'a> {
             self.push_indent();
             let ty_tag = self.field_type_tag(&field);
             self.buf.push_str(&format!("#[prost({}, tag=\"{}\")]\n", ty_tag, field.number()));
+            self.append_field_attributes(msg_name, field.name());
 
             self.push_indent();
             let ty = self.resolve_type(&field);

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -37,7 +37,7 @@ pub fn to_upper_camel(s: &str) -> String {
     ident
 }
 
-/// Matches a 'matcher' against a fully qualified field name.
+/// Matches a 'matcher' against a fully qualified identifier.
 pub fn match_ident(matcher: &str, msg: &str, field: Option<&str>) -> bool {
     assert_eq!(b'.', msg.as_bytes()[0]);
 

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -181,6 +181,8 @@ pub trait ServiceGenerator {
 pub struct Config {
     service_generator: Option<Box<ServiceGenerator>>,
     btree_map: Vec<String>,
+    container_attributes: Vec<(String, String)>,
+    field_attributes: Vec<(String, String)>,
     prost_types: bool,
 }
 
@@ -202,6 +204,9 @@ impl Config {
     /// qualified names. Paths without a leading `.` are treated as relative, and are suffix
     /// matched on the fully qualified field name. If a Protobuf map field matches any of the
     /// paths, a Rust `BTreeMap` field will be generated instead of the default [`HashMap`][3].
+    ///
+    /// The matching is done on the protobuf names, before converting to Rust-friendly casing
+    /// standards.
     ///
     /// # Examples
     ///
@@ -240,6 +245,75 @@ impl Config {
     where I: IntoIterator<Item = S>,
           S: AsRef<str> {
         self.btree_map = paths.into_iter().map(|s| s.as_ref().to_string()).collect();
+        self
+    }
+
+    /// Add additional attribute to matched fields.
+    ///
+    /// # Arguments
+    ///
+    /// **`path`** - a patch matching any number of fields. These fields will get the attribute.
+    /// For details about matching fields see [`btree_map`](#method.btree_map).
+    ///
+    /// **`attribute`** - an arbitrary string that'll be placed before each matched field. The
+    /// expected usage are additional attributes, usually in concert with whole-container
+    /// attributes set with [`container_attribute`](method.container_attribute), but it is not
+    /// checked and anything can be put there.
+    ///
+    /// Note that the calls to this method are cumulative ‒ if multiple paths from multiple calls
+    /// match the same field, the field gets all the corresponding attributes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # let mut config = prost_build::Config::new();
+    /// // Prost renames fields named `in` to `in_`. But if serialized through serde,
+    /// // we want them to appear as `in` again.
+    /// config.field_attribute("in", "#[serde(rename = \"in\")]");
+    /// ```
+    pub fn field_attribute<P, A>(&mut self, path: P, attribute: A) -> &mut Self
+    where P: AsRef<str>,
+          A: AsRef<str> {
+        self.field_attributes.push((path.as_ref().to_string(), attribute.as_ref().to_string()));
+        self
+    }
+
+    /// Add additional attribute to matched messages, enums and one-ofs.
+    ///
+    /// # Arguments
+    ///
+    /// **`paths`** - a path matching any number of containers. It works the same way as in
+    /// [`btree_map`](#method.btree_map), just with the field name omitted.
+    ///
+    /// **`attribute`** - an arbitrary string to be placed before each matched container. The
+    /// expected usage are additional attributes, but anything is allowed.
+    ///
+    /// The calls to this method are cumulative. They don't overwrite previous calls and if a
+    /// container is matched by multiple calls of the method, all relevant attributes are added to
+    /// it.
+    ///
+    /// For things like serde it might be needed to combine with [field
+    /// attributes](#method.field_attribute).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # let mut config = prost_build::Config::new();
+    /// // Nothing around uses floats, so we can derive real `Eq` in addition to `PartialEq`.
+    /// config.container_attribute(".", "#[derive(Eq)]");
+    /// // Some messages want to be serializable with serde as well.
+    /// config.container_attribute(".my_messages.MyMessageType",
+    ///                            "#[derive(Serialize)] #[serde(rename-all = \"snake_case\")]");
+    /// config.container_attribute(".my_messages.MyMessageType.MyNestedMessageType",
+    ///                            "#[derive(Serialize)] #[serde(rename-all = \"snake_case\")]");
+    /// ```
+    pub fn container_attribute<P, A>(&mut self, path: P, attribute: A) -> &mut Self
+    where P: AsRef<str>,
+          A: AsRef<str> {
+        // Note: The ~~~ is a syntetic "field" name representing the whole container and making
+        // the matching work correctly on containers.
+        self.container_attributes.push((format!("{}.~~~", path.as_ref()),
+                                        attribute.as_ref().to_string()));
         self
     }
 
@@ -357,6 +431,8 @@ impl default::Default for Config {
         Config {
             service_generator: None,
             btree_map: Vec::new(),
+            container_attributes: Vec::new(),
+            field_attributes: Vec::new(),
             prost_types: true,
         }
     }

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -26,10 +26,6 @@ fn main() {
     prost_build.field_attribute("Foo.Custom.Attrs.AnotherEnum.D", "/// The D docs");
     prost_build.field_attribute("Foo.Custom.Attrs.Msg.field.a", "/// Oneof A docs");
     prost_build.field_attribute("Foo.Custom.Attrs.Msg.field.b", "/// Oneof B docs");
-    // No idea what better to place on that field :-(. We don't wont to depend or eg. Serde to be
-    // able to place arbitrary attributes on fields. We'll have to check in nasty way, by reading
-    // the text file.
-    prost_build.field_attribute(".Foo.Bar_Baz.Foo_barBaz.fooBar_baz", "// Testing comment");
 
     prost_build.compile_protos(&[proto_includes.join("test_messages_proto2.proto")],
                                &[protobuf::include()]).unwrap();

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -13,9 +13,19 @@ fn main() {
     // values.
     let mut prost_build = prost_build::Config::new();
     prost_build.btree_map(&["."]);
-    prost_build.container_attribute(".Foo.Bar_Baz.Foo_barBaz", "#[derive(Eq, PartialOrd, Ord)]");
-    prost_build.container_attribute(".Foo.Bar_Baz.Foo_barBaz.fuzz_buster",
-                                    "#[derive(Eq, PartialOrd, Ord)]");
+    // Tests for custom attributes
+    prost_build.type_attribute("Foo.Bar_Baz.Foo_barBaz", "#[derive(Eq, PartialOrd, Ord)]");
+    prost_build.type_attribute("Foo.Bar_Baz.Foo_barBaz.fuzz_buster",
+                               "#[derive(Eq, PartialOrd, Ord)]");
+    prost_build.type_attribute("Foo.Custom.Attrs.Msg", "#[allow(missing_docs)]");
+    prost_build.type_attribute("Foo.Custom.Attrs.Msg.field", "/// Oneof docs");
+    prost_build.type_attribute("Foo.Custom.Attrs.AnEnum", "#[allow(missing_docs)]");
+    prost_build.type_attribute("Foo.Custom.Attrs.AnotherEnum", "/// Oneof docs");
+    prost_build.type_attribute("Foo.Custom.OneOfAttrs.Msg.field", "#[derive(Eq, PartialOrd, Ord)]");
+    prost_build.field_attribute("Foo.Custom.Attrs.AnotherEnum.C", "/// The C docs");
+    prost_build.field_attribute("Foo.Custom.Attrs.AnotherEnum.D", "/// The D docs");
+    prost_build.field_attribute("Foo.Custom.Attrs.Msg.field.a", "/// Oneof A docs");
+    prost_build.field_attribute("Foo.Custom.Attrs.Msg.field.b", "/// Oneof B docs");
     // No idea what better to place on that field :-(. We don't wont to depend or eg. Serde to be
     // able to place arbitrary attributes on fields. We'll have to check in nasty way, by reading
     // the text file.
@@ -40,5 +50,11 @@ fn main() {
                                &["src"]).unwrap();
 
     prost_build.compile_protos(&["src/recursive_oneof.proto"],
+                               &["src"]).unwrap();
+
+    prost_build.compile_protos(&["src/custom_attributes.proto"],
+                               &["src"]).unwrap();
+
+    prost_build.compile_protos(&["src/oneof_attributes.proto"],
                                &["src"]).unwrap();
 }

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -13,6 +13,13 @@ fn main() {
     // values.
     let mut prost_build = prost_build::Config::new();
     prost_build.btree_map(&["."]);
+    prost_build.container_attribute(".Foo.Bar_Baz.Foo_barBaz", "#[derive(Eq, PartialOrd, Ord)]");
+    prost_build.container_attribute(".Foo.Bar_Baz.Foo_barBaz.fuzz_buster",
+                                    "#[derive(Eq, PartialOrd, Ord)]");
+    // No idea what better to place on that field :-(. We don't wont to depend or eg. Serde to be
+    // able to place arbitrary attributes on fields. We'll have to check in nasty way, by reading
+    // the text file.
+    prost_build.field_attribute(".Foo.Bar_Baz.Foo_barBaz.fooBar_baz", "// Testing comment");
 
     prost_build.compile_protos(&[proto_includes.join("test_messages_proto2.proto")],
                                &[protobuf::include()]).unwrap();

--- a/tests/src/custom_attributes.proto
+++ b/tests/src/custom_attributes.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package Foo.Custom.Attrs;
+
+message Msg {
+}
+
+enum AnEnum {
+	A = 0;
+	B = 1;
+}
+
+enum AnotherEnum {
+	C = 0;
+	D = 2;
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -212,6 +212,22 @@ mod tests {
     }
 
     #[test]
+    fn test_custom_container_attributes() {
+        // We abuse the ident conversion protobuf for the custom attribute additions. We placed
+        // `Eq` on the FooBarBaz (which is not implemented by ordinary messages).
+        let msg1 = foo::bar_baz::FooBarBaz::default();
+        let msg2 = foo::bar_baz::FooBarBaz::default();
+        // This uses Eq, which wouldn't compile if the attribute didn't work
+        assert_eq!(msg1, msg2);
+    }
+
+    #[test]
+    fn test_custom_field_attributes() {
+        let input = include_str!(concat!(env!("OUT_DIR"), "/foo.bar_baz.rs"));
+        assert!(input.contains("// Testing comment"));
+    }
+
+    #[test]
     fn test_nesting() {
         use nesting::{A, B};
         let _ = A {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -43,6 +43,20 @@ pub mod recursive_oneof {
     include!(concat!(env!("OUT_DIR"), "/recursive_oneof.rs"));
 }
 
+/// This tests the custom attributes support by abusing docs.
+///
+/// Docs really are full-blown attributes. So we use them to ensure we can place them on everything
+/// we need. If they aren't put onto something or allowed not to be there (by the generator),
+/// compilation fails.
+#[deny(missing_docs)]
+pub mod custom_attributes {
+    include!(concat!(env!("OUT_DIR"), "/foo.custom.attrs.rs"));
+}
+
+pub mod oneof_attributes {
+    include!(concat!(env!("OUT_DIR"), "/foo.custom.one_of_attrs.rs"));
+}
+
 use std::error::Error;
 
 use bytes::{Buf, IntoBuf};
@@ -149,7 +163,7 @@ pub fn check_message<M>(msg: &M) where M: Message + Default + PartialEq {
 #[cfg(test)]
 mod tests {
 
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use protobuf_test_messages::proto3::TestAllTypesProto3;
     use super::*;
@@ -212,13 +226,16 @@ mod tests {
     }
 
     #[test]
-    fn test_custom_container_attributes() {
+    fn test_custom_type_attributes() {
         // We abuse the ident conversion protobuf for the custom attribute additions. We placed
-        // `Eq` on the FooBarBaz (which is not implemented by ordinary messages).
+        // `Ord` on the FooBarBaz (which is not implemented by ordinary messages).
+        let mut set1 = BTreeSet::new();
         let msg1 = foo::bar_baz::FooBarBaz::default();
-        let msg2 = foo::bar_baz::FooBarBaz::default();
-        // This uses Eq, which wouldn't compile if the attribute didn't work
-        assert_eq!(msg1, msg2);
+        set1.insert(msg1);
+        // Similar, but for oneof fields
+        let mut set2 = BTreeSet::new();
+        let msg2 = oneof_attributes::Msg::default();
+        set2.insert(msg2.field);
     }
 
     #[test]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -53,6 +53,11 @@ pub mod custom_attributes {
     include!(concat!(env!("OUT_DIR"), "/foo.custom.attrs.rs"));
 }
 
+/// Also for testing custom attributes, but on oneofs.
+///
+/// Unfortunately, an OneOf field generates a companion module in the .rs file. There's no
+/// reasonable way to place a doc comment on that, so we do the test with `derive(Ord)` and have it
+/// in a separate file.
 pub mod oneof_attributes {
     include!(concat!(env!("OUT_DIR"), "/foo.custom.one_of_attrs.rs"));
 }
@@ -236,12 +241,6 @@ mod tests {
         let mut set2 = BTreeSet::new();
         let msg2 = oneof_attributes::Msg::default();
         set2.insert(msg2.field);
-    }
-
-    #[test]
-    fn test_custom_field_attributes() {
-        let input = include_str!(concat!(env!("OUT_DIR"), "/foo.bar_baz.rs"));
-        assert!(input.contains("// Testing comment"));
     }
 
     #[test]

--- a/tests/src/oneof_attributes.proto
+++ b/tests/src/oneof_attributes.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package Foo.Custom.OneOfAttrs;
+
+message Msg {
+	oneof field {
+		string a = 1;
+		bytes b = 2;
+	}
+}

--- a/tests/src/oneof_attributes.proto
+++ b/tests/src/oneof_attributes.proto
@@ -1,5 +1,9 @@
 syntax = "proto3";
 
+// Testing oneof custom attributes (separately from the other ones, since oneof
+// fields create their own companion module and our trick with abusing
+// deny(missing_docs) doesn't work on that.
+
 package Foo.Custom.OneOfAttrs;
 
 message Msg {


### PR DESCRIPTION
This allows messages to be for example Serialize or Eq.

This is my attempt at what is suggested in #45. I hope the usage is clear from the documentation.

If you know of any attribute that can be placed on a field without bringing another dependency, I'll be happy to replace that slightly hacky comment test.