### PR TITLE
Disable unneeded features of the petgraph library.

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -16,7 +16,7 @@ heck = "0.3"
 itertools = "0.7"
 log = "0.4"
 multimap = { version = "0.4", default-features = false }
-petgraph = "0.4"
+petgraph = { version = "0.4", default-features = false }
 prost = { version = "0.3.0", path = ".." }
 prost-types = { version = "0.3.0", path = "../prost-types" }
 tempdir = "0.3"


### PR DESCRIPTION
This drops the `ordermap` dependency, for example.

Contributed on behalf of Buoyant, Inc.

Signed-off-by: Brian Smith <brian@briansmith.org>