### PR TITLE
Update minimum version of bytes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ exclude = [
 
 [dependencies]
 byteorder = "1"
-bytes = "0.4"
+bytes = "0.4.7"
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }


### PR DESCRIPTION
The get_*_be and get_*_le variants are not present in 0.4.6 and below.