### PR TITLE
prost-build: check PATH for protoc

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -21,5 +21,8 @@ prost = { version = "0.3.2", path = ".." }
 prost-types = { version = "0.3.2", path = "../prost-types" }
 tempdir = "0.3"
 
+[build-dependencies]
+which = "2"
+
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -1,56 +1,96 @@
+//! Finds the appropriate `protoc` binary and Protobuf include directory for this host, and outputs
+//! build directives so that the main `prost-build` crate can use them.
+//!
+//! The following locations are checked for `protoc` in decreasing priority:
+//!
+//!     1. The `PROTOC` environment variable.
+//!     2. The bundled `protoc`.
+//!     3. The `protoc` on the `PATH`.
+//!
+//! If no `protoc` binary is available in these locations, the build fails.
+//!
+//! The following locations are checked for the Protobuf include directory in decreasing priority:
+//!
+//!     1. The `PROTOC_INCLUDE` environment variable.
+//!     2. The bundled Protobuf include directory.
+
+extern crate which;
+
 use std::env;
 use std::path::PathBuf;
 
-fn main() {
-    if env_contains_protoc() { return; }
+/// Returns the path to the location of the bundled Protobuf artifacts.
+fn bundle_path() -> PathBuf {
+    env::current_dir().unwrap().join("third-party").join("protobuf")
+}
 
+/// Returns the path to the `protoc` pointed to by the `PROTOC` environment variable, if it is set.
+fn env_protoc() -> Option<PathBuf> {
+    let protoc = match env::var_os("PROTOC") {
+        Some(path) => PathBuf::from(path),
+        None => return None,
+    };
+
+    if !protoc.exists() {
+        panic!("PROTOC environment variable points to non-existent file ({:?})", protoc);
+    }
+
+    Some(protoc)
+}
+
+/// Returns the path to the bundled `protoc`, if it is available for the host platform.
+fn bundled_protoc() -> Option<PathBuf> {
     let protoc_bin_name = match (env::consts::OS, env::consts::ARCH) {
         ("linux", "x86") => "protoc-linux-x86_32",
         ("linux", "x86_64") => "protoc-linux-x86_64",
         ("linux", "aarch64") => "protoc-linux-aarch_64",
         ("macos", "x86_64") => "protoc-osx-x86_64",
         ("windows", _) => "protoc-win32.exe",
-        _ => panic!("no precompiled protoc binary for the current platform: {}-{}",
-                    env::consts::OS, env::consts::ARCH),
+        _ => return None,
     };
 
-    let cwd = env::current_dir().unwrap();
-    let protobuf = cwd.join("third-party/protobuf");
-    let protoc = protobuf.join(protoc_bin_name);
-    let protoc_include_dir = protobuf.join("include");
-
-    println!("cargo:rustc-env=PROTOC={}", protoc.display());
-    println!("cargo:rustc-env=PROTOC_INCLUDE={}", protoc_include_dir.display());
-    println!("cargo:rerun-if-env-changed=PROTOC");
-    println!("cargo:rerun-if-env-changed=PROTOC_INCLUDE");
+    Some(bundle_path().join(protoc_bin_name))
 }
 
-/// Returns `true` if the environment already contains the `PROTOC` and `PROTOC_INCLUDE` variables.
-fn env_contains_protoc() -> bool {
-    let protoc = match env::var("PROTOC") {
-        Ok(val) => PathBuf::from(val),
-        Err(env::VarError::NotPresent) => return false,
-        Err(env::VarError::NotUnicode(..)) => panic!("PROTOC environment variable is not valid UTF-8"),
+/// Returns the path to the `protoc` included on the `PATH`, if it exists.
+fn path_protoc() -> Option<PathBuf> {
+    which::which("protoc").ok()
+}
+
+/// Returns the path to the Protobuf include directory pointed to by the `PROTOC_INCLUDE`
+/// environment variable, if it is set.
+fn env_protoc_include() -> Option<PathBuf> {
+    let protoc_include = match env::var_os("PROTOC_INCLUDE") {
+        Some(path) => PathBuf::from(path),
+        None => return None,
     };
 
-    let protoc_include = match env::var("PROTOC_INCLUDE") {
-        Ok(val) => PathBuf::from(val),
-        Err(env::VarError::NotPresent) => panic!("PROTOC_INCLUDE environment variable not set (PROTOC is set)"),
-        Err(env::VarError::NotUnicode(..)) => panic!("PROTOC_INCLUDE environment variable is not valid UTF-8"),
-    };
-
-    if !protoc.exists() {
-        panic!("PROTOC environment variable points to non-existent file ({:?})", protoc);
-    }
     if !protoc_include.exists() {
         panic!("PROTOC_INCLUDE environment variable points to non-existent directory ({:?})",
                protoc_include);
     }
+    if !protoc_include.is_dir() {
+        panic!("PROTOC_INCLUDE environment variable points to a non-directory file ({:?})",
+               protoc_include);
+    }
+
+    Some(protoc_include)
+}
+
+/// Returns the path to the bundled Protobuf include directory.
+fn bundled_protoc_include() -> PathBuf {
+    bundle_path().join("include")
+}
+
+fn main() {
+    let protoc = env_protoc().or_else(bundled_protoc).or_else(path_protoc).expect(
+        "Failed to find the protoc binary. The PROTOC environment variable is not set, \
+        there is no bundled protoc for this platform, and protoc is not in the PATH");
+
+    let protoc_include = env_protoc_include().unwrap_or_else(bundled_protoc_include);
 
     println!("cargo:rustc-env=PROTOC={}", protoc.display());
     println!("cargo:rustc-env=PROTOC_INCLUDE={}", protoc_include.display());
     println!("cargo:rerun-if-env-changed=PROTOC");
     println!("cargo:rerun-if-env-changed=PROTOC_INCLUDE");
-    true
 }
-

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -85,9 +85,9 @@
 //! ## Sourcing `protoc`
 //!
 //! `prost-build` depends on the Protocol Buffers compiler, `protoc`, to parse `.proto` files into
-//! a representation that can be transformed into Rust. If set, `prost_build` will use the `PROTOC`
-//! and `PROTOC_INCLUDE` environment variables for locating `protoc` and the protobuf built-in
-//! includes. For example, on a macOS system where protobuf is installed with Homebrew, set the
+//! a representation that can be transformed into Rust. If set, `prost-build` uses the `PROTOC` and
+//! `PROTOC_INCLUDE` environment variables for locating `protoc` and the Protobuf includes
+//! directory. For example, on a macOS system where Protobuf is installed with Homebrew, set the
 //! environment to:
 //!
 //! ```bash
@@ -102,9 +102,14 @@
 //! PROTOC_INCLUDE=/usr/include
 //! ```
 //!
-//! If `PROTOC` and `PROTOC_INCLUDE` are not found in the environment, then a pre-compiled `protoc`
-//! binary embedded in the prost-build crate will be used. Pre-compiled `protoc` binaries exist for
-//! Linux, macOS, and Windows systems.
+//! If `PROTOC` is not found in the environment, then a pre-compiled `protoc` binary bundled in
+//! the prost-build crate is used. Pre-compiled `protoc` binaries exist for Linux, macOS, and
+//! Windows systems. If no pre-compiled `protoc` is available for the host platform, then the
+//! `protoc` or `protoc.exe` binary on the `PATH` is used. If `protoc` is not available in any of
+//! these fallback locations, then the build fails.
+//!
+//! If `PROTOC_INCLUDE` is not found in the environment, then the Protobuf include directory bundled
+//! in the prost-build crate is be used.
 
 extern crate heck;
 extern crate itertools;
@@ -219,7 +224,7 @@ impl Config {
     /// name (not the generated Rust type name). Paths with a leading `.` are treated as fully
     /// qualified names. Paths without a leading `.` are treated as relative, and are suffix
     /// matched on the fully qualified field name. If a Protobuf map field matches any of the
-    /// paths, a Rust `BTreeMap` field will be generated instead of the default [`HashMap`][3].
+    /// paths, a Rust `BTreeMap` field is generated instead of the default [`HashMap`][3].
     ///
     /// The matching is done on the Protobuf names, before converting to Rust-friendly casing
     /// standards.
@@ -268,7 +273,7 @@ impl Config {
     ///
     /// # Arguments
     ///
-    /// **`path`** - a patch matching any number of fields. These fields will get the attribute.
+    /// **`path`** - a patch matching any number of fields. These fields get the attribute.
     /// For details about matching fields see [`btree_map`](#method.btree_map).
     ///
     /// **`attribute`** - an arbitrary string that'll be placed before each matched field. The
@@ -284,7 +289,7 @@ impl Config {
     /// ```
     /// # let mut config = prost_build::Config::new();
     /// // Prost renames fields named `in` to `in_`. But if serialized through serde,
-    /// // we want them to appear as `in` again.
+    /// // they should as `in`.
     /// config.field_attribute("in", "#[serde(rename = \"in\")]");
     /// ```
     pub fn field_attribute<P, A>(&mut self, path: P, attribute: A) -> &mut Self
@@ -357,7 +362,7 @@ impl Config {
     ///
     /// Protobuf enum definitions commonly include the enum name as a prefix of every variant name.
     /// This style is non-idiomatic in Rust, so by default `prost` strips the enum name prefix from
-    /// variants which include it. Configuring this option will prevent `prost` from stripping the
+    /// variants which include it. Configuring this option prevents `prost` from stripping the
     /// prefix.
     pub fn retain_enum_prefix(&mut self) -> &mut Self {
         self.strip_enum_prefix = false;
@@ -389,10 +394,10 @@ impl Config {
                                       "OUT_DIR environment variable is not set"))?
             .into();
 
-        // TODO: We should probably emit 'rerun-if-changed=PATH' directives for
-        // cargo, however according to [1] if we output any, those paths will
-        // replace the default crate root, which we don't want. Figure out how to do
-        // it in an additive way, perhaps gcc-rs has this figured out.
+        // TODO: This should probably emit 'rerun-if-changed=PATH' directives for cargo, however
+        // according to [1] if any are output then those paths replace the default crate root,
+        // which is undesirable. Figure out how to do it in an additive way; perhaps gcc-rs has
+        // this figured out.
         // [1]: http://doc.crates.io/build-script.html#outputs-of-the-build-script
 
         let tmp = tempdir::TempDir::new("prost-build")?;
@@ -468,20 +473,19 @@ impl default::Default for Config {
 
 /// Compile `.proto` files into Rust files during a Cargo build.
 ///
-/// The generated `.rs` files will be written to the Cargo `OUT_DIR` directory, suitable for use
-/// with the [include!][1] macro. See the [Cargo `build.rs` code generation][2] example for more
-/// info.
+/// The generated `.rs` files are written to the Cargo `OUT_DIR` directory, suitable for use with
+/// the [include!][1] macro. See the [Cargo `build.rs` code generation][2] example for more info.
 ///
 /// This function should be called in a project's `build.rs`.
 ///
 /// # Arguments
 ///
 /// **`protos`** - Paths to `.proto` files to compile. Any transitively [imported][3] `.proto`
-/// files will automatically be included.
+/// files are automatically be included.
 ///
-/// **`includes`** - Paths to directories in which to search for imports. Directories will be
-/// searched in order. The `.proto` files passed in **`protos`** must be found
-/// in one of the provided include directories.
+/// **`includes`** - Paths to directories in which to search for imports. Directories are searched
+/// in order. The `.proto` files passed in **`protos`** must be found in one of the provided
+/// include directories.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
Now that the Protobuf include directory is bundled into the prost-build
crate, there's no reason not to fall-back to the `protoc` on the path
for host platforms which don't have a bundled `protoc`.