### PR TITLE
Add Default supertrait for Message

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -8,7 +8,7 @@ use EncodeError;
 use encoding::*;
 
 /// A Protocol Buffers message.
-pub trait Message: Debug + Send + Sync {
+pub trait Message: Debug + Default + Send + Sync {
 
     /// Encodes the message to a buffer.
     ///


### PR DESCRIPTION
Since prost-derive already implements Default for the messages, I think we should also require Default to be implemented for implementors of Message.