### PR TITLE
Permit using `FileDescriptorSet` as an intermediate compilation artifact 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "prost"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/danburkert/prost"
@@ -40,7 +40,7 @@ criterion = "0.2"
 env_logger = { version = "0.5", default-features = false }
 failure = "0.1"
 log = "0.4"
-prost-derive = { version = "0.4.0", path = "prost-derive" }
+prost-derive = { version = "0.5.0", path = "prost-derive" }
 protobuf = { path = "protobuf" }
 quickcheck = "0.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 keywords = ["protobuf", "serialization"]
 categories = ["encoding"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "danburkert/prost" }

--- a/README.md
+++ b/README.md
@@ -326,6 +326,16 @@ pub enum Gender {
   But it is possible to place `serde` derive tags onto the generated types, so
   the same structure can support both `prost` and `Serde`.
 
+2. **I get errors when trying to run `cargo test` on MacOS**
+
+  If the errors are about missing `autoreconf` or similar, you can probably fix
+  them by running
+
+  ```
+  brew install automake
+  brew install libtool
+  ```
+
 ## License
 
 `prost` is distributed under the terms of the Apache License (Version 2.0).

--- a/README.md
+++ b/README.md
@@ -338,11 +338,9 @@ pub enum Gender {
 
 3. **I'm getting compile errors when compiling a 2018 edition project**
 
-  If you're using prost-build, you need to use the `build-2018` feature:
+  If you're using prost-build, you will need to set `edition` to `Rust2018` in
+  the `Config`.
 
-  ```
-  prost-build = { ... , features = ["build-2018"] }
-  ```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,14 @@ pub enum Gender {
   brew install libtool
   ```
 
+3. **I'm getting compile errors when compiling a 2018 edition project**
+
+  If you're using prost-build, you need to use the `build-2018` feature:
+
+  ```
+  prost-build = { ... , features = ["build-2018"] }
+  ``` 
+
 ## License
 
 `prost` is distributed under the terms of the Apache License (Version 2.0).

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ pub enum Gender {
 
   ```
   prost-build = { ... , features = ["build-2018"] }
-  ``` 
+  ```
 
 ## License
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,16 +1,11 @@
-use criterion;
-use prost;
-use protobuf;
-
-#[macro_use]
-extern crate failure;
-
 use std::fs::File;
 use std::io::Read;
 use std::result;
 
-use criterion::{Benchmark, Criterion, Throughput};
-use prost::Message;
+use criterion::{self, Benchmark, Criterion, Throughput};
+use failure::bail;
+use prost::{self, Message};
+use protobuf;
 use protobuf::benchmarks::{proto2, proto3, BenchmarkDataset};
 
 type Result = result::Result<(), failure::Error>;

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,4 +1,3 @@
-
 use criterion;
 use prost;
 use protobuf;
@@ -10,27 +9,27 @@ use std::fs::File;
 use std::io::Read;
 use std::result;
 
-use criterion::{
-    Benchmark,
-    Criterion,
-    Throughput,
-};
+use criterion::{Benchmark, Criterion, Throughput};
 use prost::Message;
-use protobuf::benchmarks::{
-    BenchmarkDataset,
-    proto2,
-    proto3,
-};
+use protobuf::benchmarks::{proto2, proto3, BenchmarkDataset};
 
 type Result = result::Result<(), failure::Error>;
 
 fn benchmark_dataset<M>(criterion: &mut Criterion, dataset: BenchmarkDataset) -> Result
-where M: prost::Message + Default + 'static {
-
+where
+    M: prost::Message + Default + 'static,
+{
     let payload_len = dataset.payload.iter().map(Vec::len).sum::<usize>();
 
-    let messages = dataset.payload.iter().map(|buf| M::decode(buf)).collect::<result::Result<Vec<_>, _>>()?;
-    let encoded_len = messages.iter().map(|message| message.encoded_len()).sum::<usize>();
+    let messages = dataset
+        .payload
+        .iter()
+        .map(|buf| M::decode(buf))
+        .collect::<result::Result<Vec<_>, _>>()?;
+    let encoded_len = messages
+        .iter()
+        .map(|message| message.encoded_len())
+        .sum::<usize>();
 
     let mut buf = Vec::with_capacity(encoded_len);
     let encode = Benchmark::new("encode", move |b| {
@@ -41,7 +40,8 @@ where M: prost::Message + Default + 'static {
             }
             criterion::black_box(&buf);
         })
-    }).throughput(Throughput::Bytes(encoded_len as u32));
+    })
+    .throughput(Throughput::Bytes(encoded_len as u32));
 
     let payload = dataset.payload.clone();
     let decode = Benchmark::new("decode", move |b| {
@@ -50,7 +50,8 @@ where M: prost::Message + Default + 'static {
                 criterion::black_box(M::decode(buf).unwrap());
             }
         })
-    }).throughput(Throughput::Bytes(payload_len as u32));
+    })
+    .throughput(Throughput::Bytes(payload_len as u32));
 
     let payload = dataset.payload.clone();
     let merge = Benchmark::new("merge", move |b| {
@@ -62,7 +63,8 @@ where M: prost::Message + Default + 'static {
                 criterion::black_box(&message);
             }
         })
-    }).throughput(Throughput::Bytes(payload_len as u32));
+    })
+    .throughput(Throughput::Bytes(payload_len as u32));
 
     criterion
         .bench(&dataset.name, encode)
@@ -84,8 +86,12 @@ fn main() -> Result {
         };
 
         match dataset.message_name.as_str() {
-            "benchmarks.proto2.GoogleMessage1" => benchmark_dataset::<proto2::GoogleMessage1>(&mut criterion, dataset)?,
-            "benchmarks.proto3.GoogleMessage1" => benchmark_dataset::<proto3::GoogleMessage1>(&mut criterion, dataset)?,
+            "benchmarks.proto2.GoogleMessage1" => {
+                benchmark_dataset::<proto2::GoogleMessage1>(&mut criterion, dataset)?
+            }
+            "benchmarks.proto3.GoogleMessage1" => {
+                benchmark_dataset::<proto3::GoogleMessage1>(&mut criterion, dataset)?
+            }
 
             /*
              TODO: groups are not yet supported

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,7 +1,7 @@
-extern crate bytes;
-extern crate criterion;
-extern crate prost;
-extern crate protobuf;
+
+use criterion;
+use prost;
+use protobuf;
 
 #[macro_use]
 extern crate failure;

--- a/benches/varint.rs
+++ b/benches/varint.rs
@@ -1,15 +1,9 @@
 #![feature(test)]
 
-
-
 extern crate test;
 
 use bytes::IntoBuf;
-use prost::encoding::{
-    decode_varint,
-    encode_varint,
-    encoded_len_varint,
-};
+use prost::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
 macro_rules! varint_bench {
     ($encode_name:ident, $decode_name:ident, $encoded_len_name: ident, $encode:expr) => {
@@ -61,38 +55,54 @@ macro_rules! varint_bench {
             });
             b.bytes = 100 * 8;
         }
-    }
+    };
 }
 
 /// Benchmark encoding and decoding 100 varints of mixed width (average 5.5 bytes).
-varint_bench!(encode_varint_mixed, decode_varint_mixed, encoded_len_varint_mixed, |ref mut buf| {
-    for width in 0..10 {
+varint_bench!(
+    encode_varint_mixed,
+    decode_varint_mixed,
+    encoded_len_varint_mixed,
+    |ref mut buf| for width in 0..10 {
         let exponent = width * 7;
         for offset in 0..10 {
             encode_varint(offset + (1 << exponent), buf);
         }
     }
-});
+);
 
 /// Benchmark encoding and decoding 100 small (1 byte) varints.
-varint_bench!(encode_varint_small, decode_varint_small, encoded_len_varint_small, |ref mut buf| {
-    for value in 0..100 {
+varint_bench!(
+    encode_varint_small,
+    decode_varint_small,
+    encoded_len_varint_small,
+    |ref mut buf| for value in 0..100 {
         encode_varint(value, buf);
     }
-});
+);
 
 /// Benchmark encoding and decoding 100 medium (5 byte) varints.
-varint_bench!(encode_varint_medium, decode_varint_medium, encoded_len_varint_medium, |ref mut buf| {
-    let start = 1 << 28;
-    for value in start..start + 100 {
-        encode_varint(value, buf);
+varint_bench!(
+    encode_varint_medium,
+    decode_varint_medium,
+    encoded_len_varint_medium,
+    |ref mut buf| {
+        let start = 1 << 28;
+        for value in start..start + 100 {
+            encode_varint(value, buf);
+        }
     }
-});
+);
 
 /// Benchmark encoding and decoding 100 large (10 byte) varints.
-varint_bench!(encode_varint_large, decode_varint_large, encoded_len_varint_large, |ref mut buf| {
-    let start = 1 << 63;
-    for value in start..start + 100 {
-        encode_varint(value, buf);
+varint_bench!(
+    encode_varint_large,
+    decode_varint_large,
+    encoded_len_varint_large,
+    |ref mut buf| {
+        let start = 1 << 63;
+        for value in start..start + 100 {
+            encode_varint(value, buf);
+        }
     }
-});
+);

--- a/benches/varint.rs
+++ b/benches/varint.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 
-extern crate bytes;
-extern crate prost;
+
+
 extern crate test;
 
 use bytes::IntoBuf;

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -3,6 +3,7 @@ name = "conformance"
 version = "0.0.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]
 bytes = "0.4.7"

--- a/conformance/tests/conformance.rs
+++ b/conformance/tests/conformance.rs
@@ -11,20 +11,23 @@ use protobuf::conformance;
 fn test_conformance() {
     // Get the path to the proto-conformance binary. Adapted from
     // https://github.com/rust-lang/cargo/blob/19fdb308cdbb25faf4f1e25a71351d8d603fa447/tests/cargotest/support/mod.rs#L306.
-    let proto_conformance = env::current_exe().map(|mut path| {
-        path.pop();
-        if path.ends_with("deps") {
+    let proto_conformance = env::current_exe()
+        .map(|mut path| {
             path.pop();
-        }
-        path.join("conformance")
-    }).unwrap();
+            if path.ends_with("deps") {
+                path.pop();
+            }
+            path.join("conformance")
+        })
+        .unwrap();
 
     let status = Command::new(conformance::test_runner())
-                         .arg("--enforce_recommended")
-                         .arg("--failure_list").arg("failing_tests.txt")
-                         .arg(proto_conformance)
-                         .status()
-                         .expect("failed to execute conformance-test-runner");
+        .arg("--enforce_recommended")
+        .arg("--failure_list")
+        .arg("failing_tests.txt")
+        .arg(proto_conformance)
+        .status()
+        .expect("failed to execute conformance-test-runner");
 
     assert!(status.success(), "proto conformance test failed");
 }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -31,8 +31,6 @@ env_logger = { version = "0.5", default-features = false }
 # docs.rs depends on an old version of cargo which doesn't support the rustc-env
 # directives used in build.rs. This feature provides a workaround.
 docs-rs = []
-# Build for the 2018 edition
-build-2018 = []
 
 [package.metadata.docs.rs]
 features = [ "docs-rs" ]

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/danburkert/prost"
 documentation = "https://docs.rs/prost-build"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
+edition = "2018"
 
 [dependencies]
 bytes = "0.4.7"

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -31,6 +31,8 @@ env_logger = { version = "0.5", default-features = false }
 # docs.rs depends on an old version of cargo which doesn't support the rustc-env
 # directives used in build.rs. This feature provides a workaround.
 docs-rs = []
+# Build for the 2018 edition
+build-2018 = []
 
 [package.metadata.docs.rs]
 features = [ "docs-rs" ]

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "prost-build"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/danburkert/prost"
@@ -17,8 +17,8 @@ itertools = "0.7"
 log = "0.4"
 multimap = { version = "0.4", default-features = false }
 petgraph = { version = "0.4", default-features = false }
-prost = { version = "0.4.0", path = ".." }
-prost-types = { version = "0.4.0", path = "../prost-types" }
+prost = { version = "0.5.0", path = ".." }
+prost-types = { version = "0.5.0", path = "../prost-types" }
 tempfile = "3"
 
 [build-dependencies]

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -21,7 +21,10 @@ use std::path::PathBuf;
 
 /// Returns the path to the location of the bundled Protobuf artifacts.
 fn bundle_path() -> PathBuf {
-    env::current_dir().unwrap().join("third-party").join("protobuf")
+    env::current_dir()
+        .unwrap()
+        .join("third-party")
+        .join("protobuf")
 }
 
 /// Returns the path to the `protoc` pointed to by the `PROTOC` environment variable, if it is set.
@@ -32,7 +35,10 @@ fn env_protoc() -> Option<PathBuf> {
     };
 
     if !protoc.exists() {
-        panic!("PROTOC environment variable points to non-existent file ({:?})", protoc);
+        panic!(
+            "PROTOC environment variable points to non-existent file ({:?})",
+            protoc
+        );
     }
 
     Some(protoc)
@@ -66,12 +72,16 @@ fn env_protoc_include() -> Option<PathBuf> {
     };
 
     if !protoc_include.exists() {
-        panic!("PROTOC_INCLUDE environment variable points to non-existent directory ({:?})",
-               protoc_include);
+        panic!(
+            "PROTOC_INCLUDE environment variable points to non-existent directory ({:?})",
+            protoc_include
+        );
     }
     if !protoc_include.is_dir() {
-        panic!("PROTOC_INCLUDE environment variable points to a non-directory file ({:?})",
-               protoc_include);
+        panic!(
+            "PROTOC_INCLUDE environment variable points to a non-directory file ({:?})",
+            protoc_include
+        );
     }
 
     Some(protoc_include)
@@ -83,14 +93,21 @@ fn bundled_protoc_include() -> PathBuf {
 }
 
 fn main() {
-    let protoc = env_protoc().or_else(bundled_protoc).or_else(path_protoc).expect(
-        "Failed to find the protoc binary. The PROTOC environment variable is not set, \
-        there is no bundled protoc for this platform, and protoc is not in the PATH");
+    let protoc = env_protoc()
+        .or_else(bundled_protoc)
+        .or_else(path_protoc)
+        .expect(
+            "Failed to find the protoc binary. The PROTOC environment variable is not set, \
+             there is no bundled protoc for this platform, and protoc is not in the PATH",
+        );
 
     let protoc_include = env_protoc_include().unwrap_or_else(bundled_protoc_include);
 
     println!("cargo:rustc-env=PROTOC={}", protoc.display());
-    println!("cargo:rustc-env=PROTOC_INCLUDE={}", protoc_include.display());
+    println!(
+        "cargo:rustc-env=PROTOC_INCLUDE={}",
+        protoc_include.display()
+    );
     println!("cargo:rerun-if-env-changed=PROTOC");
     println!("cargo:rerun-if-env-changed=PROTOC_INCLUDE");
 }

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -14,7 +14,7 @@
 //!     1. The `PROTOC_INCLUDE` environment variable.
 //!     2. The bundled Protobuf include directory.
 
-extern crate which;
+use which;
 
 use std::env;
 use std::path::PathBuf;

--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -1,5 +1,5 @@
-use prost_types::source_code_info::Location;
 use prost_types;
+use prost_types::source_code_info::Location;
 
 /// Comments on a Protobuf item.
 #[derive(Debug)]
@@ -16,13 +16,26 @@ pub struct Comments {
 
 impl Comments {
     pub(crate) fn from_location(location: &Location) -> Comments {
-        fn get_lines<S>(comments: S) -> Vec<String> where S: AsRef<str> {
+        fn get_lines<S>(comments: S) -> Vec<String>
+        where
+            S: AsRef<str>,
+        {
             comments.as_ref().lines().map(str::to_owned).collect()
         }
 
-        let leading_detached = location.leading_detached_comments.iter().map(get_lines).collect();
-        let leading = location.leading_comments.as_ref().map_or(Vec::new(), get_lines);
-        let trailing = location.trailing_comments.as_ref().map_or(Vec::new(), get_lines);
+        let leading_detached = location
+            .leading_detached_comments
+            .iter()
+            .map(get_lines)
+            .collect();
+        let leading = location
+            .leading_comments
+            .as_ref()
+            .map_or(Vec::new(), get_lines);
+        let trailing = location
+            .trailing_comments
+            .as_ref()
+            .map_or(Vec::new(), get_lines);
         Comments {
             leading_detached: leading_detached,
             leading: leading,

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::iter;
 
 use itertools::{Either, Itertools};
+use log::debug;
 use multimap::MultiMap;
 use prost_types::field_descriptor_proto::{Label, Type};
 use prost_types::source_code_info::Location;
@@ -184,7 +185,12 @@ impl<'a> CodeGenerator<'a> {
 
         self.append_doc();
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, PartialEq, Message)]\n");
+        if cfg!(feature = "build-2018") {
+            self.buf
+                .push_str("#[derive(Clone, PartialEq, prost_derive::Message)]\n");
+        } else {
+            self.buf.push_str("#[derive(Clone, PartialEq, Message)]\n");
+        }
         self.append_type_attributes(&fq_message_name);
         self.push_indent();
         self.buf.push_str("pub struct ");
@@ -491,7 +497,12 @@ impl<'a> CodeGenerator<'a> {
         self.path.pop();
 
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, Oneof, PartialEq)]\n");
+        if cfg!(feature = "build-2018") {
+            self.buf
+                .push_str("#[derive(Clone, prost_derive::Oneof, PartialEq)]\n");
+        } else {
+            self.buf.push_str("#[derive(Clone, Oneof, PartialEq)]\n");
+        }
         let oneof_name = format!("{}.{}", msg_name, oneof.name());
         self.append_type_attributes(&oneof_name);
         self.push_indent();
@@ -576,9 +587,15 @@ impl<'a> CodeGenerator<'a> {
 
         self.append_doc();
         self.push_indent();
-        self.buf.push_str(
-            "#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]\n",
-        );
+        if cfg!(feature = "build-2018") {
+            self.buf.push_str(
+                "#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]\n",
+            );
+        } else {
+            self.buf.push_str(
+                "#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]\n",
+            );
+        }
         self.append_type_attributes(&fq_enum_name);
         self.push_indent();
         self.buf.push_str("pub enum ");

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -187,7 +187,7 @@ impl<'a> CodeGenerator<'a> {
         self.push_indent();
         if cfg!(feature = "build-2018") {
             self.buf
-                .push_str("#[derive(Clone, PartialEq, prost_derive::Message)]\n");
+                .push_str("#[derive(Clone, PartialEq, ::prost_derive::Message)]\n");
         } else {
             self.buf.push_str("#[derive(Clone, PartialEq, Message)]\n");
         }
@@ -499,7 +499,7 @@ impl<'a> CodeGenerator<'a> {
         self.push_indent();
         if cfg!(feature = "build-2018") {
             self.buf
-                .push_str("#[derive(Clone, prost_derive::Oneof, PartialEq)]\n");
+                .push_str("#[derive(Clone, ::prost_derive::Oneof, PartialEq)]\n");
         } else {
             self.buf.push_str("#[derive(Clone, Oneof, PartialEq)]\n");
         }
@@ -589,7 +589,7 @@ impl<'a> CodeGenerator<'a> {
         self.push_indent();
         if cfg!(feature = "build-2018") {
             self.buf.push_str(
-                "#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]\n",
+                "#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]\n",
             );
         } else {
             self.buf.push_str(

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -18,20 +18,20 @@ use prost_types::{
 use prost_types::field_descriptor_proto::{Label, Type};
 use prost_types::source_code_info::Location;
 
-use ast::{
+use crate::ast::{
     Comments,
     Method,
     Service,
 };
-use extern_paths::ExternPaths;
-use ident::{
+use crate::extern_paths::ExternPaths;
+use crate::ident::{
     to_snake,
     match_ident,
     to_upper_camel,
 };
-use message_graph::MessageGraph;
-use Config;
-use Module;
+use crate::message_graph::MessageGraph;
+use crate::Config;
+use crate::Module;
 
 pub fn module(file: &FileDescriptorProto) -> Module {
     file.package()
@@ -768,7 +768,7 @@ fn unescape_c_escape_string(s: &str) -> Vec<u8> {
                     dst.push(0x22);
                     p += 1;
                 },
-                b'0'...b'7' => {
+                b'0'..=b'7' => {
                     eprintln!("another octal: {}, offset: {}", s, &s[p..]);
                     let mut octal = 0;
                     for _ in 0..3 {

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -291,7 +291,7 @@ impl<'a> CodeGenerator<'a> {
 
     fn append_field(&mut self, msg_name: &str, field: FieldDescriptorProto) {
         // TODO(danburkert/prost#19): support groups.
-        let type_ = field.type_();
+        let type_ = field.r#type();
         if type_ == Type::Group {
             return;
         }
@@ -514,7 +514,7 @@ impl<'a> CodeGenerator<'a> {
         self.depth += 1;
         for (field, idx) in fields {
             // TODO(danburkert/prost#19): support groups.
-            let type_ = field.type_();
+            let type_ = field.r#type();
             if type_ == Type::Group {
                 continue;
             }
@@ -735,7 +735,7 @@ impl<'a> CodeGenerator<'a> {
     }
 
     fn resolve_type(&self, field: &FieldDescriptorProto) -> String {
-        match field.type_() {
+        match field.r#type() {
             Type::Float => String::from("f32"),
             Type::Double => String::from("f64"),
             Type::Uint32 | Type::Fixed32 => String::from("u32"),
@@ -777,7 +777,7 @@ impl<'a> CodeGenerator<'a> {
     }
 
     fn field_type_tag(&self, field: &FieldDescriptorProto) -> Cow<'static, str> {
-        match field.type_() {
+        match field.r#type() {
             Type::Float => Cow::Borrowed("float"),
             Type::Double => Cow::Borrowed("double"),
             Type::Int32 => Cow::Borrowed("int32"),
@@ -803,7 +803,7 @@ impl<'a> CodeGenerator<'a> {
     }
 
     fn map_value_type_tag(&self, field: &FieldDescriptorProto) -> Cow<'static, str> {
-        match field.type_() {
+        match field.r#type() {
             Type::Enum => Cow::Owned(format!(
                 "enumeration({})",
                 self.resolve_ident(field.type_name())
@@ -817,7 +817,7 @@ impl<'a> CodeGenerator<'a> {
             return false;
         }
 
-        match field.type_() {
+        match field.r#type() {
             Type::Message => true,
             _ => self.syntax == Syntax::Proto2,
         }
@@ -826,7 +826,7 @@ impl<'a> CodeGenerator<'a> {
 
 /// Returns `true` if the repeated field type can be packed.
 fn can_pack(field: &FieldDescriptorProto) -> bool {
-    match field.type_() {
+    match field.r#type() {
         Type::Float
         | Type::Double
         | Type::Int32

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -5,30 +5,16 @@ use std::iter;
 
 use itertools::{Either, Itertools};
 use multimap::MultiMap;
-use prost_types::{
-    DescriptorProto,
-    EnumDescriptorProto,
-    EnumValueDescriptorProto,
-    FieldDescriptorProto,
-    FileDescriptorProto,
-    OneofDescriptorProto,
-    ServiceDescriptorProto,
-    SourceCodeInfo,
-};
 use prost_types::field_descriptor_proto::{Label, Type};
 use prost_types::source_code_info::Location;
+use prost_types::{
+    DescriptorProto, EnumDescriptorProto, EnumValueDescriptorProto, FieldDescriptorProto,
+    FileDescriptorProto, OneofDescriptorProto, ServiceDescriptorProto, SourceCodeInfo,
+};
 
-use crate::ast::{
-    Comments,
-    Method,
-    Service,
-};
+use crate::ast::{Comments, Method, Service};
 use crate::extern_paths::ExternPaths;
-use crate::ident::{
-    to_snake,
-    match_ident,
-    to_upper_camel,
-};
+use crate::ident::{match_ident, to_snake, to_upper_camel};
 use crate::message_graph::MessageGraph;
 use crate::Config;
 use crate::Module;
@@ -59,19 +45,24 @@ pub struct CodeGenerator<'a> {
     buf: &'a mut String,
 }
 
-impl <'a> CodeGenerator<'a> {
-    pub fn generate(config: &mut Config,
-                    message_graph: &MessageGraph,
-                    extern_paths: &ExternPaths,
-                    file: FileDescriptorProto,
-                    buf: &mut String) {
-
-        let mut source_info = file.source_code_info.expect("no source code info in request");
+impl<'a> CodeGenerator<'a> {
+    pub fn generate(
+        config: &mut Config,
+        message_graph: &MessageGraph,
+        extern_paths: &ExternPaths,
+        file: FileDescriptorProto,
+        buf: &mut String,
+    ) {
+        let mut source_info = file
+            .source_code_info
+            .expect("no source code info in request");
         source_info.location.retain(|location| {
             let len = location.path.len();
             len > 0 && len % 2 == 0
         });
-        source_info.location.sort_by_key(|location| location.path.clone());
+        source_info
+            .location
+            .sort_by_key(|location| location.path.clone());
 
         let syntax = match file.syntax.as_ref().map(String::as_str) {
             None | Some("proto2") => Syntax::Proto2,
@@ -91,7 +82,11 @@ impl <'a> CodeGenerator<'a> {
             buf,
         };
 
-        debug!("file: {:?}, package: {:?}", file.name.as_ref().unwrap(), code_gen.package);
+        debug!(
+            "file: {:?}, package: {:?}",
+            file.name.as_ref().unwrap(),
+            code_gen.package
+        );
 
         code_gen.path.push(4);
         for (idx, message) in file.message_type.into_iter().enumerate() {
@@ -118,9 +113,13 @@ impl <'a> CodeGenerator<'a> {
             }
 
             let buf = code_gen.buf;
-            code_gen.config.service_generator.as_mut().map(|service_generator| {
-                service_generator.finalize(buf);
-            });
+            code_gen
+                .config
+                .service_generator
+                .as_mut()
+                .map(|service_generator| {
+                    service_generator.finalize(buf);
+                });
 
             code_gen.path.pop();
         }
@@ -133,16 +132,26 @@ impl <'a> CodeGenerator<'a> {
         let fq_message_name = format!(".{}.{}", self.package, message.name());
 
         // Skip external types.
-        if self.extern_paths.resolve_ident(&fq_message_name).is_some() { return; }
+        if self.extern_paths.resolve_ident(&fq_message_name).is_some() {
+            return;
+        }
 
         // Split the nested message types into a vector of normal nested message types, and a map
         // of the map field entry types. The path index of the nested message types is preserved so
         // that comments can be retrieved.
         type NestedTypes = Vec<(DescriptorProto, usize)>;
         type MapTypes = HashMap<String, (FieldDescriptorProto, FieldDescriptorProto)>;
-        let (nested_types, map_types): (NestedTypes, MapTypes) =
-            message.nested_type.into_iter().enumerate().partition_map(|(idx, nested_type)| {
-                if nested_type.options.as_ref().and_then(|options| options.map_entry).unwrap_or(false) {
+        let (nested_types, map_types): (NestedTypes, MapTypes) = message
+            .nested_type
+            .into_iter()
+            .enumerate()
+            .partition_map(|(idx, nested_type)| {
+                if nested_type
+                    .options
+                    .as_ref()
+                    .and_then(|options| options.map_entry)
+                    .unwrap_or(false)
+                {
                     let key = nested_type.field[0].clone();
                     let value = nested_type.field[1].clone();
                     assert_eq!("key", key.name());
@@ -153,14 +162,17 @@ impl <'a> CodeGenerator<'a> {
                 } else {
                     Either::Left((nested_type, idx))
                 }
-        });
+            });
 
         // Split the fields into a vector of the normal fields, and oneof fields.
         // Path indexes are preserved so that comments can be retrieved.
         type Fields = Vec<(FieldDescriptorProto, usize)>;
         type OneofFields = MultiMap<i32, (FieldDescriptorProto, usize)>;
-        let (fields, mut oneof_fields): (Fields, OneofFields) =
-            message.field.into_iter().enumerate().partition_map(|(idx, field)| {
+        let (fields, mut oneof_fields): (Fields, OneofFields) = message
+            .field
+            .into_iter()
+            .enumerate()
+            .partition_map(|(idx, field)| {
                 if let Some(oneof_index) = field.oneof_index {
                     Either::Right((oneof_index, (field, idx)))
                 } else {
@@ -183,8 +195,14 @@ impl <'a> CodeGenerator<'a> {
         self.path.push(2);
         for (field, idx) in fields {
             self.path.push(idx as i32);
-            match field.type_name.as_ref().and_then(|type_name| map_types.get(type_name)) {
-                Some(&(ref key, ref value)) => self.append_map_field(&fq_message_name, field, key, value),
+            match field
+                .type_name
+                .as_ref()
+                .and_then(|type_name| map_types.get(type_name))
+            {
+                Some(&(ref key, ref value)) => {
+                    self.append_map_field(&fq_message_name, field, key, value)
+                }
                 None => self.append_field(&fq_message_name, field),
             }
             self.path.pop();
@@ -195,10 +213,12 @@ impl <'a> CodeGenerator<'a> {
         for (idx, oneof) in message.oneof_decl.iter().enumerate() {
             let idx = idx as i32;
             self.path.push(idx);
-            self.append_oneof_field(&message_name,
-                                    &fq_message_name,
-                                    oneof,
-                                    oneof_fields.get_vec(&idx).unwrap());
+            self.append_oneof_field(
+                &message_name,
+                &fq_message_name,
+                oneof,
+                oneof_fields.get_vec(&idx).unwrap(),
+            );
             self.path.pop();
         }
         self.path.pop();
@@ -227,7 +247,12 @@ impl <'a> CodeGenerator<'a> {
 
             for (idx, oneof) in message.oneof_decl.into_iter().enumerate() {
                 let idx = idx as i32;
-                self.append_oneof(&fq_message_name, oneof, idx, oneof_fields.remove(&idx).unwrap());
+                self.append_oneof(
+                    &fq_message_name,
+                    oneof,
+                    idx,
+                    oneof_fields.remove(&idx).unwrap(),
+                );
             }
 
             self.pop_mod();
@@ -261,17 +286,24 @@ impl <'a> CodeGenerator<'a> {
     fn append_field(&mut self, msg_name: &str, field: FieldDescriptorProto) {
         // TODO(danburkert/prost#19): support groups.
         let type_ = field.type_();
-        if type_ == Type::Group { return; }
+        if type_ == Type::Group {
+            return;
+        }
 
         let repeated = field.label == Some(Label::Repeated as i32);
         let optional = self.optional(&field);
         let ty = self.resolve_type(&field);
 
         let boxed = !repeated
-                 && type_ == Type::Message
-                 && self.message_graph.is_nested(field.type_name(), msg_name);
+            && type_ == Type::Message
+            && self.message_graph.is_nested(field.type_name(), msg_name);
 
-        debug!("    field: {:?}, type: {:?}, boxed: {}", field.name(), ty, boxed);
+        debug!(
+            "    field: {:?}, type: {:?}, boxed: {}",
+            field.name(),
+            ty,
+            boxed
+        );
 
         self.append_doc();
         self.push_indent();
@@ -280,20 +312,28 @@ impl <'a> CodeGenerator<'a> {
         self.buf.push_str(&type_tag);
 
         match field.label() {
-            Label::Optional => if optional {
-                self.buf.push_str(", optional");
-            },
+            Label::Optional => {
+                if optional {
+                    self.buf.push_str(", optional");
+                }
+            }
             Label::Required => self.buf.push_str(", required"),
             Label::Repeated => {
                 self.buf.push_str(", repeated");
-                if can_pack(&field) && !field.options.as_ref().map_or(self.syntax == Syntax::Proto3,
-                                                                      |options| options.packed()) {
+                if can_pack(&field)
+                    && !field
+                        .options
+                        .as_ref()
+                        .map_or(self.syntax == Syntax::Proto3, |options| options.packed())
+                {
                     self.buf.push_str(", packed=\"false\"");
                 }
-            },
+            }
         }
 
-        if boxed { self.buf.push_str(", boxed"); }
+        if boxed {
+            self.buf.push_str(", boxed");
+        }
         self.buf.push_str(", tag=\"");
         self.buf.push_str(&field.number().to_string());
 
@@ -302,7 +342,9 @@ impl <'a> CodeGenerator<'a> {
             if type_ == Type::Bytes {
                 self.buf.push_str("b\\\"");
                 for b in unescape_c_escape_string(default) {
-                    self.buf.extend(ascii::escape_default(b).flat_map(|c| (c as char).escape_default()));
+                    self.buf.extend(
+                        ascii::escape_default(b).flat_map(|c| (c as char).escape_default()),
+                    );
                 }
                 self.buf.push_str("\\\"");
             } else if type_ == Type::Enum {
@@ -335,33 +377,49 @@ impl <'a> CodeGenerator<'a> {
         self.buf.push_str("pub ");
         self.buf.push_str(&to_snake(field.name()));
         self.buf.push_str(": ");
-        if repeated { self.buf.push_str("::std::vec::Vec<"); }
-        else if optional { self.buf.push_str("::std::option::Option<"); }
-        if boxed { self.buf.push_str("::std::boxed::Box<"); }
+        if repeated {
+            self.buf.push_str("::std::vec::Vec<");
+        } else if optional {
+            self.buf.push_str("::std::option::Option<");
+        }
+        if boxed {
+            self.buf.push_str("::std::boxed::Box<");
+        }
         self.buf.push_str(&ty);
-        if boxed { self.buf.push_str(">"); }
-        if repeated || optional { self.buf.push_str(">"); }
+        if boxed {
+            self.buf.push_str(">");
+        }
+        if repeated || optional {
+            self.buf.push_str(">");
+        }
         self.buf.push_str(",\n");
     }
 
-    fn append_map_field(&mut self,
-                        msg_name: &str,
-                        field: FieldDescriptorProto,
-                        key: &FieldDescriptorProto,
-                        value: &FieldDescriptorProto) {
+    fn append_map_field(
+        &mut self,
+        msg_name: &str,
+        field: FieldDescriptorProto,
+        key: &FieldDescriptorProto,
+        value: &FieldDescriptorProto,
+    ) {
         let key_ty = self.resolve_type(key);
         let value_ty = self.resolve_type(value);
 
-        debug!("    map field: {:?}, key type: {:?}, value type: {:?}",
-               field.name(), key_ty, value_ty);
+        debug!(
+            "    map field: {:?}, key type: {:?}, value type: {:?}",
+            field.name(),
+            key_ty,
+            value_ty
+        );
 
         self.append_doc();
         self.push_indent();
 
-        let btree_map = self.config
-                            .btree_map
-                            .iter()
-                            .any(|matcher| match_ident(matcher, msg_name, Some(field.name())));
+        let btree_map = self
+            .config
+            .btree_map
+            .iter()
+            .any(|matcher| match_ident(matcher, msg_name, Some(field.name())));
         let (annotation_ty, rust_ty) = if btree_map {
             ("btree_map", "BTreeMap")
         } else {
@@ -370,40 +428,62 @@ impl <'a> CodeGenerator<'a> {
 
         let key_tag = self.field_type_tag(key);
         let value_tag = self.map_value_type_tag(value);
-        self.buf.push_str(&format!("#[prost({}=\"{}, {}\", tag=\"{}\")]\n",
-                                   annotation_ty,
-                                   key_tag,
-                                   value_tag,
-                                   field.number()));
+        self.buf.push_str(&format!(
+            "#[prost({}=\"{}, {}\", tag=\"{}\")]\n",
+            annotation_ty,
+            key_tag,
+            value_tag,
+            field.number()
+        ));
         self.append_field_attributes(msg_name, field.name());
         self.push_indent();
-        self.buf.push_str(&format!("pub {}: ::std::collections::{}<{}, {}>,\n",
-                                   to_snake(field.name()), rust_ty, key_ty, value_ty));
+        self.buf.push_str(&format!(
+            "pub {}: ::std::collections::{}<{}, {}>,\n",
+            to_snake(field.name()),
+            rust_ty,
+            key_ty,
+            value_ty
+        ));
     }
 
-    fn append_oneof_field(&mut self,
-                          message_name: &str,
-                          fq_message_name: &str,
-                          oneof: &OneofDescriptorProto,
-                          fields: &[(FieldDescriptorProto, usize)]) {
-        let name = format!("{}::{}",
-                           to_snake(message_name),
-                           to_upper_camel(oneof.name()));
+    fn append_oneof_field(
+        &mut self,
+        message_name: &str,
+        fq_message_name: &str,
+        oneof: &OneofDescriptorProto,
+        fields: &[(FieldDescriptorProto, usize)],
+    ) {
+        let name = format!(
+            "{}::{}",
+            to_snake(message_name),
+            to_upper_camel(oneof.name())
+        );
         self.append_doc();
         self.push_indent();
-        self.buf.push_str(&format!("#[prost(oneof=\"{}\", tags=\"{}\")]\n",
-                                   name,
-                                   fields.iter().map(|&(ref field, _)| field.number()).join(", ")));
+        self.buf.push_str(&format!(
+            "#[prost(oneof=\"{}\", tags=\"{}\")]\n",
+            name,
+            fields
+                .iter()
+                .map(|&(ref field, _)| field.number())
+                .join(", ")
+        ));
         self.append_field_attributes(fq_message_name, oneof.name());
         self.push_indent();
-        self.buf.push_str(&format!("pub {}: ::std::option::Option<{}>,\n", to_snake(oneof.name()), name));
+        self.buf.push_str(&format!(
+            "pub {}: ::std::option::Option<{}>,\n",
+            to_snake(oneof.name()),
+            name
+        ));
     }
 
-    fn append_oneof(&mut self,
-                    msg_name: &str,
-                    oneof: OneofDescriptorProto,
-                    idx: i32,
-                    fields: Vec<(FieldDescriptorProto, usize)>) {
+    fn append_oneof(
+        &mut self,
+        msg_name: &str,
+        oneof: OneofDescriptorProto,
+        idx: i32,
+        fields: Vec<(FieldDescriptorProto, usize)>,
+    ) {
         self.path.push(8);
         self.path.push(idx);
         self.append_doc();
@@ -424,7 +504,9 @@ impl <'a> CodeGenerator<'a> {
         for (field, idx) in fields {
             // TODO(danburkert/prost#19): support groups.
             let type_ = field.type_();
-            if type_ == Type::Group { continue; }
+            if type_ == Type::Group {
+                continue;
+            }
 
             self.path.push(idx as i32);
             self.append_doc();
@@ -432,21 +514,32 @@ impl <'a> CodeGenerator<'a> {
 
             self.push_indent();
             let ty_tag = self.field_type_tag(&field);
-            self.buf.push_str(&format!("#[prost({}, tag=\"{}\")]\n", ty_tag, field.number()));
+            self.buf.push_str(&format!(
+                "#[prost({}, tag=\"{}\")]\n",
+                ty_tag,
+                field.number()
+            ));
             self.append_field_attributes(&oneof_name, field.name());
 
             self.push_indent();
             let ty = self.resolve_type(&field);
 
-            let boxed = type_ == Type::Message
-                     && self.message_graph.is_nested(field.type_name(), msg_name);
+            let boxed =
+                type_ == Type::Message && self.message_graph.is_nested(field.type_name(), msg_name);
 
-            debug!("    oneof: {:?}, type: {:?}, boxed: {}", field.name(), ty, boxed);
+            debug!(
+                "    oneof: {:?}, type: {:?}, boxed: {}",
+                field.name(),
+                ty,
+                boxed
+            );
 
             if boxed {
-                self.buf.push_str(&format!("{}(Box<{}>),\n", to_upper_camel(field.name()), ty));
+                self.buf
+                    .push_str(&format!("{}(Box<{}>),\n", to_upper_camel(field.name()), ty));
             } else {
-                self.buf.push_str(&format!("{}({}),\n", to_upper_camel(field.name()), ty));
+                self.buf
+                    .push_str(&format!("{}({}),\n", to_upper_camel(field.name()), ty));
             }
         }
         self.depth -= 1;
@@ -457,10 +550,11 @@ impl <'a> CodeGenerator<'a> {
     }
 
     fn location(&self) -> &Location {
-        let idx = self.source_info
-                      .location
-                      .binary_search_by_key(&&self.path[..], |location| &location.path[..])
-                      .unwrap();
+        let idx = self
+            .source_info
+            .location
+            .binary_search_by_key(&&self.path[..], |location| &location.path[..])
+            .unwrap();
 
         &self.source_info.location[idx]
     }
@@ -476,11 +570,15 @@ impl <'a> CodeGenerator<'a> {
         let enum_name = &desc.name();
         let enum_values = &desc.value;
         let fq_enum_name = format!(".{}.{}", self.package, enum_name);
-        if self.extern_paths.resolve_ident(&fq_enum_name).is_some() { return; }
+        if self.extern_paths.resolve_ident(&fq_enum_name).is_some() {
+            return;
+        }
 
         self.append_doc();
         self.push_indent();
-        self.buf.push_str("#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]\n");
+        self.buf.push_str(
+            "#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]\n",
+        );
         self.append_type_attributes(&fq_enum_name);
         self.push_indent();
         self.buf.push_str("pub enum ");
@@ -514,7 +612,12 @@ impl <'a> CodeGenerator<'a> {
         self.buf.push_str("}\n");
     }
 
-    fn append_enum_value(&mut self, fq_enum_name: &str, value: &EnumValueDescriptorProto, prefix_to_strip: Option<String>) {
+    fn append_enum_value(
+        &mut self,
+        fq_enum_name: &str,
+        value: &EnumValueDescriptorProto,
+        prefix_to_strip: Option<String>,
+    ) {
         self.append_doc();
         self.append_field_attributes(fq_enum_name, &value.name());
         self.push_indent();
@@ -536,37 +639,38 @@ impl <'a> CodeGenerator<'a> {
         let comments = Comments::from_location(self.location());
 
         self.path.push(2);
-        let methods = service.method
-                             .into_iter()
-                             .enumerate()
-                             .map(|(idx, mut method)| {
-                                 debug!("  method: {:?}", method.name());
-                                 self.path.push(idx as i32);
-                                 let comments = Comments::from_location(self.location());
-                                 self.path.pop();
+        let methods = service
+            .method
+            .into_iter()
+            .enumerate()
+            .map(|(idx, mut method)| {
+                debug!("  method: {:?}", method.name());
+                self.path.push(idx as i32);
+                let comments = Comments::from_location(self.location());
+                self.path.pop();
 
-                                 let name = method.name.take().unwrap();
-                                 let input_proto_type = method.input_type.take().unwrap();
-                                 let output_proto_type = method.output_type.take().unwrap();
-                                 let input_type = self.resolve_ident(&input_proto_type);
-                                 let output_type = self.resolve_ident(&output_proto_type);
-                                 let client_streaming = method.client_streaming();
-                                 let server_streaming = method.server_streaming();
+                let name = method.name.take().unwrap();
+                let input_proto_type = method.input_type.take().unwrap();
+                let output_proto_type = method.output_type.take().unwrap();
+                let input_type = self.resolve_ident(&input_proto_type);
+                let output_type = self.resolve_ident(&output_proto_type);
+                let client_streaming = method.client_streaming();
+                let server_streaming = method.server_streaming();
 
-                                 Method {
-                                     name: to_snake(&name),
-                                     proto_name: name,
-                                     comments,
-                                     input_type,
-                                     output_type,
-                                     input_proto_type,
-                                     output_proto_type,
-                                     options: method.options.unwrap_or_default(),
-                                     client_streaming,
-                                     server_streaming,
-                                 }
-                             })
-                             .collect();
+                Method {
+                    name: to_snake(&name),
+                    proto_name: name,
+                    comments,
+                    input_type,
+                    output_type,
+                    input_proto_type,
+                    output_proto_type,
+                    options: method.options.unwrap_or_default(),
+                    client_streaming,
+                    server_streaming,
+                }
+            })
+            .collect();
         self.path.pop();
 
         let service = Service {
@@ -579,7 +683,10 @@ impl <'a> CodeGenerator<'a> {
         };
 
         let buf = &mut self.buf;
-        self.config.service_generator.as_mut().map(move |service_generator| service_generator.generate(service, buf));
+        self.config
+            .service_generator
+            .as_mut()
+            .map(move |service_generator| service_generator.generate(service, buf));
     }
 
     fn push_indent(&mut self) {
@@ -640,16 +747,16 @@ impl <'a> CodeGenerator<'a> {
         let mut ident_path = ident_path.peekable();
 
         // Skip path elements in common.
-        while local_path.peek().is_some() &&
-              local_path.peek() == ident_path.peek() {
+        while local_path.peek().is_some() && local_path.peek() == ident_path.peek() {
             local_path.next();
             ident_path.next();
         }
 
-        local_path.map(|_| "super".to_string())
-                  .chain(ident_path.map(to_snake))
-                  .chain(iter::once(to_upper_camel(ident_type)))
-                  .join("::")
+        local_path
+            .map(|_| "super".to_string())
+            .chain(ident_path.map(to_snake))
+            .chain(iter::once(to_upper_camel(ident_type)))
+            .join("::")
     }
 
     fn field_type_tag(&self, field: &FieldDescriptorProto) -> Cow<'static, str> {
@@ -671,13 +778,19 @@ impl <'a> CodeGenerator<'a> {
             Type::Bytes => Cow::Borrowed("bytes"),
             Type::Group => Cow::Borrowed("group"),
             Type::Message => Cow::Borrowed("message"),
-            Type::Enum => Cow::Owned(format!("enumeration={:?}", self.resolve_ident(field.type_name()))),
+            Type::Enum => Cow::Owned(format!(
+                "enumeration={:?}",
+                self.resolve_ident(field.type_name())
+            )),
         }
     }
 
     fn map_value_type_tag(&self, field: &FieldDescriptorProto) -> Cow<'static, str> {
         match field.type_() {
-            Type::Enum => Cow::Owned(format!("enumeration({})", self.resolve_ident(field.type_name()))),
+            Type::Enum => Cow::Owned(format!(
+                "enumeration({})",
+                self.resolve_ident(field.type_name())
+            )),
             _ => self.field_type_tag(field),
         }
     }
@@ -696,13 +809,23 @@ impl <'a> CodeGenerator<'a> {
 
 /// Returns `true` if the repeated field type can be packed.
 fn can_pack(field: &FieldDescriptorProto) -> bool {
-        match field.type_() {
-            Type::Float   | Type::Double  | Type::Int32    | Type::Int64    |
-            Type::Uint32  | Type::Uint64  | Type::Sint32   | Type::Sint64   |
-            Type::Fixed32 | Type::Fixed64 | Type::Sfixed32 | Type::Sfixed64 |
-            Type::Bool    | Type::Enum => true,
-            _ => false,
-        }
+    match field.type_() {
+        Type::Float
+        | Type::Double
+        | Type::Int32
+        | Type::Int64
+        | Type::Uint32
+        | Type::Uint64
+        | Type::Sint32
+        | Type::Sint64
+        | Type::Fixed32
+        | Type::Fixed64
+        | Type::Sfixed32
+        | Type::Sfixed64
+        | Type::Bool
+        | Type::Enum => true,
+        _ => false,
+    }
 }
 
 /// Based on [`google::protobuf::UnescapeCEscapeString`][1]
@@ -721,53 +844,56 @@ fn unescape_c_escape_string(s: &str) -> Vec<u8> {
         } else {
             p += 1;
             if p == len {
-                panic!("invalid c-escaped default binary value ({}): ends with '\'", s)
+                panic!(
+                    "invalid c-escaped default binary value ({}): ends with '\'",
+                    s
+                )
             }
             match src[p] {
                 b'a' => {
                     dst.push(0x07);
                     p += 1;
-                },
+                }
                 b'b' => {
                     dst.push(0x08);
                     p += 1;
-                },
+                }
                 b'f' => {
                     dst.push(0x0C);
                     p += 1;
-                },
+                }
                 b'n' => {
                     dst.push(0x0A);
                     p += 1;
-                },
+                }
                 b'r' => {
                     dst.push(0x0D);
                     p += 1;
-                },
+                }
                 b't' => {
                     dst.push(0x09);
                     p += 1;
-                },
+                }
                 b'v' => {
                     dst.push(0x0B);
                     p += 1;
-                },
+                }
                 b'\\' => {
                     dst.push(0x5C);
                     p += 1;
-                },
+                }
                 b'?' => {
                     dst.push(0x3F);
                     p += 1;
-                },
+                }
                 b'\'' => {
                     dst.push(0x27);
                     p += 1;
-                },
+                }
                 b'"' => {
                     dst.push(0x22);
                     p += 1;
-                },
+                }
                 b'0'..=b'7' => {
                     eprintln!("another octal: {}, offset: {}", s, &s[p..]);
                     let mut octal = 0;
@@ -781,20 +907,27 @@ fn unescape_c_escape_string(s: &str) -> Vec<u8> {
                         }
                     }
                     dst.push(octal);
-                },
+                }
                 b'x' | b'X' => {
                     if p + 2 > len {
-                        panic!("invalid c-escaped default binary value ({}): incomplete hex value", s)
+                        panic!(
+                            "invalid c-escaped default binary value ({}): incomplete hex value",
+                            s
+                        )
                     }
-                    match u8::from_str_radix(&s[p+1..p+3], 16) {
+                    match u8::from_str_radix(&s[p + 1..p + 3], 16) {
                         Ok(b) => dst.push(b),
-                        _ => panic!("invalid c-escaped default binary value ({}): invalid hex value", &s[p..p+2]),
+                        _ => panic!(
+                            "invalid c-escaped default binary value ({}): invalid hex value",
+                            &s[p..p + 2]
+                        ),
                     }
                     p += 3;
-                },
-                _ => {
-                    panic!("invalid c-escaped default binary value ({}): invalid escape", s)
-                },
+                }
+                _ => panic!(
+                    "invalid c-escaped default binary value ({}): invalid escape",
+                    s
+                ),
             }
         }
     }
@@ -835,15 +968,23 @@ mod tests {
 
     #[test]
     fn test_unescape_c_escape_string() {
-        assert_eq!(&b"hello world"[..], &unescape_c_escape_string("hello world")[..]);
+        assert_eq!(
+            &b"hello world"[..],
+            &unescape_c_escape_string("hello world")[..]
+        );
 
         assert_eq!(&b"\0"[..], &unescape_c_escape_string(r#"\0"#)[..]);
 
-        assert_eq!(&[0o012, 0o156], &unescape_c_escape_string(r#"\012\156"#)[..]);
+        assert_eq!(
+            &[0o012, 0o156],
+            &unescape_c_escape_string(r#"\012\156"#)[..]
+        );
         assert_eq!(&[0x01, 0x02], &unescape_c_escape_string(r#"\x01\x02"#)[..]);
 
-        assert_eq!(&b"\0\x01\x07\x08\x0C\n\r\t\x0B\\\'\"\xFE"[..],
-                   &unescape_c_escape_string(r#"\0\001\a\b\f\n\r\t\v\\\'\"\xfe"#)[..]);
+        assert_eq!(
+            &b"\0\x01\x07\x08\x0C\n\r\t\x0B\\\'\"\xFE"[..],
+            &unescape_c_escape_string(r#"\0\001\a\b\f\n\r\t\v\\\'\"\xfe"#)[..]
+        );
     }
 
     #[test]

--- a/prost-build/src/extern_paths.rs
+++ b/prost-build/src/extern_paths.rs
@@ -29,7 +29,11 @@ impl ExternPaths {
         };
 
         for (proto_path, rust_path) in paths {
-            extern_paths.insert(proto_path.clone(), rust_path.clone())?;
+            if rust_path.starts_with("::") && cfg!(feature = "build-2018") {
+                extern_paths.insert(proto_path.clone(), format!("crate{}", rust_path))?;
+            } else {
+                extern_paths.insert(proto_path.clone(), rust_path.clone())?;
+            }
         }
 
         if prost_types {
@@ -127,7 +131,17 @@ mod tests {
         .unwrap();
 
         let case = |proto_ident: &str, resolved_ident: &str| {
-            assert_eq!(paths.resolve_ident(proto_ident).unwrap(), resolved_ident);
+            #[cfg(feature = "build-2018")]
+            {
+                assert_eq!(
+                    paths.resolve_ident(proto_ident).unwrap(),
+                    format!("crate{}", resolved_ident)
+                );
+            }
+            #[cfg(not(feature = "build-2018"))]
+            {
+                assert_eq!(paths.resolve_ident(proto_ident).unwrap(), resolved_ident);
+            }
         };
 
         case(".foo", "::foo1");

--- a/prost-build/src/extern_paths.rs
+++ b/prost-build/src/extern_paths.rs
@@ -5,7 +5,7 @@ use std::collections::{
 
 use itertools::Itertools;
 
-use ident::{
+use crate::ident::{
     to_snake,
     to_upper_camel,
 };

--- a/prost-build/src/extern_paths.rs
+++ b/prost-build/src/extern_paths.rs
@@ -29,11 +29,7 @@ impl ExternPaths {
         };
 
         for (proto_path, rust_path) in paths {
-            if rust_path.starts_with("::") && cfg!(feature = "build-2018") {
-                extern_paths.insert(proto_path.clone(), format!("crate{}", rust_path))?;
-            } else {
-                extern_paths.insert(proto_path.clone(), rust_path.clone())?;
-            }
+            extern_paths.insert(proto_path.clone(), rust_path.clone())?;
         }
 
         if prost_types {
@@ -131,17 +127,7 @@ mod tests {
         .unwrap();
 
         let case = |proto_ident: &str, resolved_ident: &str| {
-            #[cfg(feature = "build-2018")]
-            {
-                assert_eq!(
-                    paths.resolve_ident(proto_ident).unwrap(),
-                    format!("crate{}", resolved_ident)
-                );
-            }
-            #[cfg(not(feature = "build-2018"))]
-            {
-                assert_eq!(paths.resolve_ident(proto_ident).unwrap(), resolved_ident);
-            }
+            assert_eq!(paths.resolve_ident(proto_ident).unwrap(), resolved_ident);
         };
 
         case(".foo", "::foo1");

--- a/prost-build/src/extern_paths.rs
+++ b/prost-build/src/extern_paths.rs
@@ -1,19 +1,15 @@
-use std::collections::{
-    HashMap,
-    hash_map,
-};
+use std::collections::{hash_map, HashMap};
 
 use itertools::Itertools;
 
-use crate::ident::{
-    to_snake,
-    to_upper_camel,
-};
+use crate::ident::{to_snake, to_upper_camel};
 
 fn validate_proto_path(path: &str) -> Result<(), String> {
     if path.chars().next().map(|c| c != '.').unwrap_or(true) {
-        return Err(format!("Protobuf paths must be fully qualified (begin with a leading '.'): {}",
-                           path));
+        return Err(format!(
+            "Protobuf paths must be fully qualified (begin with a leading '.'): {}",
+            path
+        ));
     }
     if path.split('.').skip(1).any(str::is_empty) {
         return Err(format!("invalid fully-qualified Protobuf path: {}", path));
@@ -27,7 +23,7 @@ pub struct ExternPaths {
 }
 
 impl ExternPaths {
-    pub fn new(paths: &[(String, String)], prost_types: bool)-> Result<ExternPaths, String> {
+    pub fn new(paths: &[(String, String)], prost_types: bool) -> Result<ExternPaths, String> {
         let mut extern_paths = ExternPaths {
             extern_paths: HashMap::new(),
         };
@@ -39,15 +35,30 @@ impl ExternPaths {
         if prost_types {
             extern_paths.insert(".google.protobuf".to_string(), "::prost_types".to_string())?;
             extern_paths.insert(".google.protobuf.BoolValue".to_string(), "bool".to_string())?;
-            extern_paths.insert(".google.protobuf.BytesValue".to_string(), "::std::vec::Vec<u8>".to_string())?;
-            extern_paths.insert(".google.protobuf.DoubleValue".to_string(), "f64".to_string())?;
+            extern_paths.insert(
+                ".google.protobuf.BytesValue".to_string(),
+                "::std::vec::Vec<u8>".to_string(),
+            )?;
+            extern_paths.insert(
+                ".google.protobuf.DoubleValue".to_string(),
+                "f64".to_string(),
+            )?;
             extern_paths.insert(".google.protobuf.Empty".to_string(), "()".to_string())?;
             extern_paths.insert(".google.protobuf.FloatValue".to_string(), "f32".to_string())?;
             extern_paths.insert(".google.protobuf.Int32Value".to_string(), "i32".to_string())?;
             extern_paths.insert(".google.protobuf.Int64Value".to_string(), "i64".to_string())?;
-            extern_paths.insert(".google.protobuf.StringValue".to_string(), "::std::string::String".to_string())?;
-            extern_paths.insert(".google.protobuf.UInt32Value".to_string(), "u32".to_string())?;
-            extern_paths.insert(".google.protobuf.UInt64Value".to_string(), "u64".to_string())?;
+            extern_paths.insert(
+                ".google.protobuf.StringValue".to_string(),
+                "::std::string::String".to_string(),
+            )?;
+            extern_paths.insert(
+                ".google.protobuf.UInt32Value".to_string(),
+                "u32".to_string(),
+            )?;
+            extern_paths.insert(
+                ".google.protobuf.UInt64Value".to_string(),
+                "u64".to_string(),
+            )?;
         }
 
         Ok(extern_paths)
@@ -56,7 +67,12 @@ impl ExternPaths {
     fn insert(&mut self, proto_path: String, rust_path: String) -> Result<(), String> {
         validate_proto_path(&proto_path)?;
         match self.extern_paths.entry(proto_path) {
-            hash_map::Entry::Occupied(occupied) => return Err(format!("duplicate extern Protobuf path: {}", occupied.key())),
+            hash_map::Entry::Occupied(occupied) => {
+                return Err(format!(
+                    "duplicate extern Protobuf path: {}",
+                    occupied.key()
+                ));
+            }
             hash_map::Entry::Vacant(vacant) => vacant.insert(rust_path),
         };
         Ok(())
@@ -67,21 +83,23 @@ impl ExternPaths {
         assert_eq!(".", &pb_ident[..1]);
 
         if let Some(rust_path) = self.extern_paths.get(pb_ident) {
-            return Some(rust_path.clone())
+            return Some(rust_path.clone());
         }
 
         // TODO(danburkert): there must be a more efficient way to do this, maybe a trie?
         for (idx, _) in pb_ident.rmatch_indices('.') {
             if let Some(rust_path) = self.extern_paths.get(&pb_ident[..idx]) {
-
-                let mut segments = pb_ident[idx+1..].split('.');
+                let mut segments = pb_ident[idx + 1..].split('.');
                 let ident_type = segments.next_back().map(|segment| to_upper_camel(&segment));
 
-                return Some(rust_path.split("::")
-                            .chain(segments)
-                            .map(|segment| to_snake(&segment))
-                            .chain(ident_type.into_iter())
-                            .join("::"))
+                return Some(
+                    rust_path
+                        .split("::")
+                        .chain(segments)
+                        .map(|segment| to_snake(&segment))
+                        .chain(ident_type.into_iter())
+                        .join("::"),
+                );
             }
         }
 
@@ -96,13 +114,17 @@ mod tests {
 
     #[test]
     fn test_extern_paths() {
-        let paths = ExternPaths::new(&[
-            (".foo".to_string(), "::foo1".to_string()),
-            (".foo.bar".to_string(), "::foo2".to_string()),
-            (".foo.baz".to_string(), "::foo3".to_string()),
-            (".foo.Fuzz".to_string(), "::foo4::Fuzz".to_string()),
-            (".a.b.c.d.e.f".to_string(), "::abc::def".to_string()),
-        ], false).unwrap();
+        let paths = ExternPaths::new(
+            &[
+                (".foo".to_string(), "::foo1".to_string()),
+                (".foo.bar".to_string(), "::foo2".to_string()),
+                (".foo.baz".to_string(), "::foo3".to_string()),
+                (".foo.Fuzz".to_string(), "::foo4::Fuzz".to_string()),
+                (".a.b.c.d.e.f".to_string(), "::abc::def".to_string()),
+            ],
+            false,
+        )
+        .unwrap();
 
         let case = |proto_ident: &str, resolved_ident: &str| {
             assert_eq!(paths.resolve_ident(proto_ident).unwrap(), resolved_ident);

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -10,14 +10,12 @@ pub fn to_snake(s: &str) -> String {
     // Add a trailing underscore if the identifier matches a Rust keyword
     // (https://doc.rust-lang.org/grammar.html#keywords).
     match &ident[..] {
-        "abstract" | "alignof" | "as"     | "become"  | "box"   | "break"   | "const"    |
-        "continue" | "crate"   | "do"     | "else"    | "enum"  | "extern"  | "false"    |
-        "final"    | "fn"      | "for"    | "if"      | "impl"  | "in"      | "let"      |
-        "loop"     | "macro"   | "match"  | "mod"     | "move"  | "mut"     | "offsetof" |
-        "override" | "priv"    | "proc"   | "pub"     | "pure"  | "ref"     | "return"   |
-        "self"     | "sizeof"  | "static" | "struct"  | "super" | "trait"   | "true"     |
-        "type"     | "typeof"  | "unsafe" | "unsized" | "use"   | "virtual" | "where"    |
-        "while"    | "yield" => {
+        "abstract" | "alignof" | "as" | "become" | "box" | "break" | "const" | "continue"
+        | "crate" | "do" | "else" | "enum" | "extern" | "false" | "final" | "fn" | "for" | "if"
+        | "impl" | "in" | "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut"
+        | "offsetof" | "override" | "priv" | "proc" | "pub" | "pure" | "ref" | "return"
+        | "self" | "sizeof" | "static" | "struct" | "super" | "trait" | "true" | "type"
+        | "typeof" | "unsafe" | "unsized" | "use" | "virtual" | "where" | "while" | "yield" => {
             ident.push('_');
         }
         _ => (),
@@ -137,7 +135,11 @@ mod tests {
         assert!(match_ident(".foo", ".foo.bar.Baz", Some("buzz")));
         assert!(match_ident(".foo.bar", ".foo.bar.Baz", Some("buzz")));
         assert!(match_ident(".foo.bar.Baz", ".foo.bar.Baz", Some("buzz")));
-        assert!(match_ident(".foo.bar.Baz.buzz", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident(
+            ".foo.bar.Baz.buzz",
+            ".foo.bar.Baz",
+            Some("buzz")
+        ));
 
         assert!(!match_ident(".fo", ".foo.bar.Baz", Some("buzz")));
         assert!(!match_ident(".foo.", ".foo.bar.Baz", Some("buzz")));
@@ -148,7 +150,11 @@ mod tests {
         assert!(match_ident("buzz", ".foo.bar.Baz", Some("buzz")));
         assert!(match_ident("Baz.buzz", ".foo.bar.Baz", Some("buzz")));
         assert!(match_ident("bar.Baz.buzz", ".foo.bar.Baz", Some("buzz")));
-        assert!(match_ident("foo.bar.Baz.buzz", ".foo.bar.Baz", Some("buzz")));
+        assert!(match_ident(
+            "foo.bar.Baz.buzz",
+            ".foo.bar.Baz",
+            Some("buzz")
+        ));
 
         assert!(!match_ident("buz", ".foo.bar.Baz", Some("buzz")));
         assert!(!match_ident("uz", ".foo.bar.Baz", Some("buzz")));

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -1,16 +1,17 @@
 //! Utility functions for working with identifiers.
 
+use crate::{Config, Edition};
 use heck::{CamelCase, SnakeCase};
 
 /// Converts a `camelCase` or `SCREAMING_SNAKE_CASE` identifier to a `lower_snake` case Rust field
 /// identifier.
-pub fn to_snake(s: &str) -> String {
+pub fn to_snake(s: &str, config: &Config) -> String {
     let ident = s.to_snake_case();
 
     // Uses a raw identifier if the identifier matches a Rust keyword
     // (https://doc.rust-lang.org/grammar.html#keywords).
     match &ident[..] {
-        "crate" if !cfg!(feature = "build-2018") => format!("r#{}", ident),
+        "crate" if config.edition == Edition::Rust2015 => format!("r#{}", ident),
         "abstract" | "alignof" | "as" | "become" | "box" | "break" | "const" | "continue"
         | "do" | "else" | "enum" | "extern" | "false" | "final" | "fn" | "for" | "if" | "impl"
         | "in" | "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut" | "offsetof"
@@ -74,43 +75,44 @@ mod tests {
 
     #[test]
     fn test_to_snake() {
-        assert_eq!("foo_bar", &to_snake("FooBar"));
-        assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ"));
-        assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ"));
-        assert_eq!("xml_http_request", &to_snake("XMLHttpRequest"));
-        assert_eq!("r#while", &to_snake("While"));
-        assert_eq!("fuzz_buster", &to_snake("FUZZ_BUSTER"));
-        assert_eq!("foo_bar_baz", &to_snake("foo_bar_baz"));
-        assert_eq!("fuzz_buster", &to_snake("FUZZ_buster"));
-        assert_eq!("fuzz", &to_snake("_FUZZ"));
-        assert_eq!("fuzz", &to_snake("_fuzz"));
-        assert_eq!("fuzz", &to_snake("_Fuzz"));
-        assert_eq!("fuzz", &to_snake("FUZZ_"));
-        assert_eq!("fuzz", &to_snake("fuzz_"));
-        assert_eq!("fuzz", &to_snake("Fuzz_"));
-        assert_eq!("fuz_z", &to_snake("FuzZ_"));
+        let config = Config::default();
+        assert_eq!("foo_bar", &to_snake("FooBar", &config));
+        assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ", &config));
+        assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ", &config));
+        assert_eq!("xml_http_request", &to_snake("XMLHttpRequest", &config));
+        assert_eq!("r#while", &to_snake("While", &config));
+        assert_eq!("fuzz_buster", &to_snake("FUZZ_BUSTER", &config));
+        assert_eq!("foo_bar_baz", &to_snake("foo_bar_baz", &config));
+        assert_eq!("fuzz_buster", &to_snake("FUZZ_buster", &config));
+        assert_eq!("fuzz", &to_snake("_FUZZ", &config));
+        assert_eq!("fuzz", &to_snake("_fuzz", &config));
+        assert_eq!("fuzz", &to_snake("_Fuzz", &config));
+        assert_eq!("fuzz", &to_snake("FUZZ_", &config));
+        assert_eq!("fuzz", &to_snake("fuzz_", &config));
+        assert_eq!("fuzz", &to_snake("Fuzz_", &config));
+        assert_eq!("fuz_z", &to_snake("FuzZ_", &config));
 
         // From test_messages_proto3.proto.
-        assert_eq!("fieldname1", &to_snake("fieldname1"));
-        assert_eq!("field_name2", &to_snake("field_name2"));
-        assert_eq!("field_name3", &to_snake("_field_name3"));
-        assert_eq!("field_name4", &to_snake("field__name4_"));
-        assert_eq!("field0name5", &to_snake("field0name5"));
-        assert_eq!("field_0_name6", &to_snake("field_0_name6"));
-        assert_eq!("field_name7", &to_snake("fieldName7"));
-        assert_eq!("field_name8", &to_snake("FieldName8"));
-        assert_eq!("field_name9", &to_snake("field_Name9"));
-        assert_eq!("field_name10", &to_snake("Field_Name10"));
+        assert_eq!("fieldname1", &to_snake("fieldname1", &config));
+        assert_eq!("field_name2", &to_snake("field_name2", &config));
+        assert_eq!("field_name3", &to_snake("_field_name3", &config));
+        assert_eq!("field_name4", &to_snake("field__name4_", &config));
+        assert_eq!("field0name5", &to_snake("field0name5", &config));
+        assert_eq!("field_0_name6", &to_snake("field_0_name6", &config));
+        assert_eq!("field_name7", &to_snake("fieldName7", &config));
+        assert_eq!("field_name8", &to_snake("FieldName8", &config));
+        assert_eq!("field_name9", &to_snake("field_Name9", &config));
+        assert_eq!("field_name10", &to_snake("Field_Name10", &config));
 
         // TODO(withoutboats/heck#3)
         //assert_eq!("field_name11", &to_snake("FIELD_NAME11"));
-        assert_eq!("field_name12", &to_snake("FIELD_name12"));
-        assert_eq!("field_name13", &to_snake("__field_name13"));
-        assert_eq!("field_name14", &to_snake("__Field_name14"));
-        assert_eq!("field_name15", &to_snake("field__name15"));
-        assert_eq!("field_name16", &to_snake("field__Name16"));
-        assert_eq!("field_name17", &to_snake("field_name17__"));
-        assert_eq!("field_name18", &to_snake("Field_name18__"));
+        assert_eq!("field_name12", &to_snake("FIELD_name12", &config));
+        assert_eq!("field_name13", &to_snake("__field_name13", &config));
+        assert_eq!("field_name14", &to_snake("__Field_name14", &config));
+        assert_eq!("field_name15", &to_snake("field__name15", &config));
+        assert_eq!("field_name16", &to_snake("field__Name16", &config));
+        assert_eq!("field_name17", &to_snake("field_name17__", &config));
+        assert_eq!("field_name18", &to_snake("Field_name18__", &config));
     }
 
     #[test]

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -10,12 +10,15 @@ pub fn to_snake(s: &str) -> String {
     // Add a trailing underscore if the identifier matches a Rust keyword
     // (https://doc.rust-lang.org/grammar.html#keywords).
     match &ident[..] {
+        "crate" if !cfg!(feature = "build-2018") => {
+            ident.push('_');
+        }
         "abstract" | "alignof" | "as" | "become" | "box" | "break" | "const" | "continue"
-        | "crate" | "do" | "else" | "enum" | "extern" | "false" | "final" | "fn" | "for" | "if"
-        | "impl" | "in" | "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut"
-        | "offsetof" | "override" | "priv" | "proc" | "pub" | "pure" | "ref" | "return"
-        | "self" | "sizeof" | "static" | "struct" | "super" | "trait" | "true" | "type"
-        | "typeof" | "unsafe" | "unsized" | "use" | "virtual" | "where" | "while" | "yield" => {
+        | "do" | "else" | "enum" | "extern" | "false" | "final" | "fn" | "for" | "if" | "impl"
+        | "in" | "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut" | "offsetof"
+        | "override" | "priv" | "proc" | "pub" | "pure" | "ref" | "return" | "self" | "sizeof"
+        | "static" | "struct" | "super" | "trait" | "true" | "type" | "typeof" | "unsafe"
+        | "unsized" | "use" | "virtual" | "where" | "while" | "yield" => {
             ident.push('_');
         }
         _ => (),

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -5,37 +5,35 @@ use heck::{CamelCase, SnakeCase};
 /// Converts a `camelCase` or `SCREAMING_SNAKE_CASE` identifier to a `lower_snake` case Rust field
 /// identifier.
 pub fn to_snake(s: &str) -> String {
-    let mut ident = s.to_snake_case();
+    let ident = s.to_snake_case();
 
     // Add a trailing underscore if the identifier matches a Rust keyword
     // (https://doc.rust-lang.org/grammar.html#keywords).
     match &ident[..] {
-        "crate" if !cfg!(feature = "build-2018") => {
-            ident.push('_');
-        }
+        "crate" if !cfg!(feature = "build-2018") => format!("r#{}", ident),
         "abstract" | "alignof" | "as" | "become" | "box" | "break" | "const" | "continue"
         | "do" | "else" | "enum" | "extern" | "false" | "final" | "fn" | "for" | "if" | "impl"
         | "in" | "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut" | "offsetof"
         | "override" | "priv" | "proc" | "pub" | "pure" | "ref" | "return" | "self" | "sizeof"
         | "static" | "struct" | "super" | "trait" | "true" | "type" | "typeof" | "unsafe"
         | "unsized" | "use" | "virtual" | "where" | "while" | "yield" => {
-            ident.push('_');
+            format!("r#{}", ident)
         }
-        _ => (),
+        _ => ident,
     }
-    ident
 }
 
 /// Converts a `snake_case` identifier to an `UpperCamel` case Rust type identifier.
 pub fn to_upper_camel(s: &str) -> String {
-    let mut ident = s.to_camel_case();
+    let ident = s.to_camel_case();
 
     // Add a trailing underscore if the identifier matches a Rust keyword
     // (https://doc.rust-lang.org/grammar.html#keywords).
     if ident == "Self" {
-        ident.push('_');
+        format!("r#{}", ident)
+    } else {
+        ident
     }
-    ident
 }
 
 /// Matches a 'matcher' against a fully qualified identifier.
@@ -82,7 +80,7 @@ mod tests {
         assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ"));
         assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ"));
         assert_eq!("xml_http_request", &to_snake("XMLHttpRequest"));
-        assert_eq!("while_", &to_snake("While"));
+        assert_eq!("r#while", &to_snake("While"));
         assert_eq!("fuzz_buster", &to_snake("FUZZ_BUSTER"));
         assert_eq!("foo_bar_baz", &to_snake("foo_bar_baz"));
         assert_eq!("fuzz_buster", &to_snake("FUZZ_buster"));
@@ -128,7 +126,7 @@ mod tests {
         assert_eq!("FooBar", &to_upper_camel("_FOO_BAR_"));
         assert_eq!("FuzzBuster", &to_upper_camel("fuzzBuster"));
         assert_eq!("FuzzBuster", &to_upper_camel("FuzzBuster"));
-        assert_eq!("Self_", &to_upper_camel("self"));
+        assert_eq!("r#Self", &to_upper_camel("self"));
     }
 
     #[test]

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -16,9 +16,7 @@ pub fn to_snake(s: &str) -> String {
         | "in" | "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut" | "offsetof"
         | "override" | "priv" | "proc" | "pub" | "pure" | "ref" | "return" | "self" | "sizeof"
         | "static" | "struct" | "super" | "trait" | "true" | "type" | "typeof" | "unsafe"
-        | "unsized" | "use" | "virtual" | "where" | "while" | "yield" => {
-            format!("r#{}", ident)
-        }
+        | "unsized" | "use" | "virtual" | "where" | "while" | "yield" => format!("r#{}", ident),
         _ => ident,
     }
 }

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -7,7 +7,7 @@ use heck::{CamelCase, SnakeCase};
 pub fn to_snake(s: &str) -> String {
     let ident = s.to_snake_case();
 
-    // Add a trailing underscore if the identifier matches a Rust keyword
+    // Uses a raw identifier if the identifier matches a Rust keyword
     // (https://doc.rust-lang.org/grammar.html#keywords).
     match &ident[..] {
         "crate" if !cfg!(feature = "build-2018") => format!("r#{}", ident),
@@ -25,7 +25,7 @@ pub fn to_snake(s: &str) -> String {
 pub fn to_upper_camel(s: &str) -> String {
     let ident = s.to_camel_case();
 
-    // Add a trailing underscore if the identifier matches a Rust keyword
+    // Uses a raw identifier if the identifier matches a Rust keyword
     // (https://doc.rust-lang.org/grammar.html#keywords).
     if ident == "Self" {
         format!("r#{}", ident)

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -111,13 +111,8 @@
 //! If `PROTOC_INCLUDE` is not found in the environment, then the Protobuf include directory bundled
 //! in the prost-build crate is be used.
 
-extern crate heck;
-extern crate itertools;
-extern crate multimap;
-extern crate petgraph;
-extern crate prost;
-extern crate prost_types;
-extern crate tempfile;
+use prost_types;
+use tempdir;
 
 #[macro_use]
 extern crate log;
@@ -148,17 +143,17 @@ use std::process::Command;
 use prost::Message;
 use prost_types::{FileDescriptorProto, FileDescriptorSet};
 
-pub use ast::{
+pub use crate::ast::{
     Comments,
     Method,
     Service,
 };
-use code_generator::{
+use crate::code_generator::{
     CodeGenerator,
     module,
 };
-use extern_paths::ExternPaths;
-use message_graph::MessageGraph;
+use crate::extern_paths::ExternPaths;
+use crate::message_graph::MessageGraph;
 
 type Module = Vec<String>;
 
@@ -201,7 +196,7 @@ pub trait ServiceGenerator {
 ///
 /// This configuration builder can be used to set non-default code generation options.
 pub struct Config {
-    service_generator: Option<Box<ServiceGenerator>>,
+    service_generator: Option<Box<dyn ServiceGenerator>>,
     btree_map: Vec<String>,
     type_attributes: Vec<(String, String)>,
     field_attributes: Vec<(String, String)>,
@@ -350,7 +345,7 @@ impl Config {
     }
 
     /// Configures the code generator to use the provided service generator.
-    pub fn service_generator(&mut self, service_generator: Box<ServiceGenerator>) -> &mut Self {
+    pub fn service_generator(&mut self, service_generator: Box<dyn ServiceGenerator>) -> &mut Self {
         self.service_generator = Some(service_generator);
         self
     }
@@ -684,7 +679,7 @@ pub fn protoc_include() -> &'static Path {
 
 #[cfg(test)]
 mod tests {
-    extern crate env_logger;
+    use env_logger;
     use super::*;
 
     /// An example service generator that generates a trait with methods corresponding to the

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -116,7 +116,6 @@ mod message_graph;
 
 use log::trace;
 use prost_types;
-use tempdir;
 
 use std::collections::HashMap;
 use std::default;
@@ -515,9 +514,7 @@ impl Config {
         // this figured out.
         // [1]: http://doc.crates.io/build-script.html#outputs-of-the-build-script
 
-        let tmp = tempfile::Builder::new()
-            .prefix("prost-build")
-            .tempdir()?;
+        let tmp = tempfile::Builder::new().prefix("prost-build").tempdir()?;
         let descriptor_set = tmp.path().join("prost-descriptor-set");
 
         let mut cmd = Command::new(protoc());

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -24,8 +24,11 @@
 //! prost-derive = <prost-version>
 //!
 //! [build-dependencies]
-//! prost-build = <prost-version>
+//! prost-build = { version = <prost-version>, features = ["build-2018"] }
 //! ```
+//!
+//! If you're using the 2015 edition of Rust, don't include the `build-2018`
+//! feature in the dependency declaration.
 //!
 //! Next, add `src/items.proto` to the project:
 //!
@@ -51,8 +54,6 @@
 //! `build.rs` build-script:
 //!
 //! ```rust,no_run
-//! extern crate prost_build;
-//!
 //! fn main() {
 //!     prost_build::compile_protos(&["src/items.proto"],
 //!                                 &["src/"]).unwrap();
@@ -62,10 +63,6 @@
 //! And finally, in `lib.rs`, include the generated code:
 //!
 //! ```rust,ignore
-//! extern crate prost;
-//! #[macro_use]
-//! extern crate prost_derive;
-//!
 //! // Include the `items` module, which is generated from items.proto.
 //! pub mod items {
 //!     include!(concat!(env!("OUT_DIR"), "/snazzy.items.rs"));
@@ -111,17 +108,15 @@
 //! If `PROTOC_INCLUDE` is not found in the environment, then the Protobuf include directory bundled
 //! in the prost-build crate is be used.
 
-use prost_types;
-use tempdir;
-
-#[macro_use]
-extern crate log;
-
 mod ast;
 mod code_generator;
 mod extern_paths;
 mod ident;
 mod message_graph;
+
+use log::trace;
+use prost_types;
+use tempdir;
 
 use std::collections::HashMap;
 use std::default;
@@ -376,10 +371,6 @@ impl Config {
     /// ```rust,ignore
     /// // lib.rs in the uuid crate
     ///
-    /// extern crate prost;
-    /// #[macro_use]
-    /// extern crate prost_derive;
-    ///
     /// include!(concat!(env!("OUT_DIR"), "/uuid.rs"));
     ///
     /// pub trait DoSomething {
@@ -414,11 +405,6 @@ impl Config {
     ///
     /// ```rust,ignore
     /// // `main.rs` of `my_application`
-    ///
-    /// extern crate prost;
-    /// #[macro_use]
-    /// extern crate prost_derive;
-    /// extern crate uuid;
     ///
     /// use uuid::{DoSomething, Uuid};
     ///

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -4,11 +4,7 @@ use petgraph::algo::has_path_connecting;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 
-use prost_types::{
-    DescriptorProto,
-    field_descriptor_proto,
-    FileDescriptorProto,
-};
+use prost_types::{field_descriptor_proto, DescriptorProto, FileDescriptorProto};
 
 /// `MessageGraph` builds a graph of messages whose edges correspond to nesting.
 /// The goal is to recognize when message types are recursively nested, so
@@ -36,11 +32,14 @@ impl MessageGraph {
     }
 
     fn get_or_insert_index(&mut self, msg_name: String) -> NodeIndex {
-        let MessageGraph { ref mut index, ref mut graph } = *self;
+        let MessageGraph {
+            ref mut index,
+            ref mut graph,
+        } = *self;
         assert_eq!(b'.', msg_name.as_bytes()[0]);
-        *index.entry(msg_name.clone()).or_insert_with(|| {
-            graph.add_node(msg_name)
-        })
+        *index
+            .entry(msg_name.clone())
+            .or_insert_with(|| graph.add_node(msg_name))
     }
 
     fn add_message(&mut self, package: &str, msg: &DescriptorProto) {
@@ -49,7 +48,8 @@ impl MessageGraph {
 
         for field in &msg.field {
             if field.type_() == field_descriptor_proto::Type::Message
-                && field.label() != field_descriptor_proto::Label::Repeated {
+                && field.label() != field_descriptor_proto::Label::Repeated
+            {
                 let field_index = self.get_or_insert_index(field.type_name.clone().unwrap());
                 self.graph.add_edge(msg_index, field_index, ());
             }

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -47,7 +47,7 @@ impl MessageGraph {
         let msg_index = self.get_or_insert_index(msg_name.clone());
 
         for field in &msg.field {
-            if field.type_() == field_descriptor_proto::Type::Message
+            if field.r#type() == field_descriptor_proto::Type::Message
                 && field.label() != field_descriptor_proto::Label::Repeated
             {
                 let field_index = self.get_or_insert_index(field.type_name.clone().unwrap());

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/danburkert/prost"
 documentation = "https://docs.rs/prost-derive"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
+edition = "2018"
 
 [lib]
 proc_macro = true

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "prost-derive"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/danburkert/prost"

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -1,21 +1,8 @@
 use failure::Error;
-use proc_macro2::{
-    Span,
-    TokenStream,
-};
-use syn::{
-    Ident,
-    Lit,
-    Meta,
-    MetaNameValue,
-    NestedMeta,
-};
+use proc_macro2::{Span, TokenStream};
+use syn::{Ident, Lit, Meta, MetaNameValue, NestedMeta};
 
-use crate::field::{
-    scalar,
-    tag_attr,
-    set_option,
-};
+use crate::field::{scalar, set_option, tag_attr};
 
 #[derive(Clone, Debug)]
 pub enum MapTy {
@@ -58,7 +45,6 @@ pub struct Field {
 }
 
 impl Field {
-
     pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
         let mut types = None;
         let mut tag = None;
@@ -68,7 +54,10 @@ impl Field {
                 set_option(&mut tag, t, "duplicate tag attributes")?;
             } else if let Some(map_ty) = MapTy::from_str(&attr.name().to_string()) {
                 let (k, v): (String, String) = match *attr {
-                    Meta::NameValue(MetaNameValue { lit: Lit::Str(ref lit), .. }) => {
+                    Meta::NameValue(MetaNameValue {
+                        lit: Lit::Str(ref lit),
+                        ..
+                    }) => {
                         let items = lit.value();
                         let mut items = items.split(',').map(ToString::to_string);
                         let k = items.next().unwrap();
@@ -80,7 +69,6 @@ impl Field {
                             bail!("invalid map attribute: {:?}", attr);
                         }
                         (k, v)
-
                     }
                     Meta::List(ref meta_list) => {
                         // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
@@ -96,26 +84,27 @@ impl Field {
                             _ => bail!("invalid map attribute: value must be an identifier"),
                         };
                         (k, v)
-                    },
+                    }
                     _ => return Ok(None),
                 };
-                set_option(&mut types, (map_ty, key_ty_from_str(&k)?, ValueTy::from_str(&v)?),
-                           "duplicate map type attribute")?;
+                set_option(
+                    &mut types,
+                    (map_ty, key_ty_from_str(&k)?, ValueTy::from_str(&v)?),
+                    "duplicate map type attribute",
+                )?;
             } else {
                 return Ok(None);
             }
         }
 
         Ok(match (types, tag.or(inferred_tag)) {
-            (Some((map_ty, key_ty, val_ty)), Some(tag)) => {
-                Some(Field {
-                    map_ty: map_ty,
-                    key_ty: key_ty,
-                    value_ty: val_ty,
-                    tag: tag
-                })
-            },
-            _ => None
+            (Some((map_ty, key_ty, val_ty)), Some(tag)) => Some(Field {
+                map_ty: map_ty,
+                key_ty: key_ty,
+                value_ty: val_ty,
+                tag: tag,
+            }),
+            _ => None,
         })
     }
 
@@ -140,7 +129,7 @@ impl Field {
                                                                    &(#default),
                                                                    #tag, &#ident, buf);
                 }
-            },
+            }
             ValueTy::Scalar(ref value_ty) => {
                 let val_mod = value_ty.module();
                 let ve = quote!(_prost::encoding::#val_mod::encode);
@@ -149,7 +138,7 @@ impl Field {
                     _prost::encoding::#module::encode(#ke, #kl, #ve, #vl,
                                                       #tag, &#ident, buf);
                 }
-            },
+            }
             ValueTy::Message => {
                 quote! {
                     _prost::encoding::#module::encode(#ke, #kl,
@@ -157,7 +146,7 @@ impl Field {
                                                       _prost::encoding::message::encoded_len,
                                                       #tag, &#ident, buf);
                 }
-            },
+            }
         }
     }
 
@@ -174,16 +163,16 @@ impl Field {
                     _prost::encoding::#module::merge_with_default(#km, _prost::encoding::int32::merge,
                                                                   #default, &mut #ident, buf)
                 }
-            },
+            }
             ValueTy::Scalar(ref value_ty) => {
                 let val_mod = value_ty.module();
                 let vm = quote!(_prost::encoding::#val_mod::merge);
                 quote!(_prost::encoding::#module::merge(#km, #vm, &mut #ident, buf))
-            },
+            }
             ValueTy::Message => {
                 quote!(_prost::encoding::#module::merge(#km, _prost::encoding::message::merge,
                                                         &mut #ident, buf))
-            },
+            }
         }
     }
 
@@ -201,16 +190,16 @@ impl Field {
                         #kl, _prost::encoding::int32::encoded_len,
                         &(#default), #tag, &#ident)
                 }
-            },
+            }
             ValueTy::Scalar(ref value_ty) => {
                 let val_mod = value_ty.module();
                 let vl = quote!(_prost::encoding::#val_mod::encoded_len);
                 quote!(_prost::encoding::#module::encoded_len(#kl, #vl, #tag, &#ident))
-            },
+            }
             ValueTy::Message => {
                 quote!(_prost::encoding::#module::encoded_len(#kl, _prost::encoding::message::encoded_len,
                                                               #tag, &#ident))
-            },
+            }
         }
     }
 
@@ -226,7 +215,11 @@ impl Field {
 
             let get = Ident::new(&format!("get_{}", ident), Span::call_site());
             let insert = Ident::new(&format!("insert_{}", ident), Span::call_site());
-            let take_ref = if self.key_ty.is_numeric() { quote!(&) } else { quote!() };
+            let take_ref = if self.key_ty.is_numeric() {
+                quote!(&)
+            } else {
+                quote!()
+            };
 
             Some(quote! {
                 pub fn #get(&self, key: #key_ref_ty) -> ::std::option::Option<#ty> {
@@ -274,7 +267,7 @@ impl Field {
                         #fmt
                     }
                 }
-            },
+            }
             ValueTy::Message => quote! {
                 struct #wrapper_name<'a, V: 'a>(&'a ::std::collections::#type_name<#key, V>);
                 impl<'a, V> ::std::fmt::Debug for #wrapper_name<'a, V>
@@ -283,7 +276,7 @@ impl Field {
                 {
                     #fmt
                 }
-            }
+            },
         }
     }
 }
@@ -291,10 +284,18 @@ impl Field {
 fn key_ty_from_str(s: &str) -> Result<scalar::Ty, Error> {
     let ty = scalar::Ty::from_str(s)?;
     match ty {
-        scalar::Ty::Int32 | scalar::Ty::Int64 | scalar::Ty::Uint32 |
-            scalar::Ty::Uint64 | scalar::Ty::Sint32 | scalar::Ty::Sint64 |
-            scalar::Ty::Fixed32 | scalar::Ty::Fixed64 | scalar::Ty::Sfixed32 |
-            scalar::Ty::Sfixed64 | scalar::Ty::Bool | scalar::Ty::String  => Ok(ty),
+        scalar::Ty::Int32
+        | scalar::Ty::Int64
+        | scalar::Ty::Uint32
+        | scalar::Ty::Uint64
+        | scalar::Ty::Sint32
+        | scalar::Ty::Sint64
+        | scalar::Ty::Fixed32
+        | scalar::Ty::Fixed64
+        | scalar::Ty::Sfixed32
+        | scalar::Ty::Sfixed64
+        | scalar::Ty::Bool
+        | scalar::Ty::String => Ok(ty),
         _ => bail!("invalid map key type: {}", s),
     }
 }
@@ -324,7 +325,11 @@ impl ValueTy {
     fn debug(&self) -> TokenStream {
         match *self {
             ValueTy::Scalar(ref ty) => fake_scalar(ty.clone()).debug(quote!(ValueWrapper)),
-            ValueTy::Message => quote!(fn ValueWrapper<T>(v: T) -> T { v }),
+            ValueTy::Message => quote!(
+                fn ValueWrapper<T>(v: T) -> T {
+                    v
+                }
+            ),
         }
     }
 }

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -11,7 +11,7 @@ use syn::{
     NestedMeta,
 };
 
-use field::{
+use crate::field::{
     scalar,
     tag_attr,
     set_option,

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -1,5 +1,6 @@
-use failure::Error;
+use failure::{bail, Error};
 use proc_macro2::{Span, TokenStream};
+use quote::quote;
 use syn::{Ident, Lit, Meta, MetaNameValue, NestedMeta};
 
 use crate::field::{scalar, set_option, tag_attr};

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -2,13 +2,7 @@ use failure::Error;
 use proc_macro2::TokenStream;
 use syn::Meta;
 
-use crate::field::{
-    word_attr,
-    tag_attr,
-    set_option,
-    set_bool,
-    Label,
-};
+use crate::field::{set_bool, set_option, tag_attr, word_attr, Label};
 
 #[derive(Clone)]
 pub struct Field {
@@ -45,7 +39,10 @@ impl Field {
 
         match unknown_attrs.len() {
             0 => (),
-            1 => bail!("unknown attribute for message field: {:?}", unknown_attrs[0]),
+            1 => bail!(
+                "unknown attribute for message field: {:?}",
+                unknown_attrs[0]
+            ),
             _ => bail!("unknown attributes for message field: {:?}", unknown_attrs),
         }
 

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -1,5 +1,6 @@
-use failure::Error;
+use failure::{bail, Error};
 use proc_macro2::TokenStream;
+use quote::quote;
 use syn::Meta;
 
 use crate::field::{set_bool, set_option, tag_attr, word_attr, Label};

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -2,7 +2,7 @@ use failure::Error;
 use proc_macro2::TokenStream;
 use syn::Meta;
 
-use field::{
+use crate::field::{
     word_attr,
     tag_attr,
     set_option,

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -213,13 +213,13 @@ impl Label {
 }
 
 impl fmt::Debug for Label {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
 impl fmt::Display for Label {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -6,8 +6,9 @@ mod scalar;
 use std::fmt;
 use std::slice;
 
-use failure::Error;
+use failure::{bail, Error};
 use proc_macro2::TokenStream;
+use quote::quote;
 use syn::{Attribute, Ident, Lit, LitBool, Meta, MetaList, MetaNameValue, NestedMeta};
 
 #[derive(Clone)]

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -1,18 +1,8 @@
 use failure::Error;
 use proc_macro2::TokenStream;
-use syn::{
-    Lit,
-    Meta,
-    MetaNameValue,
-    NestedMeta,
-    Path,
-    parse_str,
-};
+use syn::{parse_str, Lit, Meta, MetaNameValue, NestedMeta, Path};
 
-use crate::field::{
-    tags_attr,
-    set_option,
-};
+use crate::field::{set_option, tags_attr};
 
 #[derive(Clone)]
 pub struct Field {
@@ -29,9 +19,10 @@ impl Field {
         for attr in attrs {
             if attr.name() == "oneof" {
                 let t = match *attr {
-                    Meta::NameValue(MetaNameValue { lit: Lit::Str(ref lit), .. }) => {
-                        parse_str::<Path>(&lit.value())?
-                    }
+                    Meta::NameValue(MetaNameValue {
+                        lit: Lit::Str(ref lit),
+                        ..
+                    }) => parse_str::<Path>(&lit.value())?,
                     Meta::List(ref list) if list.nested.len() == 1 => {
                         // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
                         if let NestedMeta::Meta(Meta::Word(ref ident)) = list.nested[0] {
@@ -39,7 +30,7 @@ impl Field {
                         } else {
                             bail!("invalid oneof attribute: item must be an identifier");
                         }
-                    },
+                    }
                     _ => bail!("invalid oneof attribute: {:?}", attr),
                 };
                 set_option(&mut ty, t, "duplicate oneof attribute")?;
@@ -57,7 +48,10 @@ impl Field {
 
         match unknown_attrs.len() {
             0 => (),
-            1 => bail!("unknown attribute for message field: {:?}", unknown_attrs[0]),
+            1 => bail!(
+                "unknown attribute for message field: {:?}",
+                unknown_attrs[0]
+            ),
             _ => bail!("unknown attributes for message field: {:?}", unknown_attrs),
         }
 
@@ -66,10 +60,7 @@ impl Field {
             None => bail!("oneof field is missing a tags attribute"),
         };
 
-        Ok(Some(Field {
-            ty: ty,
-            tags: tags,
-        }))
+        Ok(Some(Field { ty: ty, tags: tags }))
     }
 
     /// Returns a statement which encodes the oneof field.

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -9,7 +9,7 @@ use syn::{
     parse_str,
 };
 
-use field::{
+use crate::field::{
     tags_attr,
     set_option,
 };

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -1,5 +1,6 @@
-use failure::Error;
+use failure::{bail, Error};
 use proc_macro2::TokenStream;
+use quote::quote;
 use syn::{parse_str, Lit, Meta, MetaNameValue, NestedMeta, Path};
 
 use crate::field::{set_option, tags_attr};

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -21,7 +21,7 @@ use syn::{
     self,
 };
 
-use field::{
+use crate::field::{
     Label,
     bool_attr,
     set_option,
@@ -515,13 +515,13 @@ impl Ty {
 }
 
 impl fmt::Debug for Ty {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
 impl fmt::Display for Ty {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -1,32 +1,14 @@
 use std::fmt;
 
 use failure::Error;
-use proc_macro2::{
-    Span,
-    TokenStream,
-};
+use proc_macro2::{Span, TokenStream};
 use quote;
 use syn::{
-    FloatSuffix,
-    Ident,
-    IntSuffix,
-    Lit,
-    LitByteStr,
-    Meta,
-    MetaList,
-    MetaNameValue,
-    NestedMeta,
-    Path,
-    parse_str,
-    self,
+    self, parse_str, FloatSuffix, Ident, IntSuffix, Lit, LitByteStr, Meta, MetaList, MetaNameValue,
+    NestedMeta, Path,
 };
 
-use crate::field::{
-    Label,
-    bool_attr,
-    set_option,
-    tag_attr,
-};
+use crate::field::{bool_attr, set_option, tag_attr, Label};
 
 /// A scalar protobuf field.
 #[derive(Clone)]
@@ -37,7 +19,6 @@ pub struct Field {
 }
 
 impl Field {
-
     pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
         let mut ty = None;
         let mut label = None;
@@ -80,26 +61,30 @@ impl Field {
         };
 
         let has_default = default.is_some();
-        let default = default.map_or_else(|| Ok(DefaultValue::new(&ty)),
-                                          |lit| DefaultValue::from_lit(&ty, lit))?;
+        let default = default.map_or_else(
+            || Ok(DefaultValue::new(&ty)),
+            |lit| DefaultValue::from_lit(&ty, lit),
+        )?;
 
         let kind = match (label, packed, has_default) {
-            (None, Some(true), _) |
-            (Some(Label::Optional), Some(true), _) |
-            (Some(Label::Required), Some(true), _) => {
+            (None, Some(true), _)
+            | (Some(Label::Optional), Some(true), _)
+            | (Some(Label::Required), Some(true), _) => {
                 bail!("packed attribute may only be applied to repeated fields");
-            },
+            }
             (Some(Label::Repeated), Some(true), _) if !ty.is_numeric() => {
                 bail!("packed attribute may only be applied to numeric types");
-            },
+            }
             (Some(Label::Repeated), _, true) => {
                 bail!("repeated fields may not have a default value");
-            },
+            }
 
             (None, _, _) => Kind::Plain(default),
             (Some(Label::Optional), _, _) => Kind::Optional(default),
             (Some(Label::Required), _, _) => Kind::Required(default),
-            (Some(Label::Repeated), packed, false) if packed.unwrap_or(ty.is_numeric()) => Kind::Packed,
+            (Some(Label::Repeated), packed, false) if packed.unwrap_or(ty.is_numeric()) => {
+                Kind::Packed
+            }
             (Some(Label::Repeated), _, false) => Kind::Repeated,
         };
 
@@ -116,7 +101,7 @@ impl Field {
                 Kind::Plain(default) => {
                     field.kind = Kind::Required(default);
                     Ok(Some(field))
-                },
+                }
                 Kind::Optional(..) => bail!("invalid optional attribute on oneof field"),
                 Kind::Required(..) => bail!("invalid required attribute on oneof field"),
                 Kind::Packed | Kind::Repeated => bail!("invalid repeated attribute on oneof field"),
@@ -144,13 +129,13 @@ impl Field {
                         #encode_fn(#tag, &#ident, buf);
                     }
                 }
-            },
+            }
             Kind::Optional(..) => quote! {
                 if let ::std::option::Option::Some(ref value) = #ident {
                     #encode_fn(#tag, value, buf);
                 }
             },
-            Kind::Required(..) | Kind::Repeated | Kind::Packed => quote!{
+            Kind::Required(..) | Kind::Repeated | Kind::Packed => quote! {
                 #encode_fn(#tag, &#ident, buf);
             },
         }
@@ -199,11 +184,11 @@ impl Field {
                         0
                     }
                 }
-            },
+            }
             Kind::Optional(..) => quote! {
                 #ident.as_ref().map_or(0, |value| #encoded_len_fn(#tag, value))
             },
-            Kind::Required(..) | Kind::Repeated | Kind::Packed => quote!{
+            Kind::Required(..) | Kind::Repeated | Kind::Packed => quote! {
                 #encoded_len_fn(#tag, &#ident)
             },
         }
@@ -217,7 +202,7 @@ impl Field {
                     Ty::String | Ty::Bytes => quote!(#ident.clear()),
                     _ => quote!(#ident = #default),
                 }
-            },
+            }
             Kind::Optional(_) => quote!(#ident = ::std::option::Option::None),
             Kind::Repeated | Kind::Packed => quote!(#ident.clear()),
         }
@@ -258,8 +243,7 @@ impl Field {
         let wrapper = self.debug_inner(quote!(Inner));
         let inner_ty = self.ty.rust_type();
         match self.kind {
-            Kind::Plain(_) |
-            Kind::Required(_) => self.debug_inner(wrapper_name),
+            Kind::Plain(_) | Kind::Required(_) => self.debug_inner(wrapper_name),
             Kind::Optional(_) => quote! {
                 struct #wrapper_name<'a>(&'a ::std::option::Option<#inner_ty>);
                 impl<'a> ::std::fmt::Debug for #wrapper_name<'a> {
@@ -269,8 +253,7 @@ impl Field {
                     }
                 }
             },
-            Kind::Repeated |
-            Kind::Packed => {
+            Kind::Repeated | Kind::Packed => {
                 quote! {
                     struct #wrapper_name<'a>(&'a ::std::vec::Vec<#inner_ty>);
                     impl<'a> ::std::fmt::Debug for #wrapper_name<'a> {
@@ -304,7 +287,7 @@ impl Field {
                             self.#ident = value as i32;
                         }
                     }
-                },
+                }
                 Kind::Optional(ref default) => {
                     quote! {
                         pub fn #ident(&self) -> super::#ty {
@@ -315,7 +298,7 @@ impl Field {
                             self.#ident = ::std::option::Option::Some(value as i32);
                         }
                     }
-                },
+                }
                 Kind::Repeated | Kind::Packed => {
                     quote! {
                         pub fn #ident(&self) -> ::std::iter::FilterMap<::std::iter::Cloned<::std::slice::Iter<i32>>,
@@ -326,7 +309,7 @@ impl Field {
                             self.#ident.push(value as i32);
                         }
                     }
-                },
+                }
             })
         } else if let Kind::Optional(ref default) = self.kind {
             let ty = self.ty.rust_ref_type();
@@ -373,7 +356,6 @@ pub enum Ty {
 }
 
 impl Ty {
-
     pub fn from_attr(attr: &Meta) -> Result<Option<Ty>, Error> {
         let ty = match *attr {
             Meta::Word(ref name) if name == "float" => Ty::Float,
@@ -391,10 +373,16 @@ impl Ty {
             Meta::Word(ref name) if name == "bool" => Ty::Bool,
             Meta::Word(ref name) if name == "string" => Ty::String,
             Meta::Word(ref name) if name == "bytes" => Ty::Bytes,
-            Meta::NameValue(MetaNameValue { ref ident, lit: Lit::Str(ref l), .. }) if ident == "enumeration" => {
-                Ty::Enumeration(parse_str::<Path>(&l.value())?)
-            },
-            Meta::List(MetaList { ref ident, ref nested, .. }) if ident == "enumeration" => {
+            Meta::NameValue(MetaNameValue {
+                ref ident,
+                lit: Lit::Str(ref l),
+                ..
+            }) if ident == "enumeration" => Ty::Enumeration(parse_str::<Path>(&l.value())?),
+            Meta::List(MetaList {
+                ref ident,
+                ref nested,
+                ..
+            }) if ident == "enumeration" => {
                 // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
                 if nested.len() == 1 {
                     if let NestedMeta::Meta(Meta::Word(ref ident)) = nested[0] {
@@ -405,7 +393,7 @@ impl Ty {
                 } else {
                     bail!("invalid enumeration attribute: only a single identifier is supported");
                 }
-            },
+            }
             _ => return Ok(None),
         };
         Ok(Some(ty))
@@ -442,7 +430,7 @@ impl Ty {
                 }
 
                 Ty::Enumeration(parse_str::<Path>(s[1..s.len() - 1].trim())?)
-            },
+            }
             _ => return error,
         };
         Ok(ty)
@@ -558,7 +546,6 @@ pub enum DefaultValue {
 }
 
 impl DefaultValue {
-
     pub fn from_attr(attr: &Meta) -> Result<Option<Lit>, Error> {
         if attr.name() != "default" {
             return Ok(None);
@@ -577,29 +564,46 @@ impl DefaultValue {
         let is_u64 = *ty == Ty::Uint64 || *ty == Ty::Fixed64;
 
         let default = match lit {
-            Lit::Int(ref lit) if is_i32
-                              && (lit.suffix() == IntSuffix::I32
-                              || lit.suffix() == IntSuffix::None) => DefaultValue::I32(lit.value() as _),
-            Lit::Int(ref lit) if is_i64
-                              && (lit.suffix() == IntSuffix::I64
-                              || lit.suffix() == IntSuffix::None) => DefaultValue::I64(lit.value() as _),
-            Lit::Int(ref lit) if is_u32
-                              && (lit.suffix() == IntSuffix::U32
-                              || lit.suffix() == IntSuffix::None) => DefaultValue::U32(lit.value() as _),
-            Lit::Int(ref lit) if is_u64
-                              && (lit.suffix() == IntSuffix::U64
-                              || lit.suffix() == IntSuffix::None) => DefaultValue::U64(lit.value()),
+            Lit::Int(ref lit)
+                if is_i32
+                    && (lit.suffix() == IntSuffix::I32 || lit.suffix() == IntSuffix::None) =>
+            {
+                DefaultValue::I32(lit.value() as _)
+            }
+            Lit::Int(ref lit)
+                if is_i64
+                    && (lit.suffix() == IntSuffix::I64 || lit.suffix() == IntSuffix::None) =>
+            {
+                DefaultValue::I64(lit.value() as _)
+            }
+            Lit::Int(ref lit)
+                if is_u32
+                    && (lit.suffix() == IntSuffix::U32 || lit.suffix() == IntSuffix::None) =>
+            {
+                DefaultValue::U32(lit.value() as _)
+            }
+            Lit::Int(ref lit)
+                if is_u64
+                    && (lit.suffix() == IntSuffix::U64 || lit.suffix() == IntSuffix::None) =>
+            {
+                DefaultValue::U64(lit.value())
+            }
 
-            Lit::Float(ref lit) if *ty == Ty::Float
-                                && (lit.suffix() == FloatSuffix::F32
-                                || lit.suffix() == FloatSuffix::None) => DefaultValue::F32(lit.value() as _),
+            Lit::Float(ref lit)
+                if *ty == Ty::Float
+                    && (lit.suffix() == FloatSuffix::F32 || lit.suffix() == FloatSuffix::None) =>
+            {
+                DefaultValue::F32(lit.value() as _)
+            }
             Lit::Int(ref lit) if *ty == Ty::Float => DefaultValue::F32(lit.value() as _),
 
-            Lit::Float(ref lit) if *ty == Ty::Double
-                                && (lit.suffix() == FloatSuffix::F64
-                                || lit.suffix() == FloatSuffix::None) => DefaultValue::F64(lit.value()),
+            Lit::Float(ref lit)
+                if *ty == Ty::Double
+                    && (lit.suffix() == FloatSuffix::F64 || lit.suffix() == FloatSuffix::None) =>
+            {
+                DefaultValue::F64(lit.value())
+            }
             Lit::Int(ref lit) if *ty == Ty::Double => DefaultValue::F64(lit.value() as _),
-
 
             Lit::Bool(ref lit) if *ty == Ty::Bool => DefaultValue::Bool(lit.value),
             Lit::Str(ref lit) if *ty == Ty::String => DefaultValue::String(lit.value().clone()),
@@ -611,23 +615,43 @@ impl DefaultValue {
 
                 if let Ty::Enumeration(ref path) = *ty {
                     let variant = Ident::new(value, Span::call_site());
-                    return Ok(DefaultValue::Enumeration(quote!(#path::#variant)))
+                    return Ok(DefaultValue::Enumeration(quote!(#path::#variant)));
                 }
 
                 // Parse special floating point values.
                 if *ty == Ty::Float {
                     match value {
-                        "inf" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f32::INFINITY")?)),
-                        "-inf" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f32::NEG_INFINITY")?)),
-                        "nan" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f32::NAN")?)),
+                        "inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::std::f32::INFINITY",
+                            )?));
+                        }
+                        "-inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::std::f32::NEG_INFINITY",
+                            )?));
+                        }
+                        "nan" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>("::std::f32::NAN")?));
+                        }
                         _ => (),
                     }
                 }
                 if *ty == Ty::Double {
                     match value {
-                        "inf" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f64::INFINITY")?)),
-                        "-inf" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f64::NEG_INFINITY")?)),
-                        "nan" => return Ok(DefaultValue::Path(parse_str::<Path>("::std::f64::NAN")?)),
+                        "inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::std::f64::INFINITY",
+                            )?));
+                        }
+                        "-inf" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>(
+                                "::std::f64::NEG_INFINITY",
+                            )?));
+                        }
+                        "nan" => {
+                            return Ok(DefaultValue::Path(parse_str::<Path>("::std::f64::NAN")?));
+                        }
                         _ => (),
                     }
                 }
@@ -636,29 +660,49 @@ impl DefaultValue {
                 if value.chars().next() == Some('-') {
                     if let Ok(lit) = syn::parse_str::<Lit>(&value[1..]) {
                         match lit {
-                            Lit::Int(ref lit) if is_i32 && (lit.suffix() == IntSuffix::I32 || lit.suffix() == IntSuffix::None) => {
+                            Lit::Int(ref lit)
+                                if is_i32
+                                    && (lit.suffix() == IntSuffix::I32
+                                        || lit.suffix() == IntSuffix::None) =>
+                            {
                                 return Ok(DefaultValue::I32((!lit.value() + 1) as i32));
-                            },
+                            }
 
-                            Lit::Int(ref lit) if is_i64 && (lit.suffix() == IntSuffix::I64 || lit.suffix() == IntSuffix::None) => {
+                            Lit::Int(ref lit)
+                                if is_i64
+                                    && (lit.suffix() == IntSuffix::I64
+                                        || lit.suffix() == IntSuffix::None) =>
+                            {
                                 return Ok(DefaultValue::I64((!lit.value() + 1) as i64));
-                            },
+                            }
 
-                            Lit::Float(ref lit) if *ty == Ty::Float && (lit.suffix() == FloatSuffix::F32 || lit.suffix() == FloatSuffix::None) => {
+                            Lit::Float(ref lit)
+                                if *ty == Ty::Float
+                                    && (lit.suffix() == FloatSuffix::F32
+                                        || lit.suffix() == FloatSuffix::None) =>
+                            {
                                 return Ok(DefaultValue::F32(-lit.value() as f32));
-                            },
+                            }
 
-                            Lit::Float(ref lit) if *ty == Ty::Double && (lit.suffix() == FloatSuffix::F64 || lit.suffix() == FloatSuffix::None) => {
+                            Lit::Float(ref lit)
+                                if *ty == Ty::Double
+                                    && (lit.suffix() == FloatSuffix::F64
+                                        || lit.suffix() == FloatSuffix::None) =>
+                            {
                                 return Ok(DefaultValue::F64(-lit.value()));
-                            },
+                            }
 
-                            Lit::Int(ref lit) if *ty == Ty::Float && lit.suffix() == IntSuffix::None => {
+                            Lit::Int(ref lit)
+                                if *ty == Ty::Float && lit.suffix() == IntSuffix::None =>
+                            {
                                 return Ok(DefaultValue::F32(-(lit.value() as f32)));
-                            },
+                            }
 
-                            Lit::Int(ref lit) if *ty == Ty::Double && lit.suffix() == IntSuffix::None => {
+                            Lit::Int(ref lit)
+                                if *ty == Ty::Double && lit.suffix() == IntSuffix::None =>
+                            {
                                 return Ok(DefaultValue::F64(-(lit.value() as f64)));
-                            },
+                            }
 
                             _ => (),
                         }
@@ -670,7 +714,7 @@ impl DefaultValue {
                     _ => (),
                 }
                 bail!("invalid default value: {}", quote!(#value));
-            },
+            }
             _ => bail!("invalid default value: {}", quote!(#lit)),
         };
 
@@ -695,13 +739,15 @@ impl DefaultValue {
 
     pub fn owned(&self) -> TokenStream {
         match *self {
-            DefaultValue::String(ref value) if value.is_empty() => quote!(::std::string::String::new()),
+            DefaultValue::String(ref value) if value.is_empty() => {
+                quote!(::std::string::String::new())
+            }
             DefaultValue::String(ref value) => quote!(#value.to_owned()),
             DefaultValue::Bytes(ref value) if value.is_empty() => quote!(::std::vec::Vec::new()),
             DefaultValue::Bytes(ref value) => {
                 let lit = LitByteStr::new(value, Span::call_site());
                 quote!(#lit.to_owned())
-            },
+            }
 
             ref other => other.typed(),
         }
@@ -727,10 +773,10 @@ impl quote::ToTokens for DefaultValue {
             DefaultValue::U64(value) => value.to_tokens(tokens),
             DefaultValue::Bool(value) => value.to_tokens(tokens),
             DefaultValue::String(ref value) => value.to_tokens(tokens),
-            DefaultValue::Bytes(ref value) => LitByteStr::new(value, Span::call_site()).to_tokens(tokens),
-            DefaultValue::Enumeration(ref value) => {
-                value.to_tokens(tokens)
-            },
+            DefaultValue::Bytes(ref value) => {
+                LitByteStr::new(value, Span::call_site()).to_tokens(tokens)
+            }
+            DefaultValue::Enumeration(ref value) => value.to_tokens(tokens),
             DefaultValue::Path(ref value) => value.to_tokens(tokens),
         }
     }

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -273,8 +273,12 @@ impl Field {
 
     /// Returns methods to embed in the message.
     pub fn methods(&self, ident: &Ident) -> Option<TokenStream> {
-        let set = Ident::new(&format!("set_{}", ident), Span::call_site());
-        let push = Ident::new(&format!("push_{}", ident), Span::call_site());
+        let mut ident_str = ident.to_string();
+        if ident_str.starts_with("r#") {
+            ident_str = ident_str[2..].to_owned();
+        }
+        let set = Ident::new(&format!("set_{}", ident_str), Span::call_site());
+        let push = Ident::new(&format!("push_{}", ident_str), Span::call_site());
         if let Ty::Enumeration(ref ty) = self.ty {
             Some(match self.kind {
                 Kind::Plain(ref default) | Kind::Required(ref default) => {

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use failure::Error;
+use failure::{bail, format_err, Error};
 use proc_macro2::{Span, TokenStream};
-use quote;
+use quote::{quote, ToTokens};
 use syn::{
     self, parse_str, FloatSuffix, Ident, IntSuffix, Lit, LitByteStr, Meta, MetaList, MetaNameValue,
     NestedMeta, Path,
@@ -762,7 +762,7 @@ impl DefaultValue {
     }
 }
 
-impl quote::ToTokens for DefaultValue {
+impl ToTokens for DefaultValue {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match *self {
             DefaultValue::F64(value) => value.to_tokens(tokens),

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-derive/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/prost-derive/0.5.0")]
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -4,12 +4,9 @@
 
 extern crate proc_macro;
 
+use failure::bail;
+use quote::quote;
 use syn;
-
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate quote;
 
 use failure::Error;
 use itertools::Itertools;

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -2,7 +2,6 @@
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 
-
 extern crate proc_macro;
 
 use syn;
@@ -18,15 +17,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use syn::punctuated::Punctuated;
 use syn::{
-    Data,
-    DataEnum,
-    DataStruct,
-    DeriveInput,
-    Expr,
-    Fields,
-    FieldsNamed,
-    FieldsUnnamed,
-    Ident,
+    Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, FieldsNamed, FieldsUnnamed, Ident,
     Variant,
 };
 
@@ -44,36 +35,48 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         Data::Union(..) => bail!("Message can not be derived for a union"),
     };
 
-    if !input.generics.params.is_empty() ||
-       input.generics.where_clause.is_some() {
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
         bail!("Message may not be derived for generic type");
     }
 
     let fields = match variant_data {
-        DataStruct { fields: Fields::Named(FieldsNamed { named: fields, .. }), .. } |
-        DataStruct { fields: Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }), ..} => {
-            fields.into_iter().collect()
-        },
-        DataStruct { fields: Fields::Unit, .. } => Vec::new(),
+        DataStruct {
+            fields: Fields::Named(FieldsNamed { named: fields, .. }),
+            ..
+        }
+        | DataStruct {
+            fields:
+                Fields::Unnamed(FieldsUnnamed {
+                    unnamed: fields, ..
+                }),
+            ..
+        } => fields.into_iter().collect(),
+        DataStruct {
+            fields: Fields::Unit,
+            ..
+        } => Vec::new(),
     };
 
     let mut next_tag: u32 = 0;
-    let mut fields = fields.into_iter()
-                           .enumerate()
-                           .flat_map(|(idx, field)| {
-                               let field_ident = field.ident
-                                    .unwrap_or_else(|| Ident::new(&idx.to_string(), Span::call_site()));
-                               match Field::new(field.attrs, Some(next_tag)) {
-                                   Ok(Some(field)) => {
-                                       next_tag = field.tags().iter().max().map(|t| t + 1).unwrap_or(next_tag);
-                                       Some(Ok((field_ident, field)))
-                                   }
-                                   Ok(None) => None,
-                                   Err(err) => Some(Err(err.context(format!("invalid message field {}.{}",
-                                                                            ident, field_ident)))),
-                               }
-                           })
-                           .collect::<Result<Vec<(Ident, Field)>, failure::Context<String>>>()?;
+    let mut fields = fields
+        .into_iter()
+        .enumerate()
+        .flat_map(|(idx, field)| {
+            let field_ident = field
+                .ident
+                .unwrap_or_else(|| Ident::new(&idx.to_string(), Span::call_site()));
+            match Field::new(field.attrs, Some(next_tag)) {
+                Ok(Some(field)) => {
+                    next_tag = field.tags().iter().max().map(|t| t + 1).unwrap_or(next_tag);
+                    Some(Ok((field_ident, field)))
+                }
+                Ok(None) => None,
+                Err(err) => Some(Err(
+                    err.context(format!("invalid message field {}.{}", ident, field_ident))
+                )),
+            }
+        })
+        .collect::<Result<Vec<(Ident, Field)>, failure::Context<String>>>()?;
 
     // We want Debug to be in declaration order
     let unsorted_fields = fields.clone();
@@ -85,7 +88,10 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     fields.sort_by_key(|&(_, ref field)| field.tags().into_iter().min().unwrap());
     let fields = fields;
 
-    let mut tags = fields.iter().flat_map(|&(_, ref field)| field.tags()).collect::<Vec<_>>();
+    let mut tags = fields
+        .iter()
+        .flat_map(|&(_, ref field)| field.tags())
+        .collect::<Vec<_>>();
     let num_tags = tags.len();
     tags.sort();
     tags.dedup();
@@ -96,19 +102,21 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     // Put impls in a special module, so that 'extern crate' can be used.
     let module = Ident::new(&format!("{}_MESSAGE", ident), Span::call_site());
 
-    let encoded_len = fields.iter()
-                            .map(|&(ref field_ident, ref field)| {
-                                field.encoded_len(quote!(self.#field_ident))
-                            });
+    let encoded_len = fields
+        .iter()
+        .map(|&(ref field_ident, ref field)| field.encoded_len(quote!(self.#field_ident)));
 
-    let encode = fields.iter()
-                       .map(|&(ref field_ident, ref field)| {
-                           field.encode(quote!(self.#field_ident))
-                       });
+    let encode = fields
+        .iter()
+        .map(|&(ref field_ident, ref field)| field.encode(quote!(self.#field_ident)));
 
     let merge = fields.iter().map(|&(ref field_ident, ref field)| {
         let merge = field.merge(quote!(self.#field_ident));
-        let tags = field.tags().into_iter().map(|tag| quote!(#tag)).intersperse(quote!(|));
+        let tags = field
+            .tags()
+            .into_iter()
+            .map(|tag| quote!(#tag))
+            .intersperse(quote!(|));
         quote!(#(#tags)* => #merge.map_err(|mut error| {
             error.push(STRUCT_NAME, stringify!(#field_ident));
             error
@@ -118,30 +126,30 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let struct_name = if fields.is_empty() {
         quote!()
     } else {
-        quote!(const STRUCT_NAME: &'static str = stringify!(#ident);)
+        quote!(
+            const STRUCT_NAME: &'static str = stringify!(#ident);
+        )
     };
 
     // TODO
     let is_struct = true;
 
-    let clear = fields.iter()
-                       .map(|&(ref field_ident, ref field)| {
-                           field.clear(quote!(self.#field_ident))
-                       });
+    let clear = fields
+        .iter()
+        .map(|&(ref field_ident, ref field)| field.clear(quote!(self.#field_ident)));
 
-    let default = fields.iter()
-                        .map(|&(ref field_ident, ref field)| {
-                            let value = field.default();
-                            quote!(#field_ident: #value,)
-                        });
+    let default = fields.iter().map(|&(ref field_ident, ref field)| {
+        let value = field.default();
+        quote!(#field_ident: #value,)
+    });
 
-    let methods = fields.iter()
-                        .flat_map(|&(ref field_ident, ref field)| field.methods(field_ident))
-                        .collect::<Vec<_>>();
+    let methods = fields
+        .iter()
+        .flat_map(|&(ref field_ident, ref field)| field.methods(field_ident))
+        .collect::<Vec<_>>();
     let methods = if methods.is_empty() {
         quote!()
     } else {
-
         quote! {
             #[allow(dead_code)]
             impl #ident {
@@ -150,21 +158,20 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         }
     };
 
-    let debugs = unsorted_fields.iter()
-                                .map(|&(ref field_ident, ref field)| {
-                                    let wrapper = field.debug(quote!(self.#field_ident));
-                                    let call = if is_struct {
-                                        quote!(builder.field(stringify!(#field_ident), &wrapper))
-                                    } else {
-                                        quote!(builder.field(&wrapper))
-                                    };
-                                    quote! {
-                                         let builder = {
-                                             let wrapper = #wrapper;
-                                             #call
-                                         };
-                                    }
-                                });
+    let debugs = unsorted_fields.iter().map(|&(ref field_ident, ref field)| {
+        let wrapper = field.debug(quote!(self.#field_ident));
+        let call = if is_struct {
+            quote!(builder.field(stringify!(#field_ident), &wrapper))
+        } else {
+            quote!(builder.field(&wrapper))
+        };
+        quote! {
+             let builder = {
+                 let wrapper = #wrapper;
+                 #call
+             };
+        }
+    });
     let debug_builder = if is_struct {
         quote!(f.debug_struct(stringify!(#ident)))
     } else {
@@ -233,13 +240,11 @@ pub fn message(input: TokenStream) -> TokenStream {
     try_message(input).unwrap()
 }
 
-
 fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
     let input: DeriveInput = syn::parse(input)?;
     let ident = input.ident;
 
-    if !input.generics.params.is_empty() ||
-       input.generics.where_clause.is_some() {
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
         bail!("Message may not be derived for generic type");
     }
 
@@ -251,10 +256,18 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
 
     // Map the variants into 'fields'.
     let mut variants: Vec<(Ident, Expr)> = Vec::new();
-    for Variant { ident, fields, discriminant, .. } in punctuated_variants {
+    for Variant {
+        ident,
+        fields,
+        discriminant,
+        ..
+    } in punctuated_variants
+    {
         match fields {
             Fields::Unit => (),
-            Fields::Named(_) | Fields::Unnamed(_) => bail!("Enumeration variants may not have fields"),
+            Fields::Named(_) | Fields::Unnamed(_) => {
+                bail!("Enumeration variants may not have fields")
+            }
         }
 
         match discriminant {
@@ -271,11 +284,18 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
 
     // Put impls in a special module, so that 'extern crate' can be used.
     let module = Ident::new(&format!("{}_ENUMERATION", ident), Span::call_site());
-    let is_valid = variants.iter().map(|&(_, ref value)| quote!(#value => true));
-    let from = variants.iter().map(|&(ref variant, ref value)| quote!(#value => ::std::option::Option::Some(#ident::#variant)));
+    let is_valid = variants
+        .iter()
+        .map(|&(_, ref value)| quote!(#value => true));
+    let from = variants.iter().map(
+        |&(ref variant, ref value)| quote!(#value => ::std::option::Option::Some(#ident::#variant)),
+    );
 
     let is_valid_doc = format!("Returns `true` if `value` is a variant of `{}`.", ident);
-    let from_i32_doc = format!("Converts an `i32` to a `{}`, or `None` if `value` is not a valid variant.", ident);
+    let from_i32_doc = format!(
+        "Converts an `i32` to a `{}`, or `None` if `value` is not a valid variant.",
+        ident
+    );
 
     let expanded = quote! {
         #[allow(non_snake_case, unused_attributes)]
@@ -334,18 +354,25 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         Data::Union(..) => bail!("Oneof can not be derived for a union"),
     };
 
-    if !input.generics.params.is_empty() ||
-       input.generics.where_clause.is_some() {
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
         bail!("Message may not be derived for generic type");
     }
 
     // Map the variants into 'fields'.
     let mut fields: Vec<(Ident, Field)> = Vec::new();
-    for Variant { attrs, ident: variant_ident, fields: variant_fields, .. } in variants {
+    for Variant {
+        attrs,
+        ident: variant_ident,
+        fields: variant_fields,
+        ..
+    } in variants
+    {
         let variant_fields = match variant_fields {
             Fields::Unit => Punctuated::new(),
-            Fields::Named(FieldsNamed { named: fields, .. }) |
-            Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }) => fields,
+            Fields::Named(FieldsNamed { named: fields, .. })
+            | Fields::Unnamed(FieldsUnnamed {
+                unnamed: fields, ..
+            }) => fields,
         };
         if variant_fields.len() != 1 {
             bail!("Oneof enum variants must have a single field");
@@ -356,13 +383,19 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         }
     }
 
-    let mut tags = fields.iter().flat_map(|&(ref variant_ident, ref field)| -> Result<u32, Error> {
-        if field.tags().len() > 1 {
-            bail!("invalid oneof variant {}::{}: oneof variants may only have a single tag",
-                  ident, variant_ident);
-        }
-        Ok(field.tags()[0])
-    }).collect::<Vec<_>>();
+    let mut tags = fields
+        .iter()
+        .flat_map(|&(ref variant_ident, ref field)| -> Result<u32, Error> {
+            if field.tags().len() > 1 {
+                bail!(
+                    "invalid oneof variant {}::{}: oneof variants may only have a single tag",
+                    ident,
+                    variant_ident
+                );
+            }
+            Ok(field.tags()[0])
+        })
+        .collect::<Vec<_>>();
     tags.sort();
     tags.dedup();
     if tags.len() != fields.len() {

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -2,10 +2,10 @@
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 
-extern crate itertools;
+
 extern crate proc_macro;
-extern crate proc_macro2;
-extern crate syn;
+
+use syn;
 
 #[macro_use]
 extern crate failure;
@@ -31,7 +31,7 @@ use syn::{
 };
 
 mod field;
-use field::Field;
+use crate::field::Field;
 
 fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let input: DeriveInput = syn::parse(input)?;

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -6,7 +6,6 @@ extern crate proc_macro;
 
 use failure::bail;
 use quote::quote;
-use syn;
 
 use failure::Error;
 use itertools::Itertools;
@@ -14,7 +13,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use syn::punctuated::Punctuated;
 use syn::{
-    Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, FieldsNamed, FieldsUnnamed, Ident,
+    self, Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, FieldsNamed, FieldsUnnamed, Ident,
     Variant,
 };
 

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "prost-types"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/danburkert/prost"
@@ -16,5 +16,5 @@ test = false
 
 [dependencies]
 bytes = "0.4.7"
-prost = { version = "0.4.0", path = ".." }
-prost-derive = { version = "0.4.0", path = "../prost-derive" }
+prost = { version = "0.5.0", path = ".." }
+prost-derive = { version = "0.5.0", path = "../prost-derive" }

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/danburkert/prost"
 documentation = "https://docs.rs/prost-types"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
+edition = "2018"
 
 [lib]
 doctest = false

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -1,5 +1,5 @@
 /// The version number of protocol compiler.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Version {
     #[prost(int32, optional, tag="1")]
     pub major: ::std::option::Option<i32>,
@@ -13,7 +13,7 @@ pub struct Version {
     pub suffix: ::std::option::Option<String>,
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct CodeGeneratorRequest {
     /// The .proto files that were explicitly listed on the command-line.  The
     /// code generator should generate code only for these files.  Each file's
@@ -44,7 +44,7 @@ pub struct CodeGeneratorRequest {
     pub compiler_version: ::std::option::Option<Version>,
 }
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct CodeGeneratorResponse {
     /// Error message.  If non-empty, code generation failed.  The plugin process
     /// should exit with status code zero even if it reports an error in this way.
@@ -61,7 +61,7 @@ pub struct CodeGeneratorResponse {
 }
 pub mod code_generator_response {
     /// Represents a single generated file.
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, prost_derive::Message)]
     pub struct File {
         /// The file name, relative to the output directory.  The name must not
         /// contain "." or ".." components and must be relative, not be absolute (so,

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -1,5 +1,5 @@
 /// The version number of protocol compiler.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Version {
     #[prost(int32, optional, tag="1")]
     pub major: ::std::option::Option<i32>,
@@ -13,7 +13,7 @@ pub struct Version {
     pub suffix: ::std::option::Option<String>,
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct CodeGeneratorRequest {
     /// The .proto files that were explicitly listed on the command-line.  The
     /// code generator should generate code only for these files.  Each file's
@@ -44,7 +44,7 @@ pub struct CodeGeneratorRequest {
     pub compiler_version: ::std::option::Option<Version>,
 }
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct CodeGeneratorResponse {
     /// Error message.  If non-empty, code generation failed.  The plugin process
     /// should exit with status code zero even if it reports an error in this way.
@@ -61,7 +61,7 @@ pub struct CodeGeneratorResponse {
 }
 pub mod code_generator_response {
     /// Represents a single generated file.
-    #[derive(Clone, PartialEq, prost_derive::Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct File {
         /// The file name, relative to the output directory.  The name must not
         /// contain "." or ".." components and must be relative, not be absolute (so,

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -57,9 +57,17 @@ impl Duration {
 impl From<time::Duration> for Duration {
     fn from(duration: time::Duration) -> Duration {
         let seconds = duration.as_secs();
-        let seconds = if seconds > i64::MAX as u64 { i64::MAX } else { seconds as i64 };
+        let seconds = if seconds > i64::MAX as u64 {
+            i64::MAX
+        } else {
+            seconds as i64
+        };
         let nanos = duration.subsec_nanos();
-        let nanos = if nanos > i32::MAX as u32 { i32::MAX } else { nanos as i32 };
+        let nanos = if nanos > i32::MAX as u32 {
+            i32::MAX
+        } else {
+            nanos as i32
+        };
         let mut duration = Duration { seconds, nanos };
         duration.normalize();
         duration
@@ -73,10 +81,15 @@ impl From<Duration> for Result<time::Duration, time::Duration> {
     fn from(mut duration: Duration) -> Result<time::Duration, time::Duration> {
         duration.normalize();
         if duration.seconds >= 0 {
-            Ok(time::Duration::new(duration.seconds as u64, duration.nanos as u32))
+            Ok(time::Duration::new(
+                duration.seconds as u64,
+                duration.nanos as u32,
+            ))
         } else {
-            Err(time::Duration::new((-duration.seconds) as u64,
-                                    (-duration.nanos) as u32))
+            Err(time::Duration::new(
+                (-duration.seconds) as u64,
+                (-duration.nanos) as u32,
+            ))
         }
     }
 }
@@ -123,15 +136,18 @@ impl From<Timestamp> for Result<time::SystemTime, time::Duration> {
     fn from(mut timestamp: Timestamp) -> Result<time::SystemTime, time::Duration> {
         timestamp.normalize();
         if timestamp.seconds >= 0 {
-            Ok(time::UNIX_EPOCH + time::Duration::new(timestamp.seconds as u64,
-                                                      timestamp.nanos as u32))
+            Ok(time::UNIX_EPOCH
+                + time::Duration::new(timestamp.seconds as u64, timestamp.nanos as u32))
         } else {
             let mut duration = Duration {
                 seconds: -timestamp.seconds,
                 nanos: timestamp.nanos,
             };
             duration.normalize();
-            Err(time::Duration::new(duration.seconds as u64, duration.nanos as u32))
+            Err(time::Duration::new(
+                duration.seconds as u64,
+                duration.nanos as u32,
+            ))
         }
     }
 }

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-codegen/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/prost-types/0.5.0")]
 
 //! Protocol Buffers well-known types.
 //!

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -9,9 +9,6 @@
 //!
 //! [1]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf
 
-#[macro_use]
-extern crate prost_derive;
-
 use std::i32;
 use std::i64;
 use std::time;

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1,12 +1,12 @@
 /// The protocol compiler can output a FileDescriptorSet containing the .proto
 /// files it parses.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag="1")]
     pub file: ::std::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag="1")]
@@ -47,7 +47,7 @@ pub struct FileDescriptorProto {
     pub syntax: ::std::option::Option<String>,
 }
 /// Describes a message type.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct DescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -73,7 +73,7 @@ pub struct DescriptorProto {
     pub reserved_name: ::std::vec::Vec<String>,
 }
 pub mod descriptor_proto {
-    #[derive(Clone, PartialEq, prost_derive::Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct ExtensionRange {
         #[prost(int32, optional, tag="1")]
         pub start: ::std::option::Option<i32>,
@@ -85,7 +85,7 @@ pub mod descriptor_proto {
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
-    #[derive(Clone, PartialEq, prost_derive::Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -95,14 +95,14 @@ pub mod descriptor_proto {
         pub end: ::std::option::Option<i32>,
     }
 }
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
 /// Describes a field within a message.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -146,7 +146,7 @@ pub struct FieldDescriptorProto {
     pub options: ::std::option::Option<FieldOptions>,
 }
 pub mod field_descriptor_proto {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     pub enum Type {
         /// 0 is reserved for errors.
         /// Order is weird for historical reasons.
@@ -181,7 +181,7 @@ pub mod field_descriptor_proto {
         /// Uses ZigZag encoding.
         Sint64 = 18,
     }
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     pub enum Label {
         /// 0 is reserved for errors
         Optional = 1,
@@ -190,7 +190,7 @@ pub mod field_descriptor_proto {
     }
 }
 /// Describes a oneof.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -198,7 +198,7 @@ pub struct OneofDescriptorProto {
     pub options: ::std::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -223,7 +223,7 @@ pub mod enum_descriptor_proto {
     /// Note that this is distinct from DescriptorProto.ReservedRange in that it
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
-    #[derive(Clone, PartialEq, prost_derive::Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -234,7 +234,7 @@ pub mod enum_descriptor_proto {
     }
 }
 /// Describes a value within an enum.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -244,7 +244,7 @@ pub struct EnumValueDescriptorProto {
     pub options: ::std::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -254,7 +254,7 @@ pub struct ServiceDescriptorProto {
     pub options: ::std::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -305,7 +305,7 @@ pub struct MethodDescriptorProto {
 //   If this turns out to be popular, a web service will be set up
 //   to automatically assign option numbers.
 
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FileOptions {
     /// Sets the Java package where classes generated from this .proto will be
     /// placed.  By default, the proto package is used, but this is often
@@ -415,7 +415,7 @@ pub struct FileOptions {
 }
 pub mod file_options {
     /// Generated classes can be optimized for speed or code size.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     pub enum OptimizeMode {
         /// Generate complete code for parsing, serialization,
         Speed = 1,
@@ -427,7 +427,7 @@ pub mod file_options {
         LiteRuntime = 3,
     }
 }
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct MessageOptions {
     /// Set true to use the old proto1 MessageSet wire format for extensions.
     /// This is provided for backwards-compatibility with the MessageSet wire
@@ -487,7 +487,7 @@ pub struct MessageOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FieldOptions {
     /// The ctype option instructs the C++ code generator to use a different
     /// representation of the field than it normally would.  See the specific
@@ -559,14 +559,14 @@ pub struct FieldOptions {
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
 pub mod field_options {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     pub enum CType {
         /// Default mode.
         String = 0,
         Cord = 1,
         StringPiece = 2,
     }
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     pub enum JsType {
         /// Use the default type.
         JsNormal = 0,
@@ -576,13 +576,13 @@ pub mod field_options {
         JsNumber = 2,
     }
 }
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
@@ -598,7 +598,7 @@ pub struct EnumOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct EnumValueOptions {
     /// Is this enum value deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -610,7 +610,7 @@ pub struct EnumValueOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct ServiceOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -627,7 +627,7 @@ pub struct ServiceOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct MethodOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -650,7 +650,7 @@ pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
     /// or neither? HTTP based RPC implementation may choose GET verb for safe
     /// methods, and PUT verb for idempotent methods instead of the default POST.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     pub enum IdempotencyLevel {
         IdempotencyUnknown = 0,
         /// implies idempotent
@@ -665,7 +665,7 @@ pub mod method_options {
 /// options protos in descriptor objects (e.g. returned by Descriptor::options(),
 /// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 /// in them.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag="2")]
     pub name: ::std::vec::Vec<uninterpreted_option::NamePart>,
@@ -690,7 +690,7 @@ pub mod uninterpreted_option {
     /// extension (denoted with parentheses in options specs in .proto files).
     /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
     /// "foo.(bar.baz).qux".
-    #[derive(Clone, PartialEq, prost_derive::Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct NamePart {
         #[prost(string, required, tag="1")]
         pub name_part: String,
@@ -703,7 +703,7 @@ pub mod uninterpreted_option {
 
 /// Encapsulates information about the original source file from which a
 /// FileDescriptorProto was generated.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct SourceCodeInfo {
     /// A Location identifies a piece of source code in a .proto file which
     /// corresponds to a particular definition.  This information is intended
@@ -752,7 +752,7 @@ pub struct SourceCodeInfo {
     pub location: ::std::vec::Vec<source_code_info::Location>,
 }
 pub mod source_code_info {
-    #[derive(Clone, PartialEq, prost_derive::Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct Location {
         /// Identifies which part of the FileDescriptorProto was defined at this
         /// location.
@@ -844,7 +844,7 @@ pub mod source_code_info {
 /// Describes the relationship between generated code and its original source
 /// file. A GeneratedCodeInfo message is associated with only one generated
 /// source file, but may contain references to different source .proto files.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
@@ -852,7 +852,7 @@ pub struct GeneratedCodeInfo {
     pub annotation: ::std::vec::Vec<generated_code_info::Annotation>,
 }
 pub mod generated_code_info {
-    #[derive(Clone, PartialEq, prost_derive::Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct Annotation {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
@@ -952,7 +952,7 @@ pub mod generated_code_info {
 ///       "value": "1.212s"
 ///     }
 ///
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Any {
     /// A URL/resource name that uniquely identifies the type of the serialized
     /// protocol buffer message. The last segment of the URL's path must represent
@@ -989,7 +989,7 @@ pub struct Any {
 }
 /// `SourceContext` represents information about the source of a
 /// protobuf element, like the file in which it is defined.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
@@ -997,7 +997,7 @@ pub struct SourceContext {
     pub file_name: String,
 }
 /// A protocol buffer message type.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Type {
     /// The fully qualified message name.
     #[prost(string, tag="1")]
@@ -1019,7 +1019,7 @@ pub struct Type {
     pub syntax: i32,
 }
 /// A single field of a message type.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Field {
     /// The field type.
     #[prost(enumeration="field::Kind", tag="1")]
@@ -1056,7 +1056,7 @@ pub struct Field {
 }
 pub mod field {
     /// Basic field types.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     pub enum Kind {
         /// Field type unknown.
         TypeUnknown = 0,
@@ -1098,7 +1098,7 @@ pub mod field {
         TypeSint64 = 18,
     }
     /// Whether a field is optional, required, or repeated.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     pub enum Cardinality {
         /// For fields with unknown cardinality.
         Unknown = 0,
@@ -1111,7 +1111,7 @@ pub mod field {
     }
 }
 /// Enum type definition.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Enum {
     /// Enum type name.
     #[prost(string, tag="1")]
@@ -1130,7 +1130,7 @@ pub struct Enum {
     pub syntax: i32,
 }
 /// Enum value definition.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct EnumValue {
     /// Enum value name.
     #[prost(string, tag="1")]
@@ -1144,7 +1144,7 @@ pub struct EnumValue {
 }
 /// A protocol buffer option, which can be attached to a message, field,
 /// enumeration, etc.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Option {
     /// The option's name. For protobuf built-in options (options defined in
     /// descriptor.proto), this is the short name. For example, `"map_entry"`.
@@ -1160,7 +1160,7 @@ pub struct Option {
     pub value: ::std::option::Option<Any>,
 }
 /// The syntax in which a protocol buffer element is defined.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
 pub enum Syntax {
     /// Syntax `proto2`.
     Proto2 = 0,
@@ -1176,7 +1176,7 @@ pub enum Syntax {
 /// sometimes simply referred to as "APIs" in other contexts, such as the name of
 /// this message itself. See https://cloud.google.com/apis/design/glossary for
 /// detailed terminology.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
@@ -1223,7 +1223,7 @@ pub struct Api {
     pub syntax: i32,
 }
 /// Method represents a method of an API interface.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Method {
     /// The simple name of this method.
     #[prost(string, tag="1")]
@@ -1325,7 +1325,7 @@ pub struct Method {
 ///       }
 ///       ...
 ///     }
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
     #[prost(string, tag="1")]
@@ -1395,7 +1395,7 @@ pub struct Mixin {
 /// microsecond should be expressed in JSON format as "3.000001s".
 ///
 ///
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
@@ -1618,7 +1618,7 @@ pub struct Duration {
 /// The implementation of any API method which has a FieldMask type field in the
 /// request should verify the included field paths, and return an
 /// `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag="1")]
@@ -1632,7 +1632,7 @@ pub struct FieldMask {
 /// with the proto support for the language.
 ///
 /// The JSON representation for `Struct` is JSON object.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map="string, message", tag="1")]
@@ -1644,7 +1644,7 @@ pub struct Struct {
 /// variants, absence of any variant indicates an error.
 ///
 /// The JSON representation for `Value` is JSON value.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Value {
     /// The kind of value.
     #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
@@ -1652,7 +1652,7 @@ pub struct Value {
 }
 pub mod value {
     /// The kind of value.
-    #[derive(Clone, prost_derive::Oneof, PartialEq)]
+    #[derive(Clone, ::prost_derive::Oneof, PartialEq)]
     pub enum Kind {
         /// Represents a null value.
         #[prost(enumeration="super::NullValue", tag="1")]
@@ -1677,7 +1677,7 @@ pub mod value {
 /// `ListValue` is a wrapper around a repeated field of values.
 ///
 /// The JSON representation for `ListValue` is JSON array.
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct ListValue {
     /// Repeated field of dynamically typed values.
     #[prost(message, repeated, tag="1")]
@@ -1687,7 +1687,7 @@ pub struct ListValue {
 /// `Value` type union.
 ///
 ///  The JSON representation for `NullValue` is JSON `null`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
 pub enum NullValue {
     /// Null value.
     NullValue = 0,
@@ -1772,7 +1772,7 @@ pub enum NullValue {
 /// ) to obtain a formatter capable of generating timestamps in this format.
 ///
 ///
-#[derive(Clone, PartialEq, prost_derive::Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -113,7 +113,7 @@ pub struct FieldDescriptorProto {
     /// If type_name is set, this need not be set.  If both this and type_name
     /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     #[prost(enumeration="field_descriptor_proto::Type", optional, tag="5")]
-    pub type_: ::std::option::Option<i32>,
+    pub r#type: ::std::option::Option<i32>,
     /// For message and enum types, this is the name of the type.  If the name
     /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
     /// rules are used to find the type (i.e. first the nested types within this

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1,12 +1,12 @@
 /// The protocol compiler can output a FileDescriptorSet containing the .proto
 /// files it parses.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag="1")]
     pub file: ::std::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag="1")]
@@ -47,7 +47,7 @@ pub struct FileDescriptorProto {
     pub syntax: ::std::option::Option<String>,
 }
 /// Describes a message type.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct DescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -73,7 +73,7 @@ pub struct DescriptorProto {
     pub reserved_name: ::std::vec::Vec<String>,
 }
 pub mod descriptor_proto {
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, prost_derive::Message)]
     pub struct ExtensionRange {
         #[prost(int32, optional, tag="1")]
         pub start: ::std::option::Option<i32>,
@@ -85,7 +85,7 @@ pub mod descriptor_proto {
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, prost_derive::Message)]
     pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -95,14 +95,14 @@ pub mod descriptor_proto {
         pub end: ::std::option::Option<i32>,
     }
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
 /// Describes a field within a message.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -146,7 +146,7 @@ pub struct FieldDescriptorProto {
     pub options: ::std::option::Option<FieldOptions>,
 }
 pub mod field_descriptor_proto {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
     pub enum Type {
         /// 0 is reserved for errors.
         /// Order is weird for historical reasons.
@@ -181,7 +181,7 @@ pub mod field_descriptor_proto {
         /// Uses ZigZag encoding.
         Sint64 = 18,
     }
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
     pub enum Label {
         /// 0 is reserved for errors
         Optional = 1,
@@ -190,7 +190,7 @@ pub mod field_descriptor_proto {
     }
 }
 /// Describes a oneof.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -198,7 +198,7 @@ pub struct OneofDescriptorProto {
     pub options: ::std::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -223,7 +223,7 @@ pub mod enum_descriptor_proto {
     /// Note that this is distinct from DescriptorProto.ReservedRange in that it
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, prost_derive::Message)]
     pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -234,7 +234,7 @@ pub mod enum_descriptor_proto {
     }
 }
 /// Describes a value within an enum.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -244,7 +244,7 @@ pub struct EnumValueDescriptorProto {
     pub options: ::std::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -254,7 +254,7 @@ pub struct ServiceDescriptorProto {
     pub options: ::std::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -305,7 +305,7 @@ pub struct MethodDescriptorProto {
 //   If this turns out to be popular, a web service will be set up
 //   to automatically assign option numbers.
 
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct FileOptions {
     /// Sets the Java package where classes generated from this .proto will be
     /// placed.  By default, the proto package is used, but this is often
@@ -415,7 +415,7 @@ pub struct FileOptions {
 }
 pub mod file_options {
     /// Generated classes can be optimized for speed or code size.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
     pub enum OptimizeMode {
         /// Generate complete code for parsing, serialization,
         Speed = 1,
@@ -427,7 +427,7 @@ pub mod file_options {
         LiteRuntime = 3,
     }
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct MessageOptions {
     /// Set true to use the old proto1 MessageSet wire format for extensions.
     /// This is provided for backwards-compatibility with the MessageSet wire
@@ -487,7 +487,7 @@ pub struct MessageOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct FieldOptions {
     /// The ctype option instructs the C++ code generator to use a different
     /// representation of the field than it normally would.  See the specific
@@ -559,14 +559,14 @@ pub struct FieldOptions {
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
 pub mod field_options {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
     pub enum CType {
         /// Default mode.
         String = 0,
         Cord = 1,
         StringPiece = 2,
     }
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
     pub enum JsType {
         /// Use the default type.
         JsNormal = 0,
@@ -576,13 +576,13 @@ pub mod field_options {
         JsNumber = 2,
     }
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
@@ -598,7 +598,7 @@ pub struct EnumOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct EnumValueOptions {
     /// Is this enum value deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -610,7 +610,7 @@ pub struct EnumValueOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct ServiceOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -627,7 +627,7 @@ pub struct ServiceOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct MethodOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -650,7 +650,7 @@ pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
     /// or neither? HTTP based RPC implementation may choose GET verb for safe
     /// methods, and PUT verb for idempotent methods instead of the default POST.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
     pub enum IdempotencyLevel {
         IdempotencyUnknown = 0,
         /// implies idempotent
@@ -665,7 +665,7 @@ pub mod method_options {
 /// options protos in descriptor objects (e.g. returned by Descriptor::options(),
 /// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 /// in them.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag="2")]
     pub name: ::std::vec::Vec<uninterpreted_option::NamePart>,
@@ -690,7 +690,7 @@ pub mod uninterpreted_option {
     /// extension (denoted with parentheses in options specs in .proto files).
     /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
     /// "foo.(bar.baz).qux".
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, prost_derive::Message)]
     pub struct NamePart {
         #[prost(string, required, tag="1")]
         pub name_part: String,
@@ -703,7 +703,7 @@ pub mod uninterpreted_option {
 
 /// Encapsulates information about the original source file from which a
 /// FileDescriptorProto was generated.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct SourceCodeInfo {
     /// A Location identifies a piece of source code in a .proto file which
     /// corresponds to a particular definition.  This information is intended
@@ -752,7 +752,7 @@ pub struct SourceCodeInfo {
     pub location: ::std::vec::Vec<source_code_info::Location>,
 }
 pub mod source_code_info {
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, prost_derive::Message)]
     pub struct Location {
         /// Identifies which part of the FileDescriptorProto was defined at this
         /// location.
@@ -844,7 +844,7 @@ pub mod source_code_info {
 /// Describes the relationship between generated code and its original source
 /// file. A GeneratedCodeInfo message is associated with only one generated
 /// source file, but may contain references to different source .proto files.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
@@ -852,7 +852,7 @@ pub struct GeneratedCodeInfo {
     pub annotation: ::std::vec::Vec<generated_code_info::Annotation>,
 }
 pub mod generated_code_info {
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, prost_derive::Message)]
     pub struct Annotation {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
@@ -952,7 +952,7 @@ pub mod generated_code_info {
 ///       "value": "1.212s"
 ///     }
 ///
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Any {
     /// A URL/resource name that uniquely identifies the type of the serialized
     /// protocol buffer message. The last segment of the URL's path must represent
@@ -989,7 +989,7 @@ pub struct Any {
 }
 /// `SourceContext` represents information about the source of a
 /// protobuf element, like the file in which it is defined.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
@@ -997,7 +997,7 @@ pub struct SourceContext {
     pub file_name: String,
 }
 /// A protocol buffer message type.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Type {
     /// The fully qualified message name.
     #[prost(string, tag="1")]
@@ -1019,7 +1019,7 @@ pub struct Type {
     pub syntax: i32,
 }
 /// A single field of a message type.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Field {
     /// The field type.
     #[prost(enumeration="field::Kind", tag="1")]
@@ -1056,7 +1056,7 @@ pub struct Field {
 }
 pub mod field {
     /// Basic field types.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
     pub enum Kind {
         /// Field type unknown.
         TypeUnknown = 0,
@@ -1098,7 +1098,7 @@ pub mod field {
         TypeSint64 = 18,
     }
     /// Whether a field is optional, required, or repeated.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
     pub enum Cardinality {
         /// For fields with unknown cardinality.
         Unknown = 0,
@@ -1111,7 +1111,7 @@ pub mod field {
     }
 }
 /// Enum type definition.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Enum {
     /// Enum type name.
     #[prost(string, tag="1")]
@@ -1130,7 +1130,7 @@ pub struct Enum {
     pub syntax: i32,
 }
 /// Enum value definition.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct EnumValue {
     /// Enum value name.
     #[prost(string, tag="1")]
@@ -1144,7 +1144,7 @@ pub struct EnumValue {
 }
 /// A protocol buffer option, which can be attached to a message, field,
 /// enumeration, etc.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Option {
     /// The option's name. For protobuf built-in options (options defined in
     /// descriptor.proto), this is the short name. For example, `"map_entry"`.
@@ -1160,7 +1160,7 @@ pub struct Option {
     pub value: ::std::option::Option<Any>,
 }
 /// The syntax in which a protocol buffer element is defined.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
 pub enum Syntax {
     /// Syntax `proto2`.
     Proto2 = 0,
@@ -1176,7 +1176,7 @@ pub enum Syntax {
 /// sometimes simply referred to as "APIs" in other contexts, such as the name of
 /// this message itself. See https://cloud.google.com/apis/design/glossary for
 /// detailed terminology.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
@@ -1223,7 +1223,7 @@ pub struct Api {
     pub syntax: i32,
 }
 /// Method represents a method of an API interface.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Method {
     /// The simple name of this method.
     #[prost(string, tag="1")]
@@ -1325,7 +1325,7 @@ pub struct Method {
 ///       }
 ///       ...
 ///     }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
     #[prost(string, tag="1")]
@@ -1395,7 +1395,7 @@ pub struct Mixin {
 /// microsecond should be expressed in JSON format as "3.000001s".
 ///
 ///
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
@@ -1618,7 +1618,7 @@ pub struct Duration {
 /// The implementation of any API method which has a FieldMask type field in the
 /// request should verify the included field paths, and return an
 /// `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag="1")]
@@ -1632,7 +1632,7 @@ pub struct FieldMask {
 /// with the proto support for the language.
 ///
 /// The JSON representation for `Struct` is JSON object.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map="string, message", tag="1")]
@@ -1644,7 +1644,7 @@ pub struct Struct {
 /// variants, absence of any variant indicates an error.
 ///
 /// The JSON representation for `Value` is JSON value.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Value {
     /// The kind of value.
     #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
@@ -1652,7 +1652,7 @@ pub struct Value {
 }
 pub mod value {
     /// The kind of value.
-    #[derive(Clone, Oneof, PartialEq)]
+    #[derive(Clone, prost_derive::Oneof, PartialEq)]
     pub enum Kind {
         /// Represents a null value.
         #[prost(enumeration="super::NullValue", tag="1")]
@@ -1677,7 +1677,7 @@ pub mod value {
 /// `ListValue` is a wrapper around a repeated field of values.
 ///
 /// The JSON representation for `ListValue` is JSON array.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct ListValue {
     /// Repeated field of dynamically typed values.
     #[prost(message, repeated, tag="1")]
@@ -1687,7 +1687,7 @@ pub struct ListValue {
 /// `Value` type union.
 ///
 ///  The JSON representation for `NullValue` is JSON `null`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, prost_derive::Enumeration)]
 pub enum NullValue {
     /// Null value.
     NullValue = 0,
@@ -1772,7 +1772,7 @@ pub enum NullValue {
 /// ) to obtain a formatter capable of generating timestamps in this format.
 ///
 ///
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -3,6 +3,7 @@ name = "protobuf"
 version = "0.0.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]
 bytes = "0.4.7"

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -15,6 +15,6 @@ prost-types = { path = "../prost-types" }
 cfg-if = "0.1"
 curl = "0.4"
 flate2 = "1.0"
-prost-build = { path = "../prost-build", features = ["build-2018"] }
+prost-build = { path = "../prost-build" }
 tar = "0.4"
 tempfile = "3"

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -15,6 +15,6 @@ prost-types = { path = "../prost-types" }
 cfg-if = "0.1"
 curl = "0.4"
 flate2 = "1.0"
-prost-build = { path = "../prost-build" }
+prost-build = { path = "../prost-build", features = ["build-2018"] }
 tar = "0.4"
 tempfile = "3"

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -96,6 +96,7 @@ fn main() {
 }
 
 fn download_tarball(url: &str, out_dir: &Path) {
+    println!("downloading `{}` ...", url);
     let mut data = Vec::new();
     let mut handle = Easy::new();
 
@@ -112,6 +113,7 @@ fn download_tarball(url: &str, out_dir: &Path) {
 
     Archive::new(GzDecoder::new(Cursor::new(data)))
             .unpack(out_dir).expect("failed to unpack tarball");
+    println!("download complete");
 }
 
 /// Downloads and unpacks a Protobuf release tarball to the provided directory.

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -70,15 +70,21 @@ fn main() {
             .iter()
             .map(|proto| datasets_include_dir.join(proto)),
     );
-    prost_build::compile_protos(&benchmark_protos, &[benchmarks_include_dir.to_path_buf()])
+    let mut config = prost_build::Config::new();
+    config.edition(prost_build::Edition::Rust2018);
+    config
+        .compile_protos(&benchmark_protos, &[benchmarks_include_dir.to_path_buf()])
         .unwrap();
 
     let conformance_include_dir = include_dir.join("conformance");
-    prost_build::compile_protos(
-        &[conformance_include_dir.join("conformance.proto")],
-        &[conformance_include_dir],
-    )
-    .unwrap();
+    let mut config = prost_build::Config::new();
+    config.edition(prost_build::Edition::Rust2018);
+    config
+        .compile_protos(
+            &[conformance_include_dir.join("conformance.proto")],
+            &[conformance_include_dir],
+        )
+        .unwrap();
 
     let test_includes = &include_dir.join("google").join("protobuf");
 
@@ -87,10 +93,9 @@ fn main() {
     // compare based on the Rust PartialEq implementations is difficult, due to presence of NaN
     // values.
     let mut config = prost_build::Config::new();
+    config.edition(prost_build::Edition::Rust2018);
     config.btree_map(&["."]);
-
-    prost_build::Config::new()
-        .btree_map(&["."])
+    config
         .compile_protos(
             &[
                 test_includes.join("test_messages_proto2.proto"),

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -107,7 +107,6 @@ fn main() {
 }
 
 fn download_tarball(url: &str, out_dir: &Path) {
-    println!("downloading `{}` ...", url);
     let mut data = Vec::new();
     let mut handle = Easy::new();
 
@@ -129,7 +128,6 @@ fn download_tarball(url: &str, out_dir: &Path) {
     Archive::new(GzDecoder::new(Cursor::new(data)))
         .unpack(out_dir)
         .expect("failed to unpack tarball");
-    println!("download complete");
 }
 
 /// Downloads and unpacks a Protobuf release tarball to the provided directory.

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -21,7 +21,7 @@ static TEST_PROTOS: &[&str] = &[
     "test_messages_proto3.proto",
     "unittest.proto",
     "unittest_import.proto",
-    "unittest_import_public.proto"
+    "unittest_import_public.proto",
 ];
 
 static DATASET_PROTOS: &[&str] = &[
@@ -44,7 +44,8 @@ static DATASET_PROTOS: &[&str] = &[
 ];
 
 fn main() {
-    let out_dir = &PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"));
+    let out_dir =
+        &PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"));
     let protobuf_dir = &out_dir.join(format!("protobuf-{}", VERSION));
 
     if !protobuf_dir.exists() {
@@ -66,12 +67,20 @@ fn main() {
     let benchmarks_include_dir = &include_dir.join("benchmarks");
     let datasets_include_dir = &benchmarks_include_dir.join("datasets");
     let mut benchmark_protos = vec![benchmarks_include_dir.join("benchmarks.proto")];
-    benchmark_protos.extend(DATASET_PROTOS.iter().map(|proto| datasets_include_dir.join(proto)));
-    prost_build::compile_protos(&benchmark_protos, &[benchmarks_include_dir.to_path_buf()]).unwrap();
+    benchmark_protos.extend(
+        DATASET_PROTOS
+            .iter()
+            .map(|proto| datasets_include_dir.join(proto)),
+    );
+    prost_build::compile_protos(&benchmark_protos, &[benchmarks_include_dir.to_path_buf()])
+        .unwrap();
 
     let conformance_include_dir = include_dir.join("conformance");
-    prost_build::compile_protos(&[conformance_include_dir.join("conformance.proto")],
-                                &[conformance_include_dir]).unwrap();
+    prost_build::compile_protos(
+        &[conformance_include_dir.join("conformance.proto")],
+        &[conformance_include_dir],
+    )
+    .unwrap();
 
     let test_includes = &include_dir.join("google").join("protobuf");
 
@@ -84,11 +93,15 @@ fn main() {
 
     prost_build::Config::new()
         .btree_map(&["."])
-        .compile_protos(&[
-            test_includes.join("test_messages_proto2.proto"),
-            test_includes.join("test_messages_proto3.proto"),
-            test_includes.join("unittest.proto"),
-        ], &[include_dir.to_path_buf()]).unwrap();
+        .compile_protos(
+            &[
+                test_includes.join("test_messages_proto2.proto"),
+                test_includes.join("test_messages_proto3.proto"),
+                test_includes.join("unittest.proto"),
+            ],
+            &[include_dir.to_path_buf()],
+        )
+        .unwrap();
 
     // Emit an environment variable with the path to the build so that it can be located in the
     // main crate.
@@ -101,25 +114,35 @@ fn download_tarball(url: &str, out_dir: &Path) {
     let mut handle = Easy::new();
 
     handle.url(url).expect("failed to configure tarball URL");
-    handle.follow_location(true).expect("failed to configure follow location");
+    handle
+        .follow_location(true)
+        .expect("failed to configure follow location");
     {
         let mut transfer = handle.transfer();
-        transfer.write_function(|new_data| {
-            data.extend_from_slice(new_data);
-            Ok(new_data.len())
-        }).expect("failed to write download data");
+        transfer
+            .write_function(|new_data| {
+                data.extend_from_slice(new_data);
+                Ok(new_data.len())
+            })
+            .expect("failed to write download data");
         transfer.perform().expect("failed to download tarball");
     }
 
     Archive::new(GzDecoder::new(Cursor::new(data)))
-            .unpack(out_dir).expect("failed to unpack tarball");
+        .unpack(out_dir)
+        .expect("failed to unpack tarball");
     println!("download complete");
 }
 
 /// Downloads and unpacks a Protobuf release tarball to the provided directory.
 fn download_protobuf(out_dir: &Path) -> PathBuf {
-    download_tarball(&format!("https://github.com/google/protobuf/archive/v{}.tar.gz", VERSION),
-                     out_dir);
+    download_tarball(
+        &format!(
+            "https://github.com/google/protobuf/archive/v{}.tar.gz",
+            VERSION
+        ),
+        out_dir,
+    );
     out_dir.join(format!("protobuf-{}", VERSION))
 }
 
@@ -128,35 +151,38 @@ fn install_conformance_test_runner(src_dir: &Path, prefix_dir: &Path) {
     {
         // Build and install protoc, the protobuf libraries, and the conformance test runner.
         let rc = Command::new("./autogen.sh")
-                        .current_dir(&src_dir)
-                        .status()
-                        .expect("failed to execute autogen.sh");
+            .current_dir(&src_dir)
+            .status()
+            .expect("failed to execute autogen.sh");
         assert!(rc.success(), "protobuf autogen.sh failed");
 
         let num_jobs = env::var("NUM_JOBS").expect("NUM_JOBS environment variable not set");
 
         let rc = Command::new("./configure")
-                        .arg("--disable-shared")
-                        .arg("--prefix").arg(&prefix_dir)
-                        .current_dir(&src_dir)
-                        .status()
-                        .expect("failed to execute configure");
+            .arg("--disable-shared")
+            .arg("--prefix")
+            .arg(&prefix_dir)
+            .current_dir(&src_dir)
+            .status()
+            .expect("failed to execute configure");
         assert!(rc.success(), "failed to configure protobuf");
 
         let rc = Command::new("make")
-                        .arg("-j").arg(&num_jobs)
-                        .arg("install")
-                        .current_dir(&src_dir)
-                        .status()
-                        .expect("failed to execute make protobuf");
+            .arg("-j")
+            .arg(&num_jobs)
+            .arg("install")
+            .current_dir(&src_dir)
+            .status()
+            .expect("failed to execute make protobuf");
         assert!(rc.success(), "failed to make protobuf");
 
         let rc = Command::new("make")
-                        .arg("-j").arg(&num_jobs)
-                        .arg("install")
-                        .current_dir(src_dir.join("conformance"))
-                        .status()
-                        .expect("failed to execute make conformance");
+            .arg("-j")
+            .arg(&num_jobs)
+            .arg("install")
+            .current_dir(src_dir.join("conformance"))
+            .status()
+            .expect("failed to execute make conformance");
         assert!(rc.success(), "failed to make conformance");
     }
 }
@@ -168,51 +194,70 @@ fn install_protos(src_dir: &Path, prefix_dir: &Path) {
     let test_include_dir = &include_dir.join("google").join("protobuf");
     fs::create_dir_all(test_include_dir).expect("failed to create test include directory");
     for proto in TEST_PROTOS {
-        fs::rename(src_dir.join("src").join("google").join("protobuf").join(proto),
-                   test_include_dir.join(proto))
-            .expect(&format!("failed to move {}", proto));
+        fs::rename(
+            src_dir
+                .join("src")
+                .join("google")
+                .join("protobuf")
+                .join(proto),
+            test_include_dir.join(proto),
+        )
+        .expect(&format!("failed to move {}", proto));
     }
 
     // Move conformance.proto to the install directory.
     let conformance_include_dir = &include_dir.join("conformance");
     fs::create_dir(conformance_include_dir)
         .expect("failed to create conformance include directory");
-    fs::rename(src_dir.join("conformance").join("conformance.proto"),
-               conformance_include_dir.join("conformance.proto"))
-        .expect("failed to move conformance.proto");
+    fs::rename(
+        src_dir.join("conformance").join("conformance.proto"),
+        conformance_include_dir.join("conformance.proto"),
+    )
+    .expect("failed to move conformance.proto");
 
     // Move the benchmark datasets to the install directory.
     let benchmarks_src_dir = &src_dir.join("benchmarks");
     let benchmarks_include_dir = &include_dir.join("benchmarks");
     let datasets_src_dir = &benchmarks_src_dir.join("datasets");
     let datasets_include_dir = &benchmarks_include_dir.join("datasets");
-    fs::create_dir(benchmarks_include_dir)
-        .expect("failed to create benchmarks include directory");
-    fs::rename(benchmarks_src_dir.join("benchmarks.proto"),
-               benchmarks_include_dir.join("benchmarks.proto"))
-        .expect("failed to move benchmarks.proto");
+    fs::create_dir(benchmarks_include_dir).expect("failed to create benchmarks include directory");
+    fs::rename(
+        benchmarks_src_dir.join("benchmarks.proto"),
+        benchmarks_include_dir.join("benchmarks.proto"),
+    )
+    .expect("failed to move benchmarks.proto");
     for proto in DATASET_PROTOS.iter().map(Path::new) {
         let dir = &datasets_include_dir.join(proto.parent().unwrap());
         fs::create_dir_all(dir).expect(&format!("unable to create directory {}", dir.display()));
-        fs::rename(datasets_src_dir.join(proto), datasets_include_dir.join(proto))
-            .expect(&format!("failed to move {}", proto.display()));
+        fs::rename(
+            datasets_src_dir.join(proto),
+            datasets_include_dir.join(proto),
+        )
+        .expect(&format!("failed to move {}", proto.display()));
     }
 }
 
 fn install_datasets(src_dir: &Path, prefix_dir: &Path) {
     let share_dir = &prefix_dir.join("share");
-    fs::create_dir(share_dir)
-        .expect("failed to create share directory");
+    fs::create_dir(share_dir).expect("failed to create share directory");
     for dataset in &[
-        Path::new("google_message1").join("proto2").join("dataset.google_message1_proto2.pb"),
-        Path::new("google_message1").join("proto3").join("dataset.google_message1_proto3.pb"),
+        Path::new("google_message1")
+            .join("proto2")
+            .join("dataset.google_message1_proto2.pb"),
+        Path::new("google_message1")
+            .join("proto3")
+            .join("dataset.google_message1_proto3.pb"),
         Path::new("google_message2").join("dataset.google_message2.pb"),
     ] {
-        fs::rename(src_dir.join("benchmarks").join("datasets").join(dataset),
-                   share_dir.join(dataset.file_name().unwrap()))
-            .expect(&format!("failed to move {}", dataset.display()));
-    };
+        fs::rename(
+            src_dir.join("benchmarks").join("datasets").join(dataset),
+            share_dir.join(dataset.file_name().unwrap()),
+        )
+        .expect(&format!("failed to move {}", dataset.display()));
+    }
 
-    download_tarball("https://storage.googleapis.com/protobuf_opensource_benchmark_data/datasets.tar.gz",
-                     share_dir);
+    download_tarball(
+        "https://storage.googleapis.com/protobuf_opensource_benchmark_data/datasets.tar.gz",
+        share_dir,
+    );
 }

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -1,8 +1,6 @@
-extern crate curl;
-extern crate flate2;
-extern crate prost_build;
-extern crate tar;
-extern crate tempfile;
+use prost_build;
+
+use tempfile;
 
 use std::env;
 use std::fs;

--- a/protobuf/src/lib.rs
+++ b/protobuf/src/lib.rs
@@ -1,6 +1,6 @@
-extern crate bytes;
-extern crate prost;
-extern crate prost_types;
+
+
+
 
 #[macro_use] extern crate prost_derive;
 

--- a/protobuf/src/lib.rs
+++ b/protobuf/src/lib.rs
@@ -1,8 +1,5 @@
-
-
-
-
-#[macro_use] extern crate prost_derive;
+#[macro_use]
+extern crate prost_derive;
 
 pub mod benchmarks {
     include!(concat!(env!("OUT_DIR"), "/benchmarks.rs"));
@@ -11,15 +8,42 @@ pub mod benchmarks {
 
     pub fn datasets() -> Vec<&'static Path> {
         vec![
-            Path::new(concat!(env!("PROTOBUF"), "/share/dataset.google_message1_proto2.pb")),
-            Path::new(concat!(env!("PROTOBUF"), "/share/dataset.google_message1_proto3.pb")),
-            Path::new(concat!(env!("PROTOBUF"), "/share/dataset.google_message2.pb")),
-            Path::new(concat!(env!("PROTOBUF"), "/share/dataset.google_message3_1.pb")),
-            Path::new(concat!(env!("PROTOBUF"), "/share/dataset.google_message3_2.pb")),
-            Path::new(concat!(env!("PROTOBUF"), "/share/dataset.google_message3_3.pb")),
-            Path::new(concat!(env!("PROTOBUF"), "/share/dataset.google_message3_4.pb")),
-            Path::new(concat!(env!("PROTOBUF"), "/share/dataset.google_message3_5.pb")),
-            Path::new(concat!(env!("PROTOBUF"), "/share/dataset.google_message4.pb")),
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message1_proto2.pb"
+            )),
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message1_proto3.pb"
+            )),
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message2.pb"
+            )),
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message3_1.pb"
+            )),
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message3_2.pb"
+            )),
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message3_3.pb"
+            )),
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message3_4.pb"
+            )),
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message3_5.pb"
+            )),
+            Path::new(concat!(
+                env!("PROTOBUF"),
+                "/share/dataset.google_message4.pb"
+            )),
         ]
     }
 
@@ -49,10 +73,16 @@ pub mod conformance {
 
 pub mod test_messages {
     pub mod proto2 {
-        include!(concat!(env!("OUT_DIR"), "/protobuf_test_messages.proto2.rs"));
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/protobuf_test_messages.proto2.rs"
+        ));
     }
     pub mod proto3 {
-        include!(concat!(env!("OUT_DIR"), "/protobuf_test_messages.proto3.rs"));
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/protobuf_test_messages.proto3.rs"
+        ));
     }
     pub mod protobuf_unittest {
         include!(concat!(env!("OUT_DIR"), "/protobuf_unittest.rs"));

--- a/protobuf/src/lib.rs
+++ b/protobuf/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate prost_derive;
-
 pub mod benchmarks {
     include!(concat!(env!("OUT_DIR"), "/benchmarks.rs"));
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -435,7 +435,7 @@ macro_rules! varint {
 
             #[cfg(test)]
             mod test {
-                use quickcheck::TestResult;
+                use quickcheck::{quickcheck, TestResult};
 
                 use crate::encoding::$proto_ty::*;
                 use crate::encoding::test::{
@@ -566,7 +566,7 @@ macro_rules! fixed_width {
 
             #[cfg(test)]
             mod test {
-                use quickcheck::TestResult;
+                use quickcheck::{quickcheck, TestResult};
 
                 use super::super::test::{check_collection_type, check_type};
                 use super::*;
@@ -676,7 +676,7 @@ macro_rules! length_delimited {
 
         #[cfg(test)]
         mod test {
-            use quickcheck::TestResult;
+            use quickcheck::{quickcheck, TestResult};
 
             use super::super::test::{check_collection_type, check_type};
             use super::*;
@@ -1304,7 +1304,7 @@ mod test {
             $(
                 mod $key_proto {
                     use std::collections::$map_type;
-                    use quickcheck::TestResult;
+                    use quickcheck::{quickcheck, TestResult};
 
                     use crate::encoding::*;
                     use crate::encoding::test::check_collection_type;

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -7,13 +7,13 @@ use std::str;
 use std::u32;
 use std::usize;
 
-use bytes::{
+use ::bytes::{
     Buf,
     BufMut,
 };
 
-use DecodeError;
-use Message;
+use crate::DecodeError;
+use crate::Message;
 
 /// Encodes an integer value into LEB128 variable length format, and writes it to the buffer.
 /// The buffer must have enough remaining space (maximum 10 bytes).
@@ -311,7 +311,7 @@ macro_rules! varint {
      from_uint64($from_uint64_value:ident) $from_uint64:expr) => (
 
          pub mod $proto_ty {
-            use ::encoding::*;
+            use crate::encoding::*;
 
             pub fn encode<B>(tag: u32, $to_uint64_value: &$ty, buf: &mut B) where B: BufMut {
                 encode_key(tag, WireType::Varint, buf);
@@ -371,8 +371,8 @@ macro_rules! varint {
             mod test {
                 use quickcheck::TestResult;
 
-                use ::encoding::$proto_ty::*;
-                use ::encoding::test::{
+                use crate::encoding::$proto_ty::*;
+                use crate::encoding::test::{
                     check_collection_type,
                     check_type,
                 };
@@ -431,7 +431,7 @@ macro_rules! fixed_width {
      $put:ident,
      $get:ident) => (
         pub mod $proto_ty {
-            use ::encoding::*;
+            use crate::encoding::*;
 
             pub fn encode<B>(tag: u32, value: &$ty, buf: &mut B) where B: BufMut {
                 encode_key(tag, $wire_type, buf);
@@ -693,7 +693,7 @@ macro_rules! map {
         use std::collections::$map_ty;
         use std::hash::Hash;
 
-        use ::encoding::*;
+        use crate::encoding::*;
 
         /// Generic protobuf map encode function.
         pub fn encode<K, V, B, KE, KL, VE, VL>(key_encode: KE,
@@ -847,10 +847,10 @@ mod test {
     use std::io::Cursor;
     use std::u64;
 
-    use bytes::{Bytes, BytesMut, IntoBuf};
+    use ::bytes::{Bytes, BytesMut, IntoBuf};
     use quickcheck::TestResult;
 
-    use ::encoding::*;
+    use crate::encoding::*;
 
     pub fn check_type<T, B>(value: T,
                             tag: u32,
@@ -1071,8 +1071,8 @@ mod test {
                     use std::collections::$map_type;
                     use quickcheck::TestResult;
 
-                    use ::encoding::*;
-                    use ::encoding::test::check_collection_type;
+                    use crate::encoding::*;
+                    use crate::encoding::test::check_collection_type;
 
                     map_tests!(@private $map_type, $mod_name, ($key_ty, $key_proto), $vals);
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,12 +21,14 @@ pub struct DecodeError {
 }
 
 impl DecodeError {
-
     /// Creates a new `DecodeError` with a 'best effort' root cause description.
     ///
     /// Meant to be used only by `Message` implementations.
     #[doc(hidden)]
-    pub fn new<S>(description: S) -> DecodeError where S: Into<Cow<'static, str>> {
+    pub fn new<S>(description: S) -> DecodeError
+    where
+        S: Into<Cow<'static, str>>,
+    {
         DecodeError {
             description: description.into(),
             stack: Vec::new(),
@@ -76,7 +78,6 @@ pub struct EncodeError {
 }
 
 impl EncodeError {
-
     /// Creates a new `EncodeError`.
     pub(crate) fn new(required: usize, remaining: usize) -> EncodeError {
         EncodeError {
@@ -99,7 +100,11 @@ impl EncodeError {
 impl fmt::Display for EncodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(error::Error::description(self))?;
-        write!(f, " (required: {}, remaining: {})", self.required, self.remaining)
+        write!(
+            f,
+            " (required: {}, remaining: {})",
+            self.required, self.remaining
+        )
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ impl DecodeError {
 }
 
 impl fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("failed to decode Protobuf message: ")?;
         for &(message, field) in &self.stack {
             write!(f, "{}.{}: ", message, field)?;
@@ -97,7 +97,7 @@ impl EncodeError {
 }
 
 impl fmt::Display for EncodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(error::Error::description(self))?;
         write!(f, " (required: {}, remaining: {})", self.required, self.remaining)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/prost/0.4.0")]
 
-#[cfg(test)]
-#[macro_use]
-extern crate quickcheck;
-
 mod error;
 mod message;
 mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/prost/0.5.0")]
 
 mod error;
 mod message;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/prost/0.4.0")]
 
-extern crate bytes;
+
 
 #[cfg(test)]
 #[macro_use]
@@ -13,15 +13,15 @@ mod types;
 #[doc(hidden)]
 pub mod encoding;
 
-pub use message::Message;
-pub use error::{DecodeError, EncodeError};
+pub use crate::message::Message;
+pub use crate::error::{DecodeError, EncodeError};
 
 use bytes::{
     BufMut,
     IntoBuf,
 };
 
-use encoding::{
+use crate::encoding::{
     decode_varint,
     encode_varint,
     encoded_len_varint,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/prost/0.4.0")]
 
-
-
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
@@ -13,19 +11,12 @@ mod types;
 #[doc(hidden)]
 pub mod encoding;
 
-pub use crate::message::Message;
 pub use crate::error::{DecodeError, EncodeError};
+pub use crate::message::Message;
 
-use bytes::{
-    BufMut,
-    IntoBuf,
-};
+use bytes::{BufMut, IntoBuf};
 
-use crate::encoding::{
-    decode_varint,
-    encode_varint,
-    encoded_len_varint,
-};
+use crate::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
 /// Encodes a length delimiter to the buffer.
 ///
@@ -33,7 +24,10 @@ use crate::encoding::{
 ///
 /// An error will be returned if the buffer does not have sufficient capacity to encode the
 /// delimiter.
-pub fn encode_length_delimiter<B>(length: usize, buf: &mut B) -> Result<(), EncodeError> where B: BufMut {
+pub fn encode_length_delimiter<B>(length: usize, buf: &mut B) -> Result<(), EncodeError>
+where
+    B: BufMut,
+{
     let length = length as u64;
     let required = encoded_len_varint(length);
     let remaining = buf.remaining_mut();
@@ -63,11 +57,16 @@ pub fn length_delimiter_len(length: usize) -> usize {
 ///    input is required to decode the full delimiter.
 ///  * If the supplied buffer contains more than 10 bytes, then the buffer contains an invalid
 ///    delimiter, and typically the buffer should be considered corrupt.
-pub fn decode_length_delimiter<B>(buf: B) -> Result<usize, DecodeError> where B: IntoBuf {
+pub fn decode_length_delimiter<B>(buf: B) -> Result<usize, DecodeError>
+where
+    B: IntoBuf,
+{
     let mut buf = buf.into_buf();
     let length = decode_varint(&mut buf)?;
     if length > usize::max_value() as u64 {
-        return Err(DecodeError::new("length delimiter exceeds maximum usize value"));
+        return Err(DecodeError::new(
+            "length delimiter exceeds maximum usize value",
+        ));
     }
     Ok(length as usize)
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,26 +3,31 @@ use std::usize;
 
 use ::bytes::{Buf, BufMut, IntoBuf};
 
+use crate::encoding::*;
 use crate::DecodeError;
 use crate::EncodeError;
-use crate::encoding::*;
 
 /// A Protocol Buffers message.
 pub trait Message: Debug + Send + Sync {
-
     /// Encodes the message to a buffer.
     ///
     /// This method will panic if the buffer has insufficient capacity.
     ///
     /// Meant to be used only by `Message` implementations.
     #[doc(hidden)]
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut, Self: Sized;
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+        Self: Sized;
 
     /// Decodes a field from a buffer, and merges it into `self`.
     ///
     /// Meant to be used only by `Message` implementations.
     #[doc(hidden)]
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf, Self: Sized;
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+        Self: Sized;
 
     /// Returns the encoded length of the message without a length delimiter.
     fn encoded_len(&self) -> usize;
@@ -30,7 +35,11 @@ pub trait Message: Debug + Send + Sync {
     /// Encodes the message to a buffer.
     ///
     /// An error will be returned if the buffer does not have sufficient capacity.
-    fn encode<B>(&self, buf: &mut B) -> Result<(), EncodeError> where B: BufMut, Self: Sized {
+    fn encode<B>(&self, buf: &mut B) -> Result<(), EncodeError>
+    where
+        B: BufMut,
+        Self: Sized,
+    {
         let required = self.encoded_len();
         let remaining = buf.remaining_mut();
         if required > buf.remaining_mut() {
@@ -44,7 +53,11 @@ pub trait Message: Debug + Send + Sync {
     /// Encodes the message with a length-delimiter to a buffer.
     ///
     /// An error will be returned if the buffer does not have sufficient capacity.
-    fn encode_length_delimited<B>(&self, buf: &mut B) -> Result<(), EncodeError> where B: BufMut, Self: Sized {
+    fn encode_length_delimited<B>(&self, buf: &mut B) -> Result<(), EncodeError>
+    where
+        B: BufMut,
+        Self: Sized,
+    {
         let len = self.encoded_len();
         let required = len + encoded_len_varint(len as u64);
         let remaining = buf.remaining_mut();
@@ -59,13 +72,21 @@ pub trait Message: Debug + Send + Sync {
     /// Decodes an instance of the message from a buffer.
     ///
     /// The entire buffer will be consumed.
-    fn decode<B>(buf: B) -> Result<Self, DecodeError> where B: IntoBuf, Self: Default {
+    fn decode<B>(buf: B) -> Result<Self, DecodeError>
+    where
+        B: IntoBuf,
+        Self: Default,
+    {
         let mut message = Self::default();
         Self::merge(&mut message, &mut buf.into_buf()).map(|_| message)
     }
 
     /// Decodes a length-delimited instance of the message from the buffer.
-    fn decode_length_delimited<B>(buf: B) -> Result<Self, DecodeError> where B: IntoBuf, Self: Default {
+    fn decode_length_delimited<B>(buf: B) -> Result<Self, DecodeError>
+    where
+        B: IntoBuf,
+        Self: Default,
+    {
         let mut message = Self::default();
         message.merge_length_delimited(buf)?;
         Ok(message)
@@ -74,7 +95,11 @@ pub trait Message: Debug + Send + Sync {
     /// Decodes an instance of the message from a buffer, and merges it into `self`.
     ///
     /// The entire buffer will be consumed.
-    fn merge<B>(&mut self, buf: B) -> Result<(), DecodeError> where B: IntoBuf, Self: Sized {
+    fn merge<B>(&mut self, buf: B) -> Result<(), DecodeError>
+    where
+        B: IntoBuf,
+        Self: Sized,
+    {
         let mut buf = buf.into_buf();
         while buf.has_remaining() {
             self.merge_field(&mut buf)?;
@@ -84,7 +109,11 @@ pub trait Message: Debug + Send + Sync {
 
     /// Decodes a length-delimited instance of the message from buffer, and
     /// merges it into `self`.
-    fn merge_length_delimited<B>(&mut self, buf: B) -> Result<(), DecodeError> where B: IntoBuf, Self: Sized {
+    fn merge_length_delimited<B>(&mut self, buf: B) -> Result<(), DecodeError>
+    where
+        B: IntoBuf,
+        Self: Sized,
+    {
         message::merge(WireType::LengthDelimited, self, &mut buf.into_buf())
     }
 
@@ -92,11 +121,20 @@ pub trait Message: Debug + Send + Sync {
     fn clear(&mut self);
 }
 
-impl <M> Message for Box<M> where M: Message {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+impl<M> Message for Box<M>
+where
+    M: Message,
+{
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         (**self).encode_raw(buf)
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         (**self).merge_field(buf)
     }
     fn encoded_len(&self) -> usize {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 use std::usize;
 
-use bytes::{Buf, BufMut, IntoBuf};
+use ::bytes::{Buf, BufMut, IntoBuf};
 
-use DecodeError;
-use EncodeError;
-use encoding::*;
+use crate::DecodeError;
+use crate::EncodeError;
+use crate::encoding::*;
 
 /// A Protocol Buffers message.
 pub trait Message: Debug + Send + Sync {

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,11 +5,11 @@
 //! the `prost-types` crate in order to avoid a cyclic dependency between `prost` and
 //! `prost-build`.
 
-use bytes::{Buf, BufMut};
+use ::bytes::{Buf, BufMut};
 
-use DecodeError;
-use Message;
-use encoding::*;
+use crate::DecodeError;
+use crate::Message;
+use crate::encoding::*;
 
 /// `google.protobuf.BoolValue`
 impl Message for bool {

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,18 +7,24 @@
 
 use ::bytes::{Buf, BufMut};
 
+use crate::encoding::*;
 use crate::DecodeError;
 use crate::Message;
-use crate::encoding::*;
 
 /// `google.protobuf.BoolValue`
 impl Message for bool {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self {
             bool::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             bool::merge(wire_type, self, buf)
@@ -27,7 +33,11 @@ impl Message for bool {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self { 2 } else { 0 }
+        if *self {
+            2
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = false;
@@ -36,12 +46,18 @@ impl Message for bool {
 
 /// `google.protobuf.UInt32Value`
 impl Message for u32 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             uint32::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             uint32::merge(wire_type, self, buf)
@@ -50,7 +66,11 @@ impl Message for u32 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0 { uint32::encoded_len(1, self) } else { 0 }
+        if *self != 0 {
+            uint32::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0;
@@ -59,12 +79,18 @@ impl Message for u32 {
 
 /// `google.protobuf.UInt64Value`
 impl Message for u64 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             uint64::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             uint64::merge(wire_type, self, buf)
@@ -73,7 +99,11 @@ impl Message for u64 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0 { uint64::encoded_len(1, self) } else { 0 }
+        if *self != 0 {
+            uint64::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0;
@@ -82,12 +112,18 @@ impl Message for u64 {
 
 /// `google.protobuf.Int32Value`
 impl Message for i32 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             int32::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             int32::merge(wire_type, self, buf)
@@ -96,7 +132,11 @@ impl Message for i32 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0 { int32::encoded_len(1, self) } else { 0 }
+        if *self != 0 {
+            int32::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0;
@@ -105,12 +145,18 @@ impl Message for i32 {
 
 /// `google.protobuf.Int64Value`
 impl Message for i64 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             int64::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             int64::merge(wire_type, self, buf)
@@ -119,7 +165,11 @@ impl Message for i64 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0 { int64::encoded_len(1, self) } else { 0 }
+        if *self != 0 {
+            int64::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0;
@@ -128,12 +178,18 @@ impl Message for i64 {
 
 /// `google.protobuf.FloatValue`
 impl Message for f32 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0.0 {
             float::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             float::merge(wire_type, self, buf)
@@ -142,7 +198,11 @@ impl Message for f32 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0.0 { float::encoded_len(1, self) } else { 0 }
+        if *self != 0.0 {
+            float::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0.0;
@@ -151,12 +211,18 @@ impl Message for f32 {
 
 /// `google.protobuf.DoubleValue`
 impl Message for f64 {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0.0 {
             double::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             double::merge(wire_type, self, buf)
@@ -165,7 +231,11 @@ impl Message for f64 {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self != 0.0 { double::encoded_len(1, self) } else { 0 }
+        if *self != 0.0 {
+            double::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         *self = 0.0;
@@ -174,12 +244,18 @@ impl Message for f64 {
 
 /// `google.protobuf.StringValue`
 impl Message for String {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if !self.is_empty() {
             string::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             string::merge(wire_type, self, buf)
@@ -188,7 +264,11 @@ impl Message for String {
         }
     }
     fn encoded_len(&self) -> usize {
-        if !self.is_empty() { string::encoded_len(1, self) } else { 0 }
+        if !self.is_empty() {
+            string::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         self.clear();
@@ -197,12 +277,18 @@ impl Message for String {
 
 /// `google.protobuf.BytesValue`
 impl Message for Vec<u8> {
-    fn encode_raw<B>(&self, buf: &mut B) where B: BufMut {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if !self.is_empty() {
             bytes::encode(1, self, buf)
         }
     }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (tag, wire_type) = decode_key(buf)?;
         if tag == 1 {
             bytes::merge(wire_type, self, buf)
@@ -211,7 +297,11 @@ impl Message for Vec<u8> {
         }
     }
     fn encoded_len(&self) -> usize {
-        if !self.is_empty() { bytes::encoded_len(1, self) } else { 0 }
+        if !self.is_empty() {
+            bytes::encoded_len(1, self)
+        } else {
+            0
+        }
     }
     fn clear(&mut self) {
         self.clear();
@@ -220,11 +310,20 @@ impl Message for Vec<u8> {
 
 /// `google.protobuf.Empty`
 impl Message for () {
-    fn encode_raw<B>(&self, _buf: &mut B) where B: BufMut { }
-    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError> where B: Buf {
+    fn encode_raw<B>(&self, _buf: &mut B)
+    where
+        B: BufMut,
+    {
+    }
+    fn merge_field<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
         let (_, wire_type) = decode_key(buf)?;
         skip_field(wire_type, buf)
     }
-    fn encoded_len(&self) -> usize { 0 }
-    fn clear(&mut self) { }
+    fn encoded_len(&self) -> usize {
+        0
+    }
+    fn clear(&mut self) {}
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,10 +23,10 @@ protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
 diff = "0.1"
-prost-build = { path = "../prost-build" }
+prost-build = { path = "../prost-build", features = ["build-2018"] }
 tempfile = "3"
 
 [build-dependencies]
 env_logger = { version = "0.5", default-features = false }
-prost-build = { path = "../prost-build" }
+prost-build = { path = "../prost-build", features = ["build-2018"] }
 protobuf = { path = "../protobuf" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -3,6 +3,7 @@ name = "tests"
 version = "0.0.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 publish = false
+edition = "2018"
 
 # Cargo treats the tests/ directory as an integration-tests folder[1], so to
 # avoid Cargo executing the build.rs as an integration test, move it into a

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,10 +23,10 @@ protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
 diff = "0.1"
-prost-build = { path = "../prost-build", features = ["build-2018"] }
+prost-build = { path = "../prost-build" }
 tempfile = "3"
 
 [build-dependencies]
 env_logger = { version = "0.5", default-features = false }
-prost-build = { path = "../prost-build", features = ["build-2018"] }
+prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -3,14 +3,17 @@ use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 
-use tempfile;
 use prost_build;
+use tempfile;
+use tempdir;
 
 /// Test which bootstraps protobuf.rs and compiler.rs from the .proto definitions in the Protobuf
 /// repo. Ensures that the checked-in compiled versions are up-to-date.
 #[test]
 fn bootstrap() {
-    let protobuf = Path::new(prost_build::protoc_include()).join("google").join("protobuf");
+    let protobuf = Path::new(prost_build::protoc_include())
+        .join("google")
+        .join("protobuf");
 
     let tempdir = tempfile::Builder::new()
         .prefix("prost-types-bootstrap")
@@ -21,47 +24,68 @@ fn bootstrap() {
     config.compile_well_known_types();
     config.btree_map(&["."]);
     config.out_dir(tempdir.path());
-    config.compile_protos(&[
-                            // Protobuf Plugins.
-                            protobuf.join("descriptor.proto"),
-                            protobuf.join("compiler").join("plugin.proto"),
-                            // Well-known Types (except wrapper.proto, whose types are substituted
-                            // for the corresponding standard library types).
-                            protobuf.join("any.proto"),
-                            protobuf.join("api.proto"),
-                            protobuf.join("duration.proto"),
-                            protobuf.join("field_mask.proto"),
-                            protobuf.join("source_context.proto"),
-                            protobuf.join("struct.proto"),
-                            protobuf.join("timestamp.proto"),
-                            protobuf.join("type.proto"),
-                          ], &[]).unwrap();
+    config
+        .compile_protos(
+            &[
+                // Protobuf Plugins.
+                protobuf.join("descriptor.proto"),
+                protobuf.join("compiler").join("plugin.proto"),
+                // Well-known Types (except wrapper.proto, whose types are substituted
+                // for the corresponding standard library types).
+                protobuf.join("any.proto"),
+                protobuf.join("api.proto"),
+                protobuf.join("duration.proto"),
+                protobuf.join("field_mask.proto"),
+                protobuf.join("source_context.proto"),
+                protobuf.join("struct.proto"),
+                protobuf.join("timestamp.proto"),
+                protobuf.join("type.proto"),
+            ],
+            &[],
+        )
+        .unwrap();
 
     let mut bootstrapped_protobuf = String::new();
-    fs::File::open(tempdir.path().join("google.protobuf.rs")).unwrap()
-             .read_to_string(&mut bootstrapped_protobuf).unwrap();
+    fs::File::open(tempdir.path().join("google.protobuf.rs"))
+        .unwrap()
+        .read_to_string(&mut bootstrapped_protobuf)
+        .unwrap();
 
     let mut bootstrapped_compiler = String::new();
-    fs::File::open(tempdir.path().join("google.protobuf.compiler.rs")).unwrap()
-             .read_to_string(&mut bootstrapped_compiler).unwrap();
+    fs::File::open(tempdir.path().join("google.protobuf.compiler.rs"))
+        .unwrap()
+        .read_to_string(&mut bootstrapped_compiler)
+        .unwrap();
 
-    let src = Path::new(env!("CARGO_MANIFEST_DIR")).parent().expect("no parent").join("prost-types").join("src");
+    let src = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("no parent")
+        .join("prost-types")
+        .join("src");
 
     let mut protobuf = String::new();
-    fs::File::open(src.join("protobuf.rs")).unwrap()
-             .read_to_string(&mut protobuf).unwrap();
+    fs::File::open(src.join("protobuf.rs"))
+        .unwrap()
+        .read_to_string(&mut protobuf)
+        .unwrap();
 
     let mut compiler = String::new();
-    fs::File::open(src.join("compiler.rs")).unwrap()
-             .read_to_string(&mut compiler).unwrap();
+    fs::File::open(src.join("compiler.rs"))
+        .unwrap()
+        .read_to_string(&mut compiler)
+        .unwrap();
 
     if protobuf != bootstrapped_protobuf {
-        fs::File::create(src.join("protobuf.rs")).unwrap()
-                 .write_all(bootstrapped_protobuf.as_bytes()).unwrap();
+        fs::File::create(src.join("protobuf.rs"))
+            .unwrap()
+            .write_all(bootstrapped_protobuf.as_bytes())
+            .unwrap();
     }
     if compiler != bootstrapped_compiler {
-        fs::File::create(src.join("compiler.rs")).unwrap()
-                 .write_all(bootstrapped_compiler.as_bytes()).unwrap();
+        fs::File::create(src.join("compiler.rs"))
+            .unwrap()
+            .write_all(bootstrapped_compiler.as_bytes())
+            .unwrap();
     }
 
     assert_eq!(protobuf, bootstrapped_protobuf);

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -4,8 +4,8 @@ use std::io::Write;
 use std::path::Path;
 
 use prost_build;
-use tempfile;
 use tempdir;
+use tempfile;
 
 /// Test which bootstraps protobuf.rs and compiler.rs from the .proto definitions in the Protobuf
 /// repo. Ensures that the checked-in compiled versions are up-to-date.

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -4,7 +4,6 @@ use std::io::Write;
 use std::path::Path;
 
 use prost_build;
-use tempdir;
 use tempfile;
 
 /// Test which bootstraps protobuf.rs and compiler.rs from the .proto definitions in the Protobuf

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -23,6 +23,7 @@ fn bootstrap() {
     config.compile_well_known_types();
     config.btree_map(&["."]);
     config.out_dir(tempdir.path());
+    config.edition(prost_build::Edition::Rust2018);
     config
         .compile_protos(
             &[

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -13,6 +13,7 @@ fn main() {
     // compare based on the Rust PartialEq implementations is difficult, due to presence of NaN
     // values.
     let mut prost_build = prost_build::Config::new();
+    prost_build.edition(prost_build::Edition::Rust2018);
     prost_build.btree_map(&["."]);
     // Tests for custom attributes
     prost_build.type_attribute("Foo.Bar_Baz.Foo_barBaz", "#[derive(Eq, PartialOrd, Ord)]");

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -1,6 +1,6 @@
-extern crate env_logger;
-extern crate prost_build;
-extern crate protobuf;
+use env_logger;
+use prost_build;
+
 
 use std::env;
 use std::fs;

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -73,7 +73,7 @@ fn main() {
 
     prost_build
         .out_dir(extern_path)
-        .extern_path(".packages.gizmo", "::packages::gizmo")
+        .extern_path(".packages.gizmo", "crate::packages::gizmo")
         .compile_protos(&["src/packages/widget_factory.proto"], &["src/packages"])
         .unwrap();
 }

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -1,7 +1,6 @@
 use env_logger;
 use prost_build;
 
-
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -17,49 +16,64 @@ fn main() {
     prost_build.btree_map(&["."]);
     // Tests for custom attributes
     prost_build.type_attribute("Foo.Bar_Baz.Foo_barBaz", "#[derive(Eq, PartialOrd, Ord)]");
-    prost_build.type_attribute("Foo.Bar_Baz.Foo_barBaz.fuzz_buster",
-                               "#[derive(Eq, PartialOrd, Ord)]");
+    prost_build.type_attribute(
+        "Foo.Bar_Baz.Foo_barBaz.fuzz_buster",
+        "#[derive(Eq, PartialOrd, Ord)]",
+    );
     prost_build.type_attribute("Foo.Custom.Attrs.Msg", "#[allow(missing_docs)]");
     prost_build.type_attribute("Foo.Custom.Attrs.Msg.field", "/// Oneof docs");
     prost_build.type_attribute("Foo.Custom.Attrs.AnEnum", "#[allow(missing_docs)]");
     prost_build.type_attribute("Foo.Custom.Attrs.AnotherEnum", "/// Oneof docs");
-    prost_build.type_attribute("Foo.Custom.OneOfAttrs.Msg.field", "#[derive(Eq, PartialOrd, Ord)]");
+    prost_build.type_attribute(
+        "Foo.Custom.OneOfAttrs.Msg.field",
+        "#[derive(Eq, PartialOrd, Ord)]",
+    );
     prost_build.field_attribute("Foo.Custom.Attrs.AnotherEnum.C", "/// The C docs");
     prost_build.field_attribute("Foo.Custom.Attrs.AnotherEnum.D", "/// The D docs");
     prost_build.field_attribute("Foo.Custom.Attrs.Msg.field.a", "/// Oneof A docs");
     prost_build.field_attribute("Foo.Custom.Attrs.Msg.field.b", "/// Oneof B docs");
 
-    prost_build.compile_protos(&["src/ident_conversion.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/ident_conversion.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/nesting.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/nesting.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/recursive_oneof.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/recursive_oneof.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/custom_attributes.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/custom_attributes.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/oneof_attributes.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/oneof_attributes.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/no_unused_results.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/no_unused_results.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/default_enum_value.proto"],
-                               &["src"]).unwrap();
+    prost_build
+        .compile_protos(&["src/default_enum_value.proto"], &["src"])
+        .unwrap();
 
-    prost_build.compile_protos(&["src/packages/widget_factory.proto"],
-                               &["src/packages"]).unwrap();
+    prost_build
+        .compile_protos(&["src/packages/widget_factory.proto"], &["src/packages"])
+        .unwrap();
 
     // Compile some of the modules examples as an extern_path.
-    let extern_path = &PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"))
-        .join("extern_paths");
+    let extern_path =
+        &PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"))
+            .join("extern_paths");
     fs::create_dir_all(extern_path).expect("failed to create prefix directory");
 
-    prost_build.out_dir(extern_path)
-               .extern_path(".packages.gizmo", "::packages::gizmo")
-               .compile_protos(&["src/packages/widget_factory.proto"],
-                               &["src/packages"]).unwrap();
+    prost_build
+        .out_dir(extern_path)
+        .extern_path(".packages.gizmo", "::packages::gizmo")
+        .compile_protos(&["src/packages/widget_factory.proto"], &["src/packages"])
+        .unwrap();
 }

--- a/tests/src/debug.rs
+++ b/tests/src/debug.rs
@@ -62,7 +62,7 @@ fn tuple_struct() {
 }
 */
 
-#[derive(Clone, PartialEq, Oneof)]
+#[derive(Clone, PartialEq, prost_derive::Oneof)]
 pub enum OneofWithEnum {
     #[prost(int32, tag = "8")]
     Int(i32),
@@ -72,7 +72,7 @@ pub enum OneofWithEnum {
     Enumeration(i32),
 }
 
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 struct MessageWithOneof {
     #[prost(oneof = "OneofWithEnum", tags = "8, 9, 10")]
     of: Option<OneofWithEnum>,

--- a/tests/src/debug.rs
+++ b/tests/src/debug.rs
@@ -10,34 +10,40 @@ use crate::message_encoding::{Basic, BasicEnumeration};
 #[test]
 fn basic() {
     let mut basic = Basic::default();
-    assert_eq!(format!("{:?}", basic),
-               "Basic { \
-                    int32: 0, \
-                    bools: [], \
-                    string: \"\", \
-                    optional_string: None, \
-                    enumeration: ZERO, \
-                    enumeration_map: {}, \
-                    string_map: {}, \
-                    enumeration_btree_map: {}, \
-                    string_btree_map: {}, \
-                    oneof: None \
-                }");
-    basic.enumeration_map.insert(0, BasicEnumeration::TWO as i32);
+    assert_eq!(
+        format!("{:?}", basic),
+        "Basic { \
+         int32: 0, \
+         bools: [], \
+         string: \"\", \
+         optional_string: None, \
+         enumeration: ZERO, \
+         enumeration_map: {}, \
+         string_map: {}, \
+         enumeration_btree_map: {}, \
+         string_btree_map: {}, \
+         oneof: None \
+         }"
+    );
+    basic
+        .enumeration_map
+        .insert(0, BasicEnumeration::TWO as i32);
     basic.enumeration = 42;
-    assert_eq!(format!("{:?}", basic),
-               "Basic { \
-                    int32: 0, \
-                    bools: [], \
-                    string: \"\", \
-                    optional_string: None, \
-                    enumeration: 42, \
-                    enumeration_map: {0: TWO}, \
-                    string_map: {}, \
-                    enumeration_btree_map: {}, \
-                    string_btree_map: {}, \
-                    oneof: None \
-                }");
+    assert_eq!(
+        format!("{:?}", basic),
+        "Basic { \
+         int32: 0, \
+         bools: [], \
+         string: \"\", \
+         optional_string: None, \
+         enumeration: 42, \
+         enumeration_map: {0: TWO}, \
+         string_map: {}, \
+         enumeration_btree_map: {}, \
+         string_btree_map: {}, \
+         oneof: None \
+         }"
+    );
 }
 
 /*
@@ -58,17 +64,17 @@ fn tuple_struct() {
 
 #[derive(Clone, PartialEq, Oneof)]
 pub enum OneofWithEnum {
-    #[prost(int32, tag="8")]
+    #[prost(int32, tag = "8")]
     Int(i32),
-    #[prost(string, tag="9")]
+    #[prost(string, tag = "9")]
     String(String),
-    #[prost(enumeration="BasicEnumeration", tag="10")]
+    #[prost(enumeration = "BasicEnumeration", tag = "10")]
     Enumeration(i32),
 }
 
 #[derive(Clone, PartialEq, Message)]
 struct MessageWithOneof {
-    #[prost(oneof="OneofWithEnum", tags="8, 9, 10")]
+    #[prost(oneof = "OneofWithEnum", tags = "8, 9, 10")]
     of: Option<OneofWithEnum>,
 }
 
@@ -76,7 +82,10 @@ struct MessageWithOneof {
 #[test]
 fn oneof_with_enum() {
     let msg = MessageWithOneof {
-        of: Some(OneofWithEnum::Enumeration(BasicEnumeration::TWO as i32))
+        of: Some(OneofWithEnum::Enumeration(BasicEnumeration::TWO as i32)),
     };
-    assert_eq!(format!("{:?}", msg), "MessageWithOneof { of: Some(Enumeration(TWO)) }");
+    assert_eq!(
+        format!("{:?}", msg),
+        "MessageWithOneof { of: Some(Enumeration(TWO)) }"
+    );
 }

--- a/tests/src/debug.rs
+++ b/tests/src/debug.rs
@@ -4,7 +4,7 @@
 //! actual use.
 
 // Borrow some types from other places.
-use ::message_encoding::{Basic, BasicEnumeration};
+use crate::message_encoding::{Basic, BasicEnumeration};
 
 /// Some real-life message
 #[test]

--- a/tests/src/extern_paths.rs
+++ b/tests/src/extern_paths.rs
@@ -11,8 +11,8 @@ pub mod widget {
 
 #[test]
 fn test() {
-    use packages::DoIt;
-    use packages::gizmo;
+    use crate::packages::DoIt;
+    use crate::packages::gizmo;
     use prost::Message;
 
     let mut widget_factory = widget::factory::WidgetFactory::default();

--- a/tests/src/extern_paths.rs
+++ b/tests/src/extern_paths.rs
@@ -5,14 +5,17 @@ include!(concat!(env!("OUT_DIR"), "/extern_paths/packages.rs"));
 pub mod widget {
     include!(concat!(env!("OUT_DIR"), "/extern_paths/packages.widget.rs"));
     pub mod factory {
-        include!(concat!(env!("OUT_DIR"), "/extern_paths/packages.widget.factory.rs"));
+        include!(concat!(
+            env!("OUT_DIR"),
+            "/extern_paths/packages.widget.factory.rs"
+        ));
     }
 }
 
 #[test]
 fn test() {
-    use crate::packages::DoIt;
     use crate::packages::gizmo;
+    use crate::packages::DoIt;
     use prost::Message;
 
     let mut widget_factory = widget::factory::WidgetFactory::default();

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,13 +1,18 @@
-#[macro_use] extern crate prost_derive;
+#[macro_use]
+extern crate prost_derive;
 
 pub mod extern_paths;
 pub mod packages;
 pub mod unittest;
 
-#[cfg(test)] mod bootstrap;
-#[cfg(test)] mod debug;
-#[cfg(test)] mod message_encoding;
-#[cfg(test)] mod no_unused_results;
+#[cfg(test)]
+mod bootstrap;
+#[cfg(test)]
+mod debug;
+#[cfg(test)]
+mod message_encoding;
+#[cfg(test)]
+mod no_unused_results;
 
 pub mod foo {
     pub mod bar_baz {
@@ -71,7 +76,9 @@ impl RoundtripResult {
     pub fn unwrap(self) -> Vec<u8> {
         match self {
             RoundtripResult::Ok(buf) => buf,
-            RoundtripResult::DecodeError(error) => panic!("failed to decode the roundtrip data: {}", error),
+            RoundtripResult::DecodeError(error) => {
+                panic!("failed to decode the roundtrip data: {}", error)
+            }
             RoundtripResult::Error(error) => panic!("failed roundtrip: {}", error),
         }
     }
@@ -88,7 +95,10 @@ impl RoundtripResult {
 
 /// Tests round-tripping a message type. The message should be compiled with `BTreeMap` fields,
 /// otherwise the comparison may fail due to inconsistent `HashMap` entry encoding ordering.
-pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult where M: Message + Default {
+pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult
+where
+    M: Message + Default,
+{
     // Try to decode a message from the data. If decoding fails, continue.
     let all_types = match M::decode(data) {
         Ok(all_types) => all_types,
@@ -99,7 +109,7 @@ pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult where M: Message + Default {
 
     // TODO: Reenable this once sign-extension in negative int32s is figured out.
     //assert!(encoded_len <= len, "encoded_len: {}, len: {}, all_types: {:?}",
-                                //encoded_len, len, all_types);
+    //encoded_len, len, all_types);
 
     let mut buf1 = Vec::new();
     if let Err(error) = all_types.encode(&mut buf1) {
@@ -107,8 +117,13 @@ pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult where M: Message + Default {
     }
     if encoded_len != buf1.len() {
         return RoundtripResult::Error(
-            format!("expected encoded len ({}) did not match actual encoded len ({})",
-                    encoded_len, buf1.len()).into());
+            format!(
+                "expected encoded len ({}) did not match actual encoded len ({})",
+                encoded_len,
+                buf1.len()
+            )
+            .into(),
+        );
     }
 
     let roundtrip = match M::decode(&buf1) {
@@ -129,14 +144,17 @@ pub fn roundtrip<M>(data: &[u8]) -> RoundtripResult where M: Message + Default {
     */
 
     if buf1 != buf2 {
-        return RoundtripResult::Error("roundtripped encoded buffers do not match".into())
+        return RoundtripResult::Error("roundtripped encoded buffers do not match".into());
     }
 
     RoundtripResult::Ok(buf1)
 }
 
 /// Generic rountrip serialization check for messages.
-pub fn check_message<M>(msg: &M) where M: Message + Default + PartialEq {
+pub fn check_message<M>(msg: &M)
+where
+    M: Message + Default + PartialEq,
+{
     let expected_len = msg.encoded_len();
 
     let mut buf = Vec::with_capacity(18);
@@ -155,8 +173,10 @@ pub fn check_message<M>(msg: &M) where M: Message + Default + PartialEq {
 
 /// Serialize from A should equal Serialize from B
 pub fn check_serialize_equivalent<M, N>(msg_a: &M, msg_b: &N)
-where M: Message + Default + PartialEq,
-      N: Message + Default + PartialEq {
+where
+    M: Message + Default + PartialEq,
+    N: Message + Default + PartialEq,
+{
     let mut buf_a = Vec::new();
     msg_a.encode(&mut buf_a).unwrap();
     let mut buf_b = Vec::new();
@@ -169,8 +189,8 @@ mod tests {
 
     use std::collections::{BTreeMap, BTreeSet};
 
-    use protobuf::test_messages::proto3::TestAllTypesProto3;
     use super::*;
+    use protobuf::test_messages::proto3::TestAllTypesProto3;
 
     #[test]
     fn test_all_types_proto3() {
@@ -180,23 +200,20 @@ mod tests {
             &[0x92, 0x01, 0x00, 0x92, 0xF4, 0x01, 0x02, 0x00, 0x00],
             &[0x5d, 0xff, 0xff, 0xff, 0xff, 0x28, 0xff, 0xff, 0x21],
             &[0x98, 0x04, 0x02, 0x08, 0x0B, 0x98, 0x04, 0x02, 0x08, 0x02],
-
             // optional_int32: -1
             &[0x08, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x08],
-
             // repeated_bool: [true, true]
             &[0xDA, 0x02, 0x02, 0x2A, 0x03],
-
             // oneof_double: nan
             &[0xb1, 0x07, 0xf6, 0x3d, 0xf5, 0xff, 0x27, 0x3d, 0xf5, 0xff],
-
             // optional_float: -0.0
             &[0xdd, 0x00, 0x00, 0x00, 0x00, 0x80],
-
             // optional_value: nan
-            &[0xE2, 0x13, 0x1B, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
-              0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
-              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x08, 0xFF, 0x0E],
+            &[
+                0xE2, 0x13, 0x1B, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+                0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                0xFF, 0xFF, 0x08, 0xFF, 0x0E,
+            ],
         ];
 
         for msg in msgs {
@@ -208,12 +225,10 @@ mod tests {
     fn test_ident_conversions() {
         let msg = foo::bar_baz::FooBarBaz {
             foo_bar_baz: 42,
-            fuzz_busters: vec![
-                foo::bar_baz::foo_bar_baz::FuzzBuster {
-                    t: BTreeMap::<i32, foo::bar_baz::FooBarBaz>::new(),
-                    nested_self: None,
-                },
-            ],
+            fuzz_busters: vec![foo::bar_baz::foo_bar_baz::FuzzBuster {
+                t: BTreeMap::<i32, foo::bar_baz::FooBarBaz>::new(),
+                nested_self: None,
+            }],
             p_i_e: 0,
         };
 
@@ -261,9 +276,9 @@ mod tests {
         let _ = A {
             kind: Some(a::Kind::B(Box::new(B {
                 a: Some(Box::new(A {
-                    kind: Some(a::Kind::C(C {}))
-                }))
-            })))
+                    kind: Some(a::Kind::C(C {})),
+                })),
+            }))),
         };
     }
 
@@ -271,7 +286,13 @@ mod tests {
     fn test_default_enum() {
         let msg = default_enum_value::Test::default();
         assert_eq!(msg.privacy_level_1(), default_enum_value::PrivacyLevel::One);
-        assert_eq!(msg.privacy_level_3(), default_enum_value::PrivacyLevel::PrivacyLevelThree);
-        assert_eq!(msg.privacy_level_4(), default_enum_value::PrivacyLevel::PrivacyLevelprivacyLevelFour);
+        assert_eq!(
+            msg.privacy_level_3(),
+            default_enum_value::PrivacyLevel::PrivacyLevelThree
+        );
+        assert_eq!(
+            msg.privacy_level_4(),
+            default_enum_value::PrivacyLevel::PrivacyLevelprivacyLevelFour
+        );
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,12 +1,4 @@
-extern crate bytes;
-extern crate prost;
-extern crate prost_types;
-extern crate protobuf;
-
 #[macro_use] extern crate prost_derive;
-
-#[cfg(test)] extern crate tempfile;
-#[cfg(test)] extern crate prost_build;
 
 pub mod extern_paths;
 pub mod packages;
@@ -71,7 +63,7 @@ pub enum RoundtripResult {
     /// or it could indicate that the input was bogus.
     DecodeError(prost::DecodeError),
     /// Re-encoding or validating the data failed.  This indicates a bug in `prost`.
-    Error(Box<Error + Send + Sync>),
+    Error(Box<dyn Error + Send + Sync>),
 }
 
 impl RoundtripResult {
@@ -252,7 +244,7 @@ mod tests {
 
     #[test]
     fn test_nesting() {
-        use nesting::{A, B};
+        use crate::nesting::{A, B};
         let _ = A {
             a: Some(Box::new(A::default())),
             repeated_a: Vec::<A>::new(),
@@ -265,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_recursive_oneof() {
-        use recursive_oneof::{a, A, B, C};
+        use crate::recursive_oneof::{a, A, B, C};
         let _ = A {
             kind: Some(a::Kind::B(Box::new(B {
                 a: Some(Box::new(A {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate prost_derive;
-
 pub mod extern_paths;
 pub mod packages;
 pub mod unittest;

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -5,9 +5,9 @@ use crate::check_serialize_equivalent;
 
 #[derive(Clone, PartialEq, Message)]
 pub struct RepeatedFloats {
-    #[prost(float, tag="11")]
+    #[prost(float, tag = "11")]
     pub single_float: f32,
-    #[prost(float, repeated, packed="true", tag="41")]
+    #[prost(float, repeated, packed = "true", tag = "41")]
     pub repeated_float: Vec<f32>,
 }
 
@@ -18,7 +18,7 @@ fn check_repeated_floats() {
         repeated_float: vec![
             0.1,
             340282300000000000000000000000000000000.0,
-            0.000000000000000000000000000000000000011754944
+            0.000000000000000000000000000000000000011754944,
         ],
     });
 }
@@ -31,161 +31,161 @@ fn check_scalar_types() {
 /// A protobuf message which contains all scalar types.
 #[derive(Clone, PartialEq, Message)]
 pub struct ScalarTypes {
-    #[prost(int32, tag="001")]
+    #[prost(int32, tag = "001")]
     pub int32: i32,
-    #[prost(int64, tag="002")]
+    #[prost(int64, tag = "002")]
     pub int64: i64,
-    #[prost(uint32, tag="003")]
+    #[prost(uint32, tag = "003")]
     pub uint32: u32,
-    #[prost(uint64, tag="004")]
+    #[prost(uint64, tag = "004")]
     pub uint64: u64,
-    #[prost(sint32, tag="005")]
+    #[prost(sint32, tag = "005")]
     pub sint32: i32,
-    #[prost(sint64, tag="006")]
+    #[prost(sint64, tag = "006")]
     pub sint64: i64,
-    #[prost(fixed32, tag="007")]
+    #[prost(fixed32, tag = "007")]
     pub fixed32: u32,
-    #[prost(fixed64, tag="008")]
+    #[prost(fixed64, tag = "008")]
     pub fixed64: u64,
-    #[prost(sfixed32, tag="009")]
+    #[prost(sfixed32, tag = "009")]
     pub sfixed32: i32,
-    #[prost(sfixed64, tag="010")]
+    #[prost(sfixed64, tag = "010")]
     pub sfixed64: i64,
-    #[prost(float, tag="011")]
+    #[prost(float, tag = "011")]
     pub float: f32,
-    #[prost(double, tag="012")]
+    #[prost(double, tag = "012")]
     pub double: f64,
-    #[prost(bool, tag="013")]
+    #[prost(bool, tag = "013")]
     pub _bool: bool,
-    #[prost(string, tag="014")]
+    #[prost(string, tag = "014")]
     pub string: String,
-    #[prost(bytes, tag="015")]
+    #[prost(bytes, tag = "015")]
     pub bytes: Vec<u8>,
 
-    #[prost(int32, required, tag="101")]
+    #[prost(int32, required, tag = "101")]
     pub required_int32: i32,
-    #[prost(int64, required, tag="102")]
+    #[prost(int64, required, tag = "102")]
     pub required_int64: i64,
-    #[prost(uint32, required, tag="103")]
+    #[prost(uint32, required, tag = "103")]
     pub required_uint32: u32,
-    #[prost(uint64, required, tag="104")]
+    #[prost(uint64, required, tag = "104")]
     pub required_uint64: u64,
-    #[prost(sint32, required, tag="105")]
+    #[prost(sint32, required, tag = "105")]
     pub required_sint32: i32,
-    #[prost(sint64, required, tag="106")]
+    #[prost(sint64, required, tag = "106")]
     pub required_sint64: i64,
-    #[prost(fixed32, required, tag="107")]
+    #[prost(fixed32, required, tag = "107")]
     pub required_fixed32: u32,
-    #[prost(fixed64, required, tag="108")]
+    #[prost(fixed64, required, tag = "108")]
     pub required_fixed64: u64,
-    #[prost(sfixed32, required, tag="109")]
+    #[prost(sfixed32, required, tag = "109")]
     pub required_sfixed32: i32,
-    #[prost(sfixed64, required, tag="110")]
+    #[prost(sfixed64, required, tag = "110")]
     pub required_sfixed64: i64,
-    #[prost(float, required, tag="111")]
+    #[prost(float, required, tag = "111")]
     pub required_float: f32,
-    #[prost(double, required, tag="112")]
+    #[prost(double, required, tag = "112")]
     pub required_double: f64,
-    #[prost(bool, required, tag="113")]
+    #[prost(bool, required, tag = "113")]
     pub required_bool: bool,
-    #[prost(string, required, tag="114")]
+    #[prost(string, required, tag = "114")]
     pub required_string: String,
-    #[prost(bytes, required, tag="115")]
+    #[prost(bytes, required, tag = "115")]
     pub required_bytes: Vec<u8>,
 
-    #[prost(int32, optional, tag="201")]
+    #[prost(int32, optional, tag = "201")]
     pub optional_int32: Option<i32>,
-    #[prost(int64, optional, tag="202")]
+    #[prost(int64, optional, tag = "202")]
     pub optional_int64: Option<i64>,
-    #[prost(uint32, optional, tag="203")]
+    #[prost(uint32, optional, tag = "203")]
     pub optional_uint32: Option<u32>,
-    #[prost(uint64, optional, tag="204")]
+    #[prost(uint64, optional, tag = "204")]
     pub optional_uint64: Option<u64>,
-    #[prost(sint32, optional, tag="205")]
+    #[prost(sint32, optional, tag = "205")]
     pub optional_sint32: Option<i32>,
-    #[prost(sint64, optional, tag="206")]
+    #[prost(sint64, optional, tag = "206")]
     pub optional_sint64: Option<i64>,
 
-    #[prost(fixed32, optional, tag="207")]
+    #[prost(fixed32, optional, tag = "207")]
     pub optional_fixed32: Option<u32>,
-    #[prost(fixed64, optional, tag="208")]
+    #[prost(fixed64, optional, tag = "208")]
     pub optional_fixed64: Option<u64>,
-    #[prost(sfixed32, optional, tag="209")]
+    #[prost(sfixed32, optional, tag = "209")]
     pub optional_sfixed32: Option<i32>,
-    #[prost(sfixed64, optional, tag="210")]
+    #[prost(sfixed64, optional, tag = "210")]
     pub optional_sfixed64: Option<i64>,
-    #[prost(float, optional, tag="211")]
+    #[prost(float, optional, tag = "211")]
     pub optional_float: Option<f32>,
-    #[prost(double, optional, tag="212")]
+    #[prost(double, optional, tag = "212")]
     pub optional_double: Option<f64>,
-    #[prost(bool, optional, tag="213")]
+    #[prost(bool, optional, tag = "213")]
     pub optional_bool: Option<bool>,
-    #[prost(string, optional, tag="214")]
+    #[prost(string, optional, tag = "214")]
     pub optional_string: Option<String>,
-    #[prost(bytes, optional, tag="215")]
+    #[prost(bytes, optional, tag = "215")]
     pub optional_bytes: Option<Vec<u8>>,
 
-    #[prost(int32, repeated, packed="false", tag="301")]
+    #[prost(int32, repeated, packed = "false", tag = "301")]
     pub repeated_int32: Vec<i32>,
-    #[prost(int64, repeated, packed="false", tag="302")]
+    #[prost(int64, repeated, packed = "false", tag = "302")]
     pub repeated_int64: Vec<i64>,
-    #[prost(uint32, repeated, packed="false", tag="303")]
+    #[prost(uint32, repeated, packed = "false", tag = "303")]
     pub repeated_uint32: Vec<u32>,
-    #[prost(uint64, repeated, packed="false", tag="304")]
+    #[prost(uint64, repeated, packed = "false", tag = "304")]
     pub repeated_uint64: Vec<u64>,
-    #[prost(sint32, repeated, packed="false", tag="305")]
+    #[prost(sint32, repeated, packed = "false", tag = "305")]
     pub repeated_sint32: Vec<i32>,
-    #[prost(sint64, repeated, packed="false", tag="306")]
+    #[prost(sint64, repeated, packed = "false", tag = "306")]
     pub repeated_sint64: Vec<i64>,
-    #[prost(fixed32, repeated, packed="false", tag="307")]
+    #[prost(fixed32, repeated, packed = "false", tag = "307")]
     pub repeated_fixed32: Vec<u32>,
-    #[prost(fixed64, repeated, packed="false", tag="308")]
+    #[prost(fixed64, repeated, packed = "false", tag = "308")]
     pub repeated_fixed64: Vec<u64>,
-    #[prost(sfixed32, repeated, packed="false", tag="309")]
+    #[prost(sfixed32, repeated, packed = "false", tag = "309")]
     pub repeated_sfixed32: Vec<i32>,
-    #[prost(sfixed64, repeated, packed="false", tag="310")]
+    #[prost(sfixed64, repeated, packed = "false", tag = "310")]
     pub repeated_sfixed64: Vec<i64>,
-    #[prost(float, repeated, packed="false", tag="311")]
+    #[prost(float, repeated, packed = "false", tag = "311")]
     pub repeated_float: Vec<f32>,
-    #[prost(double, repeated, packed="false", tag="312")]
+    #[prost(double, repeated, packed = "false", tag = "312")]
     pub repeated_double: Vec<f64>,
-    #[prost(bool, repeated, packed="false", tag="313")]
+    #[prost(bool, repeated, packed = "false", tag = "313")]
     pub repeated_bool: Vec<bool>,
-    #[prost(string, repeated, packed="false", tag="315")]
+    #[prost(string, repeated, packed = "false", tag = "315")]
     pub repeated_string: Vec<String>,
-    #[prost(bytes, repeated, packed="false", tag="316")]
+    #[prost(bytes, repeated, packed = "false", tag = "316")]
     pub repeated_bytes: Vec<Vec<u8>>,
 
-    #[prost(int32, repeated, tag="401")]
+    #[prost(int32, repeated, tag = "401")]
     pub packed_int32: Vec<i32>,
-    #[prost(int64, repeated, tag="402")]
+    #[prost(int64, repeated, tag = "402")]
     pub packed_int64: Vec<i64>,
-    #[prost(uint32, repeated, tag="403")]
+    #[prost(uint32, repeated, tag = "403")]
     pub packed_uint32: Vec<u32>,
-    #[prost(uint64, repeated, tag="404")]
+    #[prost(uint64, repeated, tag = "404")]
     pub packed_uint64: Vec<u64>,
-    #[prost(sint32, repeated, tag="405")]
+    #[prost(sint32, repeated, tag = "405")]
     pub packed_sint32: Vec<i32>,
-    #[prost(sint64, repeated, tag="406")]
+    #[prost(sint64, repeated, tag = "406")]
     pub packed_sint64: Vec<i64>,
-    #[prost(fixed32, repeated, tag="407")]
+    #[prost(fixed32, repeated, tag = "407")]
     pub packed_fixed32: Vec<u32>,
 
-    #[prost(fixed64, repeated, tag="408")]
+    #[prost(fixed64, repeated, tag = "408")]
     pub packed_fixed64: Vec<u64>,
-    #[prost(sfixed32, repeated, tag="409")]
+    #[prost(sfixed32, repeated, tag = "409")]
     pub packed_sfixed32: Vec<i32>,
-    #[prost(sfixed64, repeated, tag="410")]
+    #[prost(sfixed64, repeated, tag = "410")]
     pub packed_sfixed64: Vec<i64>,
-    #[prost(float, repeated, tag="411")]
+    #[prost(float, repeated, tag = "411")]
     pub packed_float: Vec<f32>,
-    #[prost(double, repeated, tag="412")]
+    #[prost(double, repeated, tag = "412")]
     pub packed_double: Vec<f64>,
-    #[prost(bool, repeated, tag="413")]
+    #[prost(bool, repeated, tag = "413")]
     pub packed_bool: Vec<bool>,
-    #[prost(string, repeated, tag="415")]
+    #[prost(string, repeated, tag = "415")]
     pub packed_string: Vec<String>,
-    #[prost(bytes, repeated, tag="416")]
+    #[prost(bytes, repeated, tag = "416")]
     pub packed_bytes: Vec<Vec<u8>>,
 }
 
@@ -204,14 +204,14 @@ pub struct TagsInferred {
     #[prost(float, repeated)]
     pub three: Vec<f32>,
 
-    #[prost(tag="9", string, required)]
+    #[prost(tag = "9", string, required)]
     pub skip_to_nine: String,
-    #[prost(enumeration="BasicEnumeration", default="ONE")]
+    #[prost(enumeration = "BasicEnumeration", default = "ONE")]
     pub ten: i32,
-    #[prost(map="string, string")]
+    #[prost(map = "string, string")]
     pub eleven: ::std::collections::HashMap<String, String>,
 
-    #[prost(tag="5", bytes)]
+    #[prost(tag = "5", bytes)]
     pub back_to_five: Vec<u8>,
     #[prost(message, required)]
     pub six: Basic,
@@ -219,45 +219,45 @@ pub struct TagsInferred {
 
 #[derive(Clone, PartialEq, Message)]
 pub struct TagsQualified {
-    #[prost(tag="1", bool)]
+    #[prost(tag = "1", bool)]
     pub one: bool,
-    #[prost(tag="2", int32, optional)]
+    #[prost(tag = "2", int32, optional)]
     pub two: Option<i32>,
-    #[prost(tag="3", float, repeated)]
+    #[prost(tag = "3", float, repeated)]
     pub three: Vec<f32>,
 
-    #[prost(tag="5", bytes)]
+    #[prost(tag = "5", bytes)]
     pub five: Vec<u8>,
-    #[prost(tag="6", message, required)]
+    #[prost(tag = "6", message, required)]
     pub six: Basic,
 
-    #[prost(tag="9", string, required)]
+    #[prost(tag = "9", string, required)]
     pub nine: String,
-    #[prost(tag="10", enumeration="BasicEnumeration", default="ONE")]
+    #[prost(tag = "10", enumeration = "BasicEnumeration", default = "ONE")]
     pub ten: i32,
-    #[prost(tag="11", map="string, string")]
+    #[prost(tag = "11", map = "string, string")]
     pub eleven: ::std::collections::HashMap<String, String>,
 }
 
 /// A prost message with default value.
 #[derive(Clone, PartialEq, Message)]
 pub struct DefaultValues {
-    #[prost(int32, tag="1", default="42")]
+    #[prost(int32, tag = "1", default = "42")]
     pub int32: i32,
 
-    #[prost(int32, optional, tag="2", default="88")]
+    #[prost(int32, optional, tag = "2", default = "88")]
     pub optional_int32: Option<i32>,
 
-    #[prost(string, tag="3", default="fourty two")]
+    #[prost(string, tag = "3", default = "fourty two")]
     pub string: String,
 
-    #[prost(enumeration="BasicEnumeration", tag="4", default="ONE")]
+    #[prost(enumeration = "BasicEnumeration", tag = "4", default = "ONE")]
     pub enumeration: i32,
 
-    #[prost(enumeration="BasicEnumeration", optional, tag="5", default="TWO")]
+    #[prost(enumeration = "BasicEnumeration", optional, tag = "5", default = "TWO")]
     pub optional_enumeration: Option<i32>,
 
-    #[prost(enumeration="BasicEnumeration", repeated, tag="6")]
+    #[prost(enumeration = "BasicEnumeration", repeated, tag = "6")]
     pub repeated_enumeration: Vec<i32>,
 }
 
@@ -284,59 +284,59 @@ pub enum BasicEnumeration {
 
 #[derive(Clone, PartialEq, Message)]
 pub struct Basic {
-    #[prost(int32, tag="1")]
+    #[prost(int32, tag = "1")]
     pub int32: i32,
 
-    #[prost(bool, repeated, packed="false", tag="2")]
+    #[prost(bool, repeated, packed = "false", tag = "2")]
     pub bools: Vec<bool>,
 
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub string: String,
 
-    #[prost(string, optional, tag="4")]
+    #[prost(string, optional, tag = "4")]
     pub optional_string: Option<String>,
 
-    #[prost(enumeration="BasicEnumeration", tag="5")]
+    #[prost(enumeration = "BasicEnumeration", tag = "5")]
     pub enumeration: i32,
 
-    #[prost(map="int32, enumeration(BasicEnumeration)", tag="6")]
+    #[prost(map = "int32, enumeration(BasicEnumeration)", tag = "6")]
     pub enumeration_map: ::std::collections::HashMap<i32, i32>,
 
-    #[prost(hash_map="string, string", tag="7")]
+    #[prost(hash_map = "string, string", tag = "7")]
     pub string_map: ::std::collections::HashMap<String, String>,
 
-    #[prost(btree_map="int32, enumeration(BasicEnumeration)", tag="10")]
+    #[prost(btree_map = "int32, enumeration(BasicEnumeration)", tag = "10")]
     pub enumeration_btree_map: ::std::collections::BTreeMap<i32, i32>,
 
-    #[prost(btree_map="string, string", tag="11")]
+    #[prost(btree_map = "string, string", tag = "11")]
     pub string_btree_map: ::std::collections::BTreeMap<String, String>,
 
-    #[prost(oneof="BasicOneof", tags="8, 9")]
+    #[prost(oneof = "BasicOneof", tags = "8, 9")]
     pub oneof: Option<BasicOneof>,
 }
 
 #[derive(Clone, PartialEq, Message)]
 pub struct Compound {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub optional_message: Option<Basic>,
 
-    #[prost(message, required, tag="2")]
+    #[prost(message, required, tag = "2")]
     pub required_message: Basic,
 
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub repeated_message: Vec<Basic>,
 
-    #[prost(map="sint32, message", tag="4")]
+    #[prost(map = "sint32, message", tag = "4")]
     pub message_map: ::std::collections::HashMap<i32, Basic>,
 
-    #[prost(btree_map="sint32, message", tag="5")]
+    #[prost(btree_map = "sint32, message", tag = "5")]
     pub message_btree_map: ::std::collections::BTreeMap<i32, Basic>,
 }
 
 #[derive(Clone, PartialEq, Oneof)]
 pub enum BasicOneof {
-    #[prost(int32, tag="8")]
+    #[prost(int32, tag = "8")]
     Int(i32),
-    #[prost(string, tag="9")]
+    #[prost(string, tag = "9")]
     String(String),
 }

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -1,4 +1,5 @@
-use prost::Message;
+use prost::Message as MessageTrait;
+use prost_derive::{Enumeration, Message, Oneof};
 
 use crate::check_message;
 use crate::check_serialize_equivalent;

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -1,7 +1,7 @@
 use prost::Message;
 
-use check_message;
-use check_serialize_equivalent;
+use crate::check_message;
+use crate::check_serialize_equivalent;
 
 #[derive(Clone, PartialEq, Message)]
 pub struct RepeatedFloats {

--- a/tests/src/packages/mod.rs
+++ b/tests/src/packages/mod.rs
@@ -19,8 +19,7 @@ pub trait DoIt {
 }
 
 impl DoIt for gizmo::Gizmo {
-    fn do_it(&self) {
-    }
+    fn do_it(&self) {}
 }
 
 #[test]

--- a/tests/src/unittest.rs
+++ b/tests/src/unittest.rs
@@ -1,11 +1,14 @@
 #[test]
 fn extreme_default_values() {
-    use std::{f32, f64};
     use protobuf::test_messages::protobuf_unittest;
+    use std::{f32, f64};
 
     let pb = protobuf_unittest::TestExtremeDefaultValues::default();
 
-    assert_eq!(b"\0\x01\x07\x08\x0C\n\r\t\x0B\\\'\"\xFE", pb.escaped_bytes());
+    assert_eq!(
+        b"\0\x01\x07\x08\x0C\n\r\t\x0B\\\'\"\xFE",
+        pb.escaped_bytes()
+    );
 
     assert_eq!(0xFFFFFFFF, pb.large_uint32());
     assert_eq!(0xFFFFFFFFFFFFFFFF, pb.large_uint64());


### PR DESCRIPTION
Currently based on #147.

Motivation for doing this is so we can pre-compile the FileDescriptorSet and also so that the set can be inspected to find the package name and thus the name of the generated file.