### PR TITLE
Strip enum type prefix in default field values

### DIFF
--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -56,4 +56,7 @@ fn main() {
 
     prost_build.compile_protos(&["src/no_unused_results.proto"],
                                &["src"]).unwrap();
+
+    prost_build.compile_protos(&["src/default_enum_value.proto"],
+                               &["src"]).unwrap();
 }

--- a/tests/src/default_enum_value.proto
+++ b/tests/src/default_enum_value.proto
@@ -1,0 +1,18 @@
+// From https://github.com/danburkert/prost/issues/118
+
+syntax = "proto2";
+
+package default_enum_value;
+
+enum PrivacyLevel {
+  PRIVACY_LEVEL_ONE = 1;
+  PRIVACY_LEVEL_TWO = 2;
+  PRIVACY_LEVEL_PRIVACY_LEVEL_THREE = 3;
+  PRIVACY_LEVELPRIVACY_LEVEL_FOUR = 4;
+}
+
+message Test {
+  optional PrivacyLevel privacy_level_1 = 1 [default = PRIVACY_LEVEL_ONE];
+  optional PrivacyLevel privacy_level_3 = 2 [default = PRIVACY_LEVEL_PRIVACY_LEVEL_THREE];
+  optional PrivacyLevel privacy_level_4 = 3 [default = PRIVACY_LEVELPRIVACY_LEVEL_FOUR];
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -63,6 +63,14 @@ pub mod oneof_attributes {
     include!(concat!(env!("OUT_DIR"), "/foo.custom.one_of_attrs.rs"));
 }
 
+/// Issue https://github.com/danburkert/prost/issues/118
+///
+/// When a message contains an enum field with a default value, we
+/// must ensure that the appropriate name conventions are used.
+pub mod default_enum_value {
+    include!(concat!(env!("OUT_DIR"), "/default_enum_value.rs"));
+}
+
 use std::error::Error;
 
 use bytes::{Buf, IntoBuf};
@@ -278,5 +286,13 @@ mod tests {
                 }))
             })))
         };
+    }
+
+    #[test]
+    fn test_default_enum() {
+        let msg = default_enum_value::Test::default();
+        assert_eq!(msg.privacy_level_1(), default_enum_value::PrivacyLevel::One);
+        assert_eq!(msg.privacy_level_3(), default_enum_value::PrivacyLevel::PrivacyLevelThree);
+        assert_eq!(msg.privacy_level_4(), default_enum_value::PrivacyLevel::PrivacyLevelprivacyLevelFour);
     }
 }


### PR DESCRIPTION
Fix for #118 - If the `strip_enum_prefix` option is enabled, then default values for enum fields must have their prefixes stripped as well.