### PR TITLE
prost-build: add Config option, use_idiomatic_enum_values

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -199,6 +199,7 @@ pub struct Config {
     type_attributes: Vec<(String, String)>,
     field_attributes: Vec<(String, String)>,
     prost_types: bool,
+    idiomatic_enum_values: bool,
 }
 
 impl Config {
@@ -352,6 +353,11 @@ impl Config {
         self
     }
 
+    pub fn use_idiomatic_enum_values(&mut self, idiomatic: bool) -> &mut Self {
+        self.idiomatic_enum_values = idiomatic;
+        self
+    }
+
     /// Compile `.proto` files into Rust files during a Cargo build with additional code generator
     /// configuration options.
     ///
@@ -456,6 +462,7 @@ impl default::Default for Config {
             type_attributes: Vec::new(),
             field_attributes: Vec::new(),
             prost_types: true,
+            idiomatic_enum_values: false, // defaulting to false (non-idiomatic), consider defaulting to true
         }
     }
 }


### PR DESCRIPTION
Fix for #80 

When enabled, this will attempt to create idiomatic Rust enum variants
from idiomatic protocol buffer enum value names by detecting value
names which are prefixed with the enum name and removing the prefix.

For now this defaults to false (previous behavior) and must be
explicitly enabled. This is for backward compatibility, but enabling by
default should be considered as this won't affect any who aren't
prefixing their protocol buffer enum value names, and will probably
be welcomed by most who are.