### PR TITLE
Allow generating Rust 2018 code

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -172,7 +172,11 @@ impl <'a> CodeGenerator<'a> {
 
         self.append_doc();
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, PartialEq, Message)]\n");
+        if self.config.rust_2018 {
+            self.buf.push_str("#[derive(Clone, PartialEq, ::prost_derive::Message)]\n");
+        } else {
+            self.buf.push_str("#[derive(Clone, PartialEq, Message)]\n");
+        }
         self.append_type_attributes(&fq_message_name);
         self.push_indent();
         self.buf.push_str("pub struct ");
@@ -411,7 +415,11 @@ impl <'a> CodeGenerator<'a> {
         self.path.pop();
 
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, Oneof, PartialEq)]\n");
+        if self.config.rust_2018 {
+            self.buf.push_str("#[derive(Clone, ::prost_derive::Oneof, PartialEq)]\n");
+        } else {
+            self.buf.push_str("#[derive(Clone, Oneof, PartialEq)]\n");
+        }
         let oneof_name = format!("{}.{}", msg_name, oneof.name());
         self.append_type_attributes(&oneof_name);
         self.push_indent();
@@ -480,7 +488,11 @@ impl <'a> CodeGenerator<'a> {
 
         self.append_doc();
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]\n");
+        if self.config.rust_2018 {
+            self.buf.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]\n");
+        } else {
+            self.buf.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]\n");
+        }
         self.append_type_attributes(&fq_enum_name);
         self.push_indent();
         self.buf.push_str("pub enum ");

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -206,6 +206,7 @@ pub struct Config {
     type_attributes: Vec<(String, String)>,
     field_attributes: Vec<(String, String)>,
     prost_types: bool,
+    rust_2018: bool,
     strip_enum_prefix: bool,
     out_dir: Option<PathBuf>,
     extern_paths: Vec<(String, String)>,
@@ -359,6 +360,12 @@ impl Config {
     /// types, and instead generate Protobuf well-known types from their `.proto` definitions.
     pub fn compile_well_known_types(&mut self) -> &mut Self {
         self.prost_types = false;
+        self
+    }
+
+    /// Configures the code generator to output Rust 2018 compatible code.
+    pub fn generate_rust_2018_code(&mut self) -> &mut Self {
+        self.rust_2018 = true;
         self
     }
 
@@ -599,6 +606,7 @@ impl Config {
 impl default::Default for Config {
     fn default() -> Config {
         Config {
+            rust_2018: false,
             service_generator: None,
             btree_map: Vec::new(),
             type_attributes: Vec::new(),


### PR DESCRIPTION
This PR is a small subset of https://github.com/danburkert/prost/pull/147 we can land earlier than its more ambitious counterpart, tag a new release and unblock Rust 2018 projects depending on Prost.