### PR TITLE
Update dependencies

### DIFF
--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -15,6 +15,6 @@ proc_macro = true
 [dependencies]
 failure = { version = "0.1", default-features = false, features = ["std"] }
 itertools = "0.7"
-proc-macro2 = "0.2"
-quote = "0.4"
-syn = { version = "0.12", features = [ "extra-traits" ] }
+proc-macro2 = "0.3"
+quote = "0.5"
+syn = { version = "0.13", features = [ "extra-traits" ] }

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -696,7 +696,7 @@ impl DefaultValue {
             DefaultValue::String(ref value) => quote!(#value.to_owned()),
             DefaultValue::Bytes(ref value) if value.is_empty() => quote!(::std::vec::Vec::new()),
             DefaultValue::Bytes(ref value) => {
-                let lit = LitByteStr::new(value, Span::def_site());
+                let lit = LitByteStr::new(value, Span::call_site());
                 quote!(#lit.to_owned())
             },
 
@@ -724,7 +724,7 @@ impl quote::ToTokens for DefaultValue {
             DefaultValue::U64(value) => value.to_tokens(tokens),
             DefaultValue::Bool(value) => value.to_tokens(tokens),
             DefaultValue::String(ref value) => value.to_tokens(tokens),
-            DefaultValue::Bytes(ref value) => LitByteStr::new(value, Span::def_site()).to_tokens(tokens),
+            DefaultValue::Bytes(ref value) => LitByteStr::new(value, Span::call_site()).to_tokens(tokens),
             DefaultValue::Enumeration(ref value) => {
                 value.to_tokens(tokens)
             },


### PR DESCRIPTION
`def_site` was replaced by `call_site` because new `proc-macro2` doesn't expose it anymore. Besides, `prost-derive` only used spans for literals which shouldn't depend on span information at the same degree as identifiers.