### PR TITLE
Fix "warning: unused result" when using "#![warn(unused_results)]"

### DIFF
--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -158,10 +158,10 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                                         quote!(builder.field(&wrapper))
                                     };
                                     quote! {
-                                         {
+                                         let builder = {
                                              let wrapper = #wrapper;
-                                             #call;
-                                         }
+                                             #call
+                                         };
                                     }
                                 });
     let debug_builder = if is_struct {

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -53,4 +53,7 @@ fn main() {
 
     prost_build.compile_protos(&["src/oneof_attributes.proto"],
                                &["src"]).unwrap();
+
+    prost_build.compile_protos(&["src/no_unused_results.proto"],
+                               &["src"]).unwrap();
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -13,6 +13,7 @@ pub mod unittest;
 #[cfg(test)] mod bootstrap;
 #[cfg(test)] mod debug;
 #[cfg(test)] mod message_encoding;
+#[cfg(test)] mod no_unused_results;
 
 pub mod protobuf_test_messages {
     pub mod proto2 {

--- a/tests/src/no_unused_results.proto
+++ b/tests/src/no_unused_results.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package no_unused_results;
+
+message Test {
+    string dummy_field = 1;
+}

--- a/tests/src/no_unused_results.rs
+++ b/tests/src/no_unused_results.rs
@@ -1,0 +1,7 @@
+mod should_compile_successfully {
+    #![deny(unused_results)]
+    include!(concat!(env!("OUT_DIR"), "/no_unused_results.rs"));
+}
+
+#[test]
+fn dummy() {}


### PR DESCRIPTION
This fixes danburkert/prost#101.