### PR TITLE
prost-build: strip enum name from enum variant prefix

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -199,6 +199,7 @@ pub struct Config {
     type_attributes: Vec<(String, String)>,
     field_attributes: Vec<(String, String)>,
     prost_types: bool,
+    strip_enum_prefix: bool,
 }
 
 impl Config {
@@ -352,6 +353,17 @@ impl Config {
         self
     }
 
+    /// Configures the code generator to not strip the enum name from variant names.
+    ///
+    /// Protobuf enum definitions commonly include the enum name as a prefix of every variant name.
+    /// This style is non-idiomatic in Rust, so by default `prost` strips the enum name prefix from
+    /// variants which include it. Configuring this option will prevent `prost` from stripping the
+    /// prefix.
+    pub fn retain_enum_prefix(&mut self) -> &mut Self {
+        self.strip_enum_prefix = false;
+        self
+    }
+
     /// Compile `.proto` files into Rust files during a Cargo build with additional code generator
     /// configuration options.
     ///
@@ -449,6 +461,7 @@ impl default::Default for Config {
             type_attributes: Vec::new(),
             field_attributes: Vec::new(),
             prost_types: true,
+            strip_enum_prefix: true,
         }
     }
 }

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -48,8 +48,8 @@ impl MessageGraph {
         let msg_index = self.get_or_insert_index(msg_name.clone());
 
         for field in &msg.field {
-            if field.type_() == field_descriptor_proto::Type::TypeMessage
-                && field.label() != field_descriptor_proto::Label::LabelRepeated {
+            if field.type_() == field_descriptor_proto::Type::Message
+                && field.label() != field_descriptor_proto::Label::Repeated {
                 let field_index = self.get_or_insert_index(field.type_name.clone().unwrap());
                 self.graph.add_edge(msg_index, field_index, ());
             }

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -150,43 +150,43 @@ pub mod field_descriptor_proto {
     pub enum Type {
         /// 0 is reserved for errors.
         /// Order is weird for historical reasons.
-        TypeDouble = 1,
-        TypeFloat = 2,
+        Double = 1,
+        Float = 2,
         /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
         /// negative values are likely.
-        TypeInt64 = 3,
-        TypeUint64 = 4,
+        Int64 = 3,
+        Uint64 = 4,
         /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
         /// negative values are likely.
-        TypeInt32 = 5,
-        TypeFixed64 = 6,
-        TypeFixed32 = 7,
-        TypeBool = 8,
-        TypeString = 9,
+        Int32 = 5,
+        Fixed64 = 6,
+        Fixed32 = 7,
+        Bool = 8,
+        String = 9,
         /// Tag-delimited aggregate.
         /// Group type is deprecated and not supported in proto3. However, Proto3
         /// implementations should still be able to parse the group wire format and
         /// treat group fields as unknown fields.
-        TypeGroup = 10,
+        Group = 10,
         /// Length-delimited aggregate.
-        TypeMessage = 11,
+        Message = 11,
         /// New in version 2.
-        TypeBytes = 12,
-        TypeUint32 = 13,
-        TypeEnum = 14,
-        TypeSfixed32 = 15,
-        TypeSfixed64 = 16,
+        Bytes = 12,
+        Uint32 = 13,
+        Enum = 14,
+        Sfixed32 = 15,
+        Sfixed64 = 16,
         /// Uses ZigZag encoding.
-        TypeSint32 = 17,
+        Sint32 = 17,
         /// Uses ZigZag encoding.
-        TypeSint64 = 18,
+        Sint64 = 18,
     }
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
     pub enum Label {
         /// 0 is reserved for errors
-        LabelOptional = 1,
-        LabelRequired = 2,
-        LabelRepeated = 3,
+        Optional = 1,
+        Required = 2,
+        Repeated = 3,
     }
 }
 /// Describes a oneof.
@@ -1086,13 +1086,13 @@ pub mod field {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
     pub enum Cardinality {
         /// For fields with unknown cardinality.
-        CardinalityUnknown = 0,
+        Unknown = 0,
         /// For optional fields.
-        CardinalityOptional = 1,
+        Optional = 1,
         /// For required fields. Proto2 syntax only.
-        CardinalityRequired = 2,
+        Required = 2,
         /// For repeated fields.
-        CardinalityRepeated = 3,
+        Repeated = 3,
     }
 }
 /// Enum type definition.
@@ -1148,9 +1148,9 @@ pub struct Option {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
 pub enum Syntax {
     /// Syntax `proto2`.
-    SyntaxProto2 = 0,
+    Proto2 = 0,
     /// Syntax `proto3`.
-    SyntaxProto3 = 1,
+    Proto3 = 1,
 }
 /// Api is a light-weight descriptor for an API Interface.
 ///


### PR DESCRIPTION
This commit modifies prost-build to strip the enum name from enum
variants which include the enum name as a prefix. This style is common
with Protobuf (since it's heavily tied to C++ name resolution), however
it's non-idiomatic in Rust. To restore the previous behavior, a new
Config option is provided: `retain_enum_prefix`. This is a breaking
change.