### PR TITLE
prost-derive: infer tag values of hand-written types

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,52 @@ annotations.
 Currently the best documentation on adding annotations is to look at the
 generated code examples above.
 
+### Tag Inference for Existing Types
+
+Prost automatically infers tags for the struct.
+
+Fields are tagged sequentially in the order they
+are specified, starting with `1`.
+
+You may skip tags which have been reserved, or where there are gaps between
+sequentially occurring tag values by specifying the tag number to skip to with
+the `tag` attribute on the first field after the gap. The following fields will
+be tagged sequentially starting from the next number.
+
+```rust
+#[derive(Clone, Debug, PartialEq, Message)]
+struct Person {
+  pub id: String, // tag=1
+
+  // NOTE: Old "name" field has been removed
+  // pub name: String, // tag=2 (Removed)
+
+  #[prost(tag="6")]
+  pub given_name: String, // tag=6
+  pub family_name: String, // tag=7
+  pub formatted_name: String, // tag=8
+
+  #[prost(tag="3")]
+  pub age: u32, // tag=3
+  pub height: u32, // tag=4
+  #[prost(enumeration="Gender")]
+  pub gender: i32, // tag=5
+
+  // NOTE: Skip to less commonly occurring fields
+  #[prost(tag="16")]
+  pub name_prefix: String, // tag=16  (eg. mr/mrs/ms)
+  pub name_suffix: String, // tag=17  (eg. jr/esq)
+  pub maiden_name: String, // tag=18
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+pub enum Gender {
+  Unknown = 0,
+  Female = 1,
+  Male = 2,
+}
+```
+
 ## FAQ
 
 1. **Could `prost` be implemented as a serializer for [Serde](https://serde.rs/)?**
@@ -279,12 +325,6 @@ generated code examples above.
 
   But it is possible to place `serde` derive tags onto the generated types, so
   the same structure can support both `prost` and `Serde`.
-
-2. **Looks like a lot of field annotations. Can those be simplified?**
-
-  Probably. Effort has not yet been spent on reducing the number of annotations.
-  The recommended way of using `prost` is through [`prost-build`](prost-build),
-  in which case the annotations are never seen.
 
 ## License
 

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -56,7 +56,7 @@ pub struct Field {
 
 impl Field {
 
-    pub fn new(attrs: &[Meta]) -> Result<Option<Field>, Error> {
+    pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
         let mut types = None;
         let mut tag = None;
 
@@ -103,7 +103,7 @@ impl Field {
             }
         }
 
-        Ok(match (types, tag) {
+        Ok(match (types, tag.or(inferred_tag)) {
             (Some((map_ty, key_ty, val_ty)), Some(tag)) => {
                 Some(Field {
                     map_ty: map_ty,
@@ -117,7 +117,7 @@ impl Field {
     }
 
     pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
-        Field::new(attrs)
+        Field::new(attrs, None)
     }
 
     /// Returns a statement which encodes the map field.

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -17,7 +17,7 @@ pub struct Field {
 }
 
 impl Field {
-    pub fn new(attrs: &[Meta]) -> Result<Option<Field>, Error> {
+    pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
         let mut message = false;
         let mut label = None;
         let mut tag = None;
@@ -49,7 +49,7 @@ impl Field {
             _ => bail!("unknown attributes for message field: {:?}", unknown_attrs),
         }
 
-        let tag = match tag {
+        let tag = match tag.or(inferred_tag) {
             Some(tag) => tag,
             None => bail!("message field is missing a tag attribute"),
         };
@@ -61,7 +61,7 @@ impl Field {
     }
 
     pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
-        if let Some(mut field) = Field::new(attrs)? {
+        if let Some(mut field) = Field::new(attrs, None)? {
             if let Some(attr) = attrs.iter().find(|attr| Label::from_attr(attr).is_some()) {
                 bail!("invalid atribute for oneof field: {}", attr.name());
             }

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -37,16 +37,16 @@ impl Field {
     ///
     /// If the meta items are invalid, an error will be returned.
     /// If the field should be ignored, `None` is returned.
-    pub fn new(attrs: Vec<Attribute>) -> Result<Option<Field>, Error> {
+    pub fn new(attrs: Vec<Attribute>, inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
         let attrs = prost_attrs(attrs)?;
 
         // TODO: check for ignore attribute.
 
-        let field = if let Some(field) = scalar::Field::new(&attrs)? {
+        let field = if let Some(field) = scalar::Field::new(&attrs, inferred_tag)? {
             Field::Scalar(field)
-        } else if let Some(field) = message::Field::new(&attrs)? {
+        } else if let Some(field) = message::Field::new(&attrs, inferred_tag)? {
             Field::Message(field)
-        } else if let Some(field) = map::Field::new(&attrs)? {
+        } else if let Some(field) = map::Field::new(&attrs, inferred_tag)? {
             Field::Map(field)
         } else if let Some(field) = oneof::Field::new(&attrs)? {
             Field::Oneof(field)
@@ -224,8 +224,7 @@ impl fmt::Display for Label {
     }
 }
 
-/// Get the items belonging to the 'prost' list attribute
-/// (e.g. #[prost(foo, bar="baz")]).
+/// Get the items belonging to the 'prost' list attribute, e.g. `#[prost(foo, bar="baz")]`.
 fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
     Ok(attrs.iter().flat_map(Attribute::interpret_meta).flat_map(|meta| match meta {
         Meta::List(MetaList { ident, nested, .. }) => if ident == "prost" {

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -35,7 +35,7 @@ pub struct Field {
 
 impl Field {
 
-    pub fn new(attrs: &[Meta]) -> Result<Option<Field>, Error> {
+    pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
         let mut ty = None;
         let mut label = None;
         let mut packed = None;
@@ -71,7 +71,7 @@ impl Field {
             _ => bail!("unknown attributes: {:?}", unknown_attrs),
         }
 
-        let tag = match tag {
+        let tag = match tag.or(inferred_tag) {
             Some(tag) => tag,
             None => bail!("missing tag attribute"),
         };
@@ -108,7 +108,7 @@ impl Field {
     }
 
     pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
-        if let Some(mut field) = Field::new(attrs)? {
+        if let Some(mut field) = Field::new(attrs, None)? {
             match field.kind {
                 Kind::Plain(default) => {
                     field.kind = Kind::Required(default);

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -165,6 +165,17 @@ pub fn check_message<M>(msg: &M) where M: Message + Default + PartialEq {
     assert_eq!(msg, &roundtrip);
 }
 
+/// Serialize from A should equal Serialize from B
+pub fn check_serialize_equivalent<M, N>(msg_a: &M, msg_b: &N)
+where M: Message + Default + PartialEq,
+      N: Message + Default + PartialEq {
+    let mut buf_a = Vec::new();
+    msg_a.encode(&mut buf_a).unwrap();
+    let mut buf_b = Vec::new();
+    msg_b.encode(&mut buf_b).unwrap();
+    assert_eq!(buf_a, buf_b);
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -1,6 +1,7 @@
 use prost::Message;
 
 use check_message;
+use check_serialize_equivalent;
 
 #[derive(Clone, PartialEq, Message)]
 pub struct RepeatedFloats {
@@ -186,6 +187,56 @@ pub struct ScalarTypes {
     pub packed_string: Vec<String>,
     #[prost(bytes, repeated, tag="416")]
     pub packed_bytes: Vec<Vec<u8>>,
+}
+
+#[test]
+fn check_tags_inferred() {
+    check_message(&TagsInferred::default());
+    check_serialize_equivalent(&TagsInferred::default(), &TagsQualified::default());
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct TagsInferred {
+    #[prost(bool)]
+    pub one: bool,
+    #[prost(int32, optional)]
+    pub two: Option<i32>,
+    #[prost(float, repeated)]
+    pub three: Vec<f32>,
+
+    #[prost(tag="9", string, required)]
+    pub skip_to_nine: String,
+    #[prost(enumeration="BasicEnumeration", default="ONE")]
+    pub ten: i32,
+    #[prost(map="string, string")]
+    pub eleven: ::std::collections::HashMap<String, String>,
+
+    #[prost(tag="5", bytes)]
+    pub back_to_five: Vec<u8>,
+    #[prost(message, required)]
+    pub six: Basic,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct TagsQualified {
+    #[prost(tag="1", bool)]
+    pub one: bool,
+    #[prost(tag="2", int32, optional)]
+    pub two: Option<i32>,
+    #[prost(tag="3", float, repeated)]
+    pub three: Vec<f32>,
+
+    #[prost(tag="5", bytes)]
+    pub five: Vec<u8>,
+    #[prost(tag="6", message, required)]
+    pub six: Basic,
+
+    #[prost(tag="9", string, required)]
+    pub nine: String,
+    #[prost(tag="10", enumeration="BasicEnumeration", default="ONE")]
+    pub ten: i32,
+    #[prost(tag="11", map="string, string")]
+    pub eleven: ::std::collections::HashMap<String, String>,
 }
 
 /// A prost message with default value.


### PR DESCRIPTION
This contains the tag inference logic extracted from #73.