### PR TITLE
Reduce env_logger-related dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ byteorder = "1"
 bytes = "0.4"
 
 [dev-dependencies]
-env_logger = "0.5"
+env_logger = { version = "0.5", default-features = false }
 log = "0.4"
 prost-derive = { version = "0.3.0", path = "prost-derive" }
 quickcheck = "0.6"

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 bytes = "0.4"
-env_logger = "0.4"
+env_logger = { version = "0.5", default-features = false }
 log = "0.3"
 prost = { path = ".." }
 prost-derive = { path = "../prost-derive" }

--- a/conformance/src/main.rs
+++ b/conformance/src/main.rs
@@ -28,7 +28,7 @@ use tests::{
 };
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
     let mut bytes = Vec::new();
 
     loop {

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -11,7 +11,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 
 [dependencies]
 bytes = "0.4"
-env_logger = "0.4"
+env_logger = { version = "0.5", default-features = false }
 heck = "0.3"
 itertools = "0.7"
 log = "0.4"
@@ -27,4 +27,4 @@ tempdir = "0.3"
 zip = "0.2"
 
 [dev-dependencies]
-env_logger = "0.4"
+env_logger = { version = "0.5", default-features = false }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -25,6 +25,6 @@ prost-build = { path = "../prost-build" }
 tempdir = "0.3"
 
 [build-dependencies]
-env_logger = "0.4"
+env_logger = { version = "0.5", default-features = false }
 prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }


### PR DESCRIPTION
Use env_logger 0.5 everywhere, instead of a mix of 0.5 and 0.4, to
avoid needing to download and build two versions. This won't have an
effect on standalone builds of prost because prost has a dev-dependency
on quickcheck, which uses env_logger 0.4 still. However, it will have
a positive effect on things that depend on prost-build and that use
env_logger 0.5.

Also, don't automatically enable the "regex" default feature of
env_logger. Things that depend on Prost can still enable it (and will
enable it by default, since it is a default feature) if they need it.

Contributed on behalf of Buoyant, Inc.

Signed-off-by: Brian Smith <brian@briansmith.org>