### PR TITLE
prost-build: Remove non-dev env_logger dependency

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -11,7 +11,6 @@ description = "A Protocol Buffers implementation for the Rust Language."
 
 [dependencies]
 bytes = "0.4.7"
-env_logger = { version = "0.5", default-features = false }
 heck = "0.3"
 itertools = "0.7"
 log = "0.4"


### PR DESCRIPTION
The dependency was duplicated and not needed except to run test builds.
This cuts down on required dependencies for users of prost-build.