### PR TITLE
Extern path

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -260,7 +260,7 @@ impl <'a> CodeGenerator<'a> {
 
         let repeated = field.label == Some(Label::Repeated as i32);
         let optional = self.optional(&field);
-        let ty = self.resolve_type(&field).into_owned();
+        let ty = self.resolve_type(&field);
 
         let boxed = !repeated
                  && type_ == Type::Message
@@ -344,8 +344,8 @@ impl <'a> CodeGenerator<'a> {
                         field: FieldDescriptorProto,
                         key: &FieldDescriptorProto,
                         value: &FieldDescriptorProto) {
-        let key_ty = self.resolve_type(key).into_owned();
-        let value_ty = self.resolve_type(value).into_owned();
+        let key_ty = self.resolve_type(key);
+        let value_ty = self.resolve_type(value);
 
         debug!("    map field: {:?}, key type: {:?}, value type: {:?}",
                field.name(), key_ty, value_ty);
@@ -431,7 +431,7 @@ impl <'a> CodeGenerator<'a> {
             self.append_field_attributes(&oneof_name, field.name());
 
             self.push_indent();
-            let ty = self.resolve_type(&field).into_owned();
+            let ty = self.resolve_type(&field);
 
             let boxed = type_ == Type::Message
                      && self.message_graph.is_nested(field.type_name(), msg_name);
@@ -605,22 +605,22 @@ impl <'a> CodeGenerator<'a> {
         self.buf.push_str("}\n");
     }
 
-    fn resolve_type(&'a self, field: &FieldDescriptorProto) -> Cow<'a, str>{
+    fn resolve_type(&self, field: &FieldDescriptorProto) -> String {
         match field.type_() {
-            Type::Float => Cow::Borrowed("f32"),
-            Type::Double => Cow::Borrowed("f64"),
-            Type::Uint32 | Type::Fixed32 => Cow::Borrowed("u32"),
-            Type::Uint64 | Type::Fixed64 => Cow::Borrowed("u64"),
-            Type::Int32 | Type::Sfixed32 | Type::Sint32 | Type::Enum => Cow::Borrowed("i32"),
-            Type::Int64 | Type::Sfixed64 | Type::Sint64 => Cow::Borrowed("i64"),
-            Type::Bool => Cow::Borrowed("bool"),
-            Type::String => Cow::Borrowed("String"),
-            Type::Bytes => Cow::Borrowed("Vec<u8>"),
+            Type::Float => String::from("f32"),
+            Type::Double => String::from("f64"),
+            Type::Uint32 | Type::Fixed32 => String::from("u32"),
+            Type::Uint64 | Type::Fixed64 => String::from("u64"),
+            Type::Int32 | Type::Sfixed32 | Type::Sint32 | Type::Enum => String::from("i32"),
+            Type::Int64 | Type::Sfixed64 | Type::Sint64 => String::from("i64"),
+            Type::Bool => String::from("bool"),
+            Type::String => String::from("String"),
+            Type::Bytes => String::from("Vec<u8>"),
             Type::Group | Type::Message => {
                 if let Some(ty) = self.known_type(field.type_name()) {
-                    Cow::Borrowed(ty)
+                    String::from(ty)
                 } else {
-                    Cow::Owned(self.resolve_ident(field.type_name()))
+                    self.resolve_ident(field.type_name())
                 }
             },
         }

--- a/prost-build/src/extern_paths.rs
+++ b/prost-build/src/extern_paths.rs
@@ -1,0 +1,139 @@
+use std::collections::{
+    HashMap,
+    hash_map,
+};
+
+use itertools::Itertools;
+
+use ident::{
+    to_snake,
+    to_upper_camel,
+};
+
+fn validate_proto_path(path: &str) -> Result<(), String> {
+    if path.chars().next().map(|c| c != '.').unwrap_or(true) {
+        return Err(format!("Protobuf paths must be fully qualified (begin with a leading '.'): {}",
+                           path));
+    }
+    if path.split('.').skip(1).any(str::is_empty) {
+        return Err(format!("invalid fully-qualified Protobuf path: {}", path));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct ExternPaths {
+    extern_paths: HashMap<String, String>,
+}
+
+impl ExternPaths {
+    pub fn new(paths: &[(String, String)], prost_types: bool)-> Result<ExternPaths, String> {
+        let mut extern_paths = ExternPaths {
+            extern_paths: HashMap::new(),
+        };
+
+        for (proto_path, rust_path) in paths {
+            extern_paths.insert(proto_path.clone(), rust_path.clone())?;
+        }
+
+        if prost_types {
+            extern_paths.insert(".google.protobuf".to_string(), "::prost_types".to_string())?;
+            extern_paths.insert(".google.protobuf.BoolValue".to_string(), "bool".to_string())?;
+            extern_paths.insert(".google.protobuf.BytesValue".to_string(), "::std::vec::Vec<u8>".to_string())?;
+            extern_paths.insert(".google.protobuf.DoubleValue".to_string(), "f64".to_string())?;
+            extern_paths.insert(".google.protobuf.Empty".to_string(), "()".to_string())?;
+            extern_paths.insert(".google.protobuf.FloatValue".to_string(), "f32".to_string())?;
+            extern_paths.insert(".google.protobuf.Int32Value".to_string(), "i32".to_string())?;
+            extern_paths.insert(".google.protobuf.Int64Value".to_string(), "i64".to_string())?;
+            extern_paths.insert(".google.protobuf.StringValue".to_string(), "::std::string::String".to_string())?;
+            extern_paths.insert(".google.protobuf.UInt32Value".to_string(), "u32".to_string())?;
+            extern_paths.insert(".google.protobuf.UInt64Value".to_string(), "u64".to_string())?;
+        }
+
+        Ok(extern_paths)
+    }
+
+    fn insert(&mut self, proto_path: String, rust_path: String) -> Result<(), String> {
+        validate_proto_path(&proto_path)?;
+        match self.extern_paths.entry(proto_path) {
+            hash_map::Entry::Occupied(occupied) => return Err(format!("duplicate extern Protobuf path: {}", occupied.key())),
+            hash_map::Entry::Vacant(vacant) => vacant.insert(rust_path),
+        };
+        Ok(())
+    }
+
+    pub fn resolve_ident(&self, pb_ident: &str) -> Option<String> {
+        // protoc should always give fully qualified identifiers.
+        assert_eq!(".", &pb_ident[..1]);
+
+        if let Some(rust_path) = self.extern_paths.get(pb_ident) {
+            return Some(rust_path.clone())
+        }
+
+        // TODO(danburkert): there must be a more efficient way to do this, maybe a trie?
+        for (idx, _) in pb_ident.rmatch_indices('.') {
+            if let Some(rust_path) = self.extern_paths.get(&pb_ident[..idx]) {
+
+                let mut segments = pb_ident[idx+1..].split('.');
+                let ident_type = segments.next_back().map(|segment| to_upper_camel(&segment));
+
+                return Some(rust_path.split("::")
+                            .chain(segments)
+                            .map(|segment| to_snake(&segment))
+                            .chain(ident_type.into_iter())
+                            .join("::"))
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_extern_paths() {
+        let paths = ExternPaths::new(&[
+            (".foo".to_string(), "::foo1".to_string()),
+            (".foo.bar".to_string(), "::foo2".to_string()),
+            (".foo.baz".to_string(), "::foo3".to_string()),
+            (".foo.Fuzz".to_string(), "::foo4::Fuzz".to_string()),
+            (".a.b.c.d.e.f".to_string(), "::abc::def".to_string()),
+        ], false).unwrap();
+
+        let case = |proto_ident: &str, resolved_ident: &str| {
+            assert_eq!(paths.resolve_ident(proto_ident).unwrap(), resolved_ident);
+        };
+
+        case(".foo", "::foo1");
+        case(".foo.Foo", "::foo1::Foo");
+        case(".foo.bar", "::foo2");
+        case(".foo.Bas", "::foo1::Bas");
+
+        case(".foo.bar.Bar", "::foo2::Bar");
+        case(".foo.Fuzz.Bar", "::foo4::fuzz::Bar");
+
+        case(".a.b.c.d.e.f", "::abc::def");
+        case(".a.b.c.d.e.f.g.FooBar.Baz", "::abc::def::g::foo_bar::Baz");
+
+        assert!(paths.resolve_ident(".a").is_none());
+        assert!(paths.resolve_ident(".a.b").is_none());
+        assert!(paths.resolve_ident(".a.c").is_none());
+    }
+
+    #[test]
+    fn test_well_known_types() {
+        let paths = ExternPaths::new(&[], true).unwrap();
+
+        let case = |proto_ident: &str, resolved_ident: &str| {
+            assert_eq!(paths.resolve_ident(proto_ident).unwrap(), resolved_ident);
+        };
+
+        case(".google.protobuf.Value", "::prost_types::Value");
+        case(".google.protobuf.Duration", "::prost_types::Duration");
+        case(".google.protobuf.Empty", "()");
+    }
+}

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -366,7 +366,7 @@ impl Config {
         self
     }
 
-    /// Maps Protobuf types to a Rust types.
+    /// Maps a set of Protobuf types to Rust types.
     pub fn map_types(&mut self, map: HashMap<String, String>) -> &mut Self {
         self.mapped_types.extend(map);
         self

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -206,6 +206,7 @@ pub struct Config {
     prost_types: bool,
     strip_enum_prefix: bool,
     out_dir: Option<PathBuf>,
+    mapped_types: HashMap<String, String>,
 }
 
 impl Config {
@@ -359,6 +360,18 @@ impl Config {
         self
     }
 
+    /// Maps a Protobuf type to a Rust type. Both types must be fully-qualified.
+    pub fn map_type(&mut self, source: String, target: String) -> &mut Self {
+        self.mapped_types.insert(source, target);
+        self
+    }
+
+    /// Maps Protobuf types to a Rust types.
+    pub fn map_types(&mut self, map: HashMap<String, String>) -> &mut Self {
+        self.mapped_types.extend(map);
+        self
+    }
+
     /// Configures the code generator to not strip the enum name from variant names.
     ///
     /// Protobuf enum definitions commonly include the enum name as a prefix of every variant name.
@@ -480,6 +493,7 @@ impl default::Default for Config {
             prost_types: true,
             strip_enum_prefix: true,
             out_dir: None,
+            mapped_types: HashMap::new(),
         }
     }
 }

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -2,6 +2,10 @@ extern crate env_logger;
 extern crate prost_build;
 extern crate protobuf;
 
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
 fn main() {
     let _ = env_logger::init();
 
@@ -25,9 +29,6 @@ fn main() {
     prost_build.field_attribute("Foo.Custom.Attrs.Msg.field.a", "/// Oneof A docs");
     prost_build.field_attribute("Foo.Custom.Attrs.Msg.field.b", "/// Oneof B docs");
 
-    prost_build.compile_protos(&["src/packages/widget_factory.proto"],
-                               &["src/packages"]).unwrap();
-
     prost_build.compile_protos(&["src/ident_conversion.proto"],
                                &["src"]).unwrap();
 
@@ -48,4 +49,17 @@ fn main() {
 
     prost_build.compile_protos(&["src/default_enum_value.proto"],
                                &["src"]).unwrap();
+
+    prost_build.compile_protos(&["src/packages/widget_factory.proto"],
+                               &["src/packages"]).unwrap();
+
+    // Compile some of the modules examples as an extern_path.
+    let extern_path = &PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"))
+        .join("extern_paths");
+    fs::create_dir_all(extern_path).expect("failed to create prefix directory");
+
+    prost_build.out_dir(extern_path)
+               .extern_path(".packages.gizmo", "::packages::gizmo")
+               .compile_protos(&["src/packages/widget_factory.proto"],
+                               &["src/packages"]).unwrap();
 }

--- a/tests/src/extern_paths.rs
+++ b/tests/src/extern_paths.rs
@@ -1,30 +1,18 @@
-//! Tests nested packages.
+//! Tests nested packages with `extern_path`.
 
-include!(concat!(env!("OUT_DIR"), "/packages.rs"));
-
-pub mod gizmo {
-    include!(concat!(env!("OUT_DIR"), "/packages.gizmo.rs"));
-}
+include!(concat!(env!("OUT_DIR"), "/extern_paths/packages.rs"));
 
 pub mod widget {
-    include!(concat!(env!("OUT_DIR"), "/packages.widget.rs"));
+    include!(concat!(env!("OUT_DIR"), "/extern_paths/packages.widget.rs"));
     pub mod factory {
-        include!(concat!(env!("OUT_DIR"), "/packages.widget.factory.rs"));
-    }
-}
-
-// Trait used in extern_paths.rs.
-pub trait DoIt {
-    fn do_it(&self);
-}
-
-impl DoIt for gizmo::Gizmo {
-    fn do_it(&self) {
+        include!(concat!(env!("OUT_DIR"), "/extern_paths/packages.widget.factory.rs"));
     }
 }
 
 #[test]
 fn test() {
+    use packages::DoIt;
+    use packages::gizmo;
     use prost::Message;
 
     let mut widget_factory = widget::factory::WidgetFactory::default();
@@ -47,6 +35,7 @@ fn test() {
 
     widget_factory.gizmo = Some(gizmo::Gizmo {});
     assert_eq!(12, widget_factory.encoded_len());
+    widget_factory.gizmo.as_ref().map(DoIt::do_it);
 
     widget_factory.gizmo_inner = Some(gizmo::gizmo::Inner {});
     assert_eq!(14, widget_factory.encoded_len());

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,6 +8,7 @@ extern crate protobuf;
 #[cfg(test)] extern crate tempdir;
 #[cfg(test)] extern crate prost_build;
 
+pub mod extern_paths;
 pub mod packages;
 pub mod unittest;
 


### PR DESCRIPTION
This builds on #111, solving the same usecase but in a slightly more general way (entire packages can be mapped to Rust modules).  I also took the opportunity to clean up the special cased well-known-types handling using the new feature.

@ebkalderon @trha would you mind taking a look at this API?  Does it meet y'alls needs?