### PR TITLE
Add ServiceGenerator::finalize

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -106,16 +106,12 @@ impl <'a> CodeGenerator<'a> {
 
         if let Some(ref service_generator) = code_gen.config.service_generator {
             code_gen.path.push(6);
-            let mut generated = false; // We call finalize only if there's at least one service
             for (idx, service) in file.service.into_iter().enumerate() {
                 code_gen.path.push(idx as i32);
                 service_generator.generate(code_gen.unpack_service(service), &mut code_gen.buf);
                 code_gen.path.pop();
-                generated = true;
             }
-            if generated {
-                service_generator.finalize(&mut code_gen.buf);
-            }
+            service_generator.finalize(&mut code_gen.buf);
             code_gen.path.pop();
         }
     }

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -106,10 +106,15 @@ impl <'a> CodeGenerator<'a> {
 
         if let Some(ref service_generator) = code_gen.config.service_generator {
             code_gen.path.push(6);
+            let mut generated = false; // We call finalize only if there's at least one service
             for (idx, service) in file.service.into_iter().enumerate() {
                 code_gen.path.push(idx as i32);
                 service_generator.generate(code_gen.unpack_service(service), &mut code_gen.buf);
                 code_gen.path.pop();
+                generated = true;
+            }
+            if generated {
+                service_generator.finalize(&mut code_gen.buf);
             }
             code_gen.path.pop();
         }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -173,17 +173,18 @@ pub trait ServiceGenerator {
     /// Generates a Rust interface or implementation for a service, writing the
     /// result to `buf`.
     fn generate(&self, service: Service, buf: &mut String);
+
     /// Finalizes the generation process.
     ///
     /// In case there's something that needs to be output at the end of the generation process, it
     /// goes here. Similar to [`generate`](#method.generate), the output should be appended to
-    /// `buf.
+    /// `buf`.
     ///
     /// An example can be a module or other thing that needs to appear just once, not for each
     /// service generated.
     ///
     /// This still can be called multiple times in a lifetime of the service generator, because it
-    /// can be used through multiple `.proto` files.
+    /// is called once per `.proto` file.
     ///
     /// The default implementation is empty and does nothing.
     fn finalize(&self, _buf: &mut String) {}

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -173,6 +173,20 @@ pub trait ServiceGenerator {
     /// Generates a Rust interface or implementation for a service, writing the
     /// result to `buf`.
     fn generate(&self, service: Service, buf: &mut String);
+    /// Finalizes the generation process.
+    ///
+    /// In case there's something that needs to be output at the end of the generation process, it
+    /// goes here. Similar to [`generate`](#method.generate), the output should be appended to
+    /// `buf.
+    ///
+    /// An example can be a module or other thing that needs to appear just once, not for each
+    /// service generated.
+    ///
+    /// This still can be called multiple times in a lifetime of the service generator, because it
+    /// can be used through multiple `.proto` files.
+    ///
+    /// The default implementation is empty and does nothing.
+    fn finalize(&self, _buf: &mut String) {}
 }
 
 /// Configuration options for Protobuf code generation.
@@ -443,6 +457,10 @@ mod tests {
 
             // Close out the trait.
             buf.push_str("}\n");
+        }
+        fn finalize(&self, buf: &mut String) {
+            // Needs to be present only once, no matter how many services there are
+            buf.push_str("pub mod utils { }\n");
         }
     }
 


### PR DESCRIPTION
It can be used to output things that need to exist only once per file
(eg. a module). Contains empty default implementation, for cases when no
such thing is needed.

This is a solution for a real-life problem, the `tower-grpc` wants to put its traits into submodules (`client` and `service`), but this fails if there's more than one service in a proto file. See https://github.com/tower-rs/tower-grpc/pull/10.