### PR TITLE
Remove unused failure_derive dependency.

### DIFF
--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -13,7 +13,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 proc_macro = true
 
 [dependencies]
-failure = "0.1"
+failure = { version = "0.1", default-features = false, features = ["std"] }
 itertools = "0.7"
 proc-macro2 = "0.2"
 quote = "0.4"


### PR DESCRIPTION
Remove the indirect and unneeded dependency on failure_derive. In our
prost-based application, this change removes the following dependencies
from our Cargo.lock (partial output from `cargo update -p prost-derive`):

    Removing failure_derive v0.1.1
    Removing quote v0.3.15
    Removing syn v0.11.11
    Removing synom v0.11.3
    Removing synstructure v0.6.1
    Removing unicode-xid v0.0.4

Note in particular that prost itself is using a newer version of `syn` and
`quote` than `failure` is using.

Contributed on behalf of Buoyant, Inc.

Signed-off-by: Brian Smith <brian@briansmith.org>