### PR TITLE
Add Rust 2018 edition support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 keywords = ["protobuf", "serialization"]
 categories = ["encoding"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "danburkert/prost" }
@@ -23,6 +24,7 @@ members = [
   "prost-types",
   "protobuf",
   "tests",
+  "tests-2015",
 ]
 exclude = [
   # The fuzz crate can't be compiled or tested without the 'cargo fuzz' command,

--- a/README.md
+++ b/README.md
@@ -326,6 +326,16 @@ pub enum Gender {
   But it is possible to place `serde` derive tags onto the generated types, so
   the same structure can support both `prost` and `Serde`.
 
+2. **I get errors when trying to run `cargo test` on MacOS**
+
+  If the errors are about missing `autoreconf` or similar, you can probably fix
+  them by running
+
+  ```
+  brew install automake
+  brew install libtool
+  ```
+
 ## License
 
 `prost` is distributed under the terms of the Apache License (Version 2.0).

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,16 +1,9 @@
-extern crate bytes;
-extern crate criterion;
-extern crate prost;
-extern crate protobuf;
-
-#[macro_use]
-extern crate failure;
-
 use std::fs::File;
 use std::io::Read;
 use std::result;
 
 use criterion::{Benchmark, Criterion, Throughput};
+use failure::bail;
 use prost::Message;
 use protobuf::benchmarks::{proto2, proto3, BenchmarkDataset};
 

--- a/benches/varint.rs
+++ b/benches/varint.rs
@@ -1,7 +1,5 @@
 #![feature(test)]
 
-extern crate bytes;
-extern crate prost;
 extern crate test;
 
 use bytes::IntoBuf;

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -3,6 +3,7 @@ name = "conformance"
 version = "0.0.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]
 bytes = "0.4.7"

--- a/conformance/src/main.rs
+++ b/conformance/src/main.rs
@@ -1,9 +1,3 @@
-extern crate bytes;
-extern crate env_logger;
-extern crate prost;
-extern crate protobuf;
-extern crate tests;
-
 use std::io::{self, Read, Write};
 
 use bytes::{ByteOrder, LittleEndian};

--- a/conformance/tests/conformance.rs
+++ b/conformance/tests/conformance.rs
@@ -1,5 +1,3 @@
-extern crate protobuf;
-
 use std::env;
 use std::process::Command;
 

--- a/fuzz/fuzzers/proto3.rs
+++ b/fuzz/fuzzers/proto3.rs
@@ -1,12 +1,8 @@
 #![no_main]
 
-#[macro_use] extern crate libfuzzer_sys;
-extern crate protobuf;
-extern crate tests;
-
 use protobuf::test_messages::proto3::TestAllTypesProto3;
 use tests::roundtrip;
 
-fuzz_target!(|data: &[u8]| {
+libfuzzer_sys::fuzz_target!(|data: &[u8]| {
     let _ = roundtrip::<TestAllTypesProto3>(data).unwrap_error();
 });

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/danburkert/prost"
 documentation = "https://docs.rs/prost-build"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
+edition = "2018"
 
 [dependencies]
 bytes = "0.4.7"

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -14,8 +14,6 @@
 //!     1. The `PROTOC_INCLUDE` environment variable.
 //!     2. The bundled Protobuf include directory.
 
-extern crate which;
-
 use std::env;
 use std::path::PathBuf;
 

--- a/prost-build/src/extern_paths.rs
+++ b/prost-build/src/extern_paths.rs
@@ -2,7 +2,7 @@ use std::collections::{hash_map, HashMap};
 
 use itertools::Itertools;
 
-use ident::{to_snake, to_upper_camel};
+use crate::ident::{to_snake, to_upper_camel};
 
 fn validate_proto_path(path: &str) -> Result<(), String> {
     if path.chars().next().map(|c| c != '.').unwrap_or(true) {
@@ -96,7 +96,16 @@ impl ExternPaths {
                     rust_path
                         .split("::")
                         .chain(segments)
-                        .map(|segment| to_snake(&segment))
+                        .enumerate()
+                        .map(|(idx, segment)| {
+                            if idx == 0 && segment == "crate" {
+                                // If the first segment of the path is 'crate', then do not escape
+                                // it into a raw identifier, since it's being used as the keyword.
+                                segment.to_owned()
+                            } else {
+                                to_snake(&segment)
+                            }
+                        })
                         .chain(ident_type.into_iter())
                         .join("::"),
                 );

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -7,17 +7,21 @@ use heck::{CamelCase, SnakeCase};
 pub fn to_snake(s: &str) -> String {
     let mut ident = s.to_snake_case();
 
-    // Add a trailing underscore if the identifier matches a Rust keyword
-    // (https://doc.rust-lang.org/grammar.html#keywords).
-    match &ident[..] {
-        "abstract" | "alignof" | "as" | "become" | "box" | "break" | "const" | "continue"
-        | "crate" | "do" | "else" | "enum" | "extern" | "false" | "final" | "fn" | "for" | "if"
-        | "impl" | "in" | "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut"
-        | "offsetof" | "override" | "priv" | "proc" | "pub" | "pure" | "ref" | "return"
-        | "self" | "sizeof" | "static" | "struct" | "super" | "trait" | "true" | "type"
-        | "typeof" | "unsafe" | "unsized" | "use" | "virtual" | "where" | "while" | "yield" => {
-            ident.push('_');
-        }
+    // Use a raw identifier if the identifier matches a Rust keyword:
+    // https://doc.rust-lang.org/reference/keywords.html.
+    match ident.as_str() {
+        // 2015 strict keywords.
+        | "as" | "break" | "const" | "continue" | "crate" | "else" | "enum" | "extern" | "false"
+        | "fn" | "for" | "if" | "impl" | "in" | "let" | "loop" | "match" | "mod" | "move" | "mut"
+        | "pub" | "ref" | "return" | "self" | "static" | "struct" | "super" | "trait" | "true"
+        | "type" | "unsafe" | "use" | "where" | "while"
+        // 2018 strict keywords.
+        | "dyn"
+        // 2015 reserved keywords.
+        | "abstract" | "become" | "box" | "do" | "final" | "macro" | "override" | "priv" | "typeof"
+        | "unsized" | "virtual" | "yield"
+        // 2018 reserved keywords.
+        | "async" | "await" | "try" => ident.insert_str(0, "r#"),
         _ => (),
     }
     ident
@@ -27,10 +31,10 @@ pub fn to_snake(s: &str) -> String {
 pub fn to_upper_camel(s: &str) -> String {
     let mut ident = s.to_camel_case();
 
-    // Add a trailing underscore if the identifier matches a Rust keyword
-    // (https://doc.rust-lang.org/grammar.html#keywords).
+    // Use a raw identifier if the identifier matches a Rust keyword:
+    // https://doc.rust-lang.org/reference/keywords.html.
     if ident == "Self" {
-        ident.push('_');
+        ident.insert_str(0, "r#");
     }
     ident
 }
@@ -79,7 +83,7 @@ mod tests {
         assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ"));
         assert_eq!("foo_bar_baz", &to_snake("FooBarBAZ"));
         assert_eq!("xml_http_request", &to_snake("XMLHttpRequest"));
-        assert_eq!("while_", &to_snake("While"));
+        assert_eq!("r#while", &to_snake("While"));
         assert_eq!("fuzz_buster", &to_snake("FUZZ_BUSTER"));
         assert_eq!("foo_bar_baz", &to_snake("foo_bar_baz"));
         assert_eq!("fuzz_buster", &to_snake("FUZZ_buster"));
@@ -125,7 +129,7 @@ mod tests {
         assert_eq!("FooBar", &to_upper_camel("_FOO_BAR_"));
         assert_eq!("FuzzBuster", &to_upper_camel("fuzzBuster"));
         assert_eq!("FuzzBuster", &to_upper_camel("FuzzBuster"));
-        assert_eq!("Self_", &to_upper_camel("self"));
+        assert_eq!("r#Self", &to_upper_camel("self"));
     }
 
     #[test]

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -47,7 +47,7 @@ impl MessageGraph {
         let msg_index = self.get_or_insert_index(msg_name.clone());
 
         for field in &msg.field {
-            if field.type_() == field_descriptor_proto::Type::Message
+            if field.r#type() == field_descriptor_proto::Type::Message
                 && field.label() != field_descriptor_proto::Label::Repeated
             {
                 let field_index = self.get_or_insert_index(field.type_name.clone().unwrap());

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/danburkert/prost"
 documentation = "https://docs.rs/prost-derive"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
+edition = "2018"
 
 [lib]
 proc_macro = true

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -1,8 +1,9 @@
-use failure::Error;
+use failure::{bail, Error};
 use proc_macro2::{Span, TokenStream};
+use quote::quote;
 use syn::{Ident, Lit, Meta, MetaNameValue, NestedMeta};
 
-use field::{scalar, set_option, tag_attr};
+use crate::field::{scalar, set_option, tag_attr};
 
 #[derive(Clone, Debug)]
 pub enum MapTy {

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -1,8 +1,9 @@
-use failure::Error;
+use failure::{bail, Error};
 use proc_macro2::TokenStream;
+use quote::quote;
 use syn::Meta;
 
-use field::{set_bool, set_option, tag_attr, word_attr, Label};
+use crate::field::{set_bool, set_option, tag_attr, word_attr, Label};
 
 #[derive(Clone)]
 pub struct Field {

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -6,8 +6,9 @@ mod scalar;
 use std::fmt;
 use std::slice;
 
-use failure::Error;
+use failure::{bail, Error};
 use proc_macro2::TokenStream;
+use quote::quote;
 use syn::{Attribute, Ident, Lit, LitBool, Meta, MetaList, MetaNameValue, NestedMeta};
 
 #[derive(Clone)]
@@ -199,13 +200,13 @@ impl Label {
 }
 
 impl fmt::Debug for Label {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
 impl fmt::Display for Label {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -1,8 +1,9 @@
-use failure::Error;
+use failure::{bail, Error};
 use proc_macro2::TokenStream;
+use quote::quote;
 use syn::{parse_str, Lit, Meta, MetaNameValue, NestedMeta, Path};
 
-use field::{set_option, tags_attr};
+use crate::field::{set_option, tags_attr};
 
 #[derive(Clone)]
 pub struct Field {

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -2,28 +2,22 @@
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 
-extern crate itertools;
 extern crate proc_macro;
-extern crate proc_macro2;
-extern crate syn;
 
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate quote;
+use failure::bail;
+use quote::quote;
 
 use failure::Error;
 use itertools::Itertools;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use syn::punctuated::Punctuated;
 use syn::{
-    Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, FieldsNamed, FieldsUnnamed, Ident,
-    Variant,
+    punctuated::Punctuated, Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, FieldsNamed,
+    FieldsUnnamed, Ident, Variant,
 };
 
 mod field;
-use field::Field;
+use crate::field::Field;
 
 fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let input: DeriveInput = syn::parse(input)?;

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/danburkert/prost"
 documentation = "https://docs.rs/prost-types"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
+edition = "2018"
 
 [lib]
 doctest = false

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -1,5 +1,5 @@
 /// The version number of protocol compiler.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Version {
     #[prost(int32, optional, tag="1")]
     pub major: ::std::option::Option<i32>,
@@ -13,7 +13,7 @@ pub struct Version {
     pub suffix: ::std::option::Option<String>,
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct CodeGeneratorRequest {
     /// The .proto files that were explicitly listed on the command-line.  The
     /// code generator should generate code only for these files.  Each file's
@@ -44,7 +44,7 @@ pub struct CodeGeneratorRequest {
     pub compiler_version: ::std::option::Option<Version>,
 }
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct CodeGeneratorResponse {
     /// Error message.  If non-empty, code generation failed.  The plugin process
     /// should exit with status code zero even if it reports an error in this way.
@@ -61,7 +61,7 @@ pub struct CodeGeneratorResponse {
 }
 pub mod code_generator_response {
     /// Represents a single generated file.
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct File {
         /// The file name, relative to the output directory.  The name must not
         /// contain "." or ".." components and must be relative, not be absolute (so,

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -9,9 +9,6 @@
 //!
 //! [1]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf
 
-#[macro_use]
-extern crate prost_derive;
-
 use std::i32;
 use std::i64;
 use std::time;

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1,12 +1,12 @@
 /// The protocol compiler can output a FileDescriptorSet containing the .proto
 /// files it parses.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag="1")]
     pub file: ::std::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag="1")]
@@ -47,7 +47,7 @@ pub struct FileDescriptorProto {
     pub syntax: ::std::option::Option<String>,
 }
 /// Describes a message type.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct DescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -73,7 +73,7 @@ pub struct DescriptorProto {
     pub reserved_name: ::std::vec::Vec<String>,
 }
 pub mod descriptor_proto {
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct ExtensionRange {
         #[prost(int32, optional, tag="1")]
         pub start: ::std::option::Option<i32>,
@@ -85,7 +85,7 @@ pub mod descriptor_proto {
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -95,14 +95,14 @@ pub mod descriptor_proto {
         pub end: ::std::option::Option<i32>,
     }
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
 /// Describes a field within a message.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -113,7 +113,7 @@ pub struct FieldDescriptorProto {
     /// If type_name is set, this need not be set.  If both this and type_name
     /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     #[prost(enumeration="field_descriptor_proto::Type", optional, tag="5")]
-    pub type_: ::std::option::Option<i32>,
+    pub r#type: ::std::option::Option<i32>,
     /// For message and enum types, this is the name of the type.  If the name
     /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
     /// rules are used to find the type (i.e. first the nested types within this
@@ -146,7 +146,7 @@ pub struct FieldDescriptorProto {
     pub options: ::std::option::Option<FieldOptions>,
 }
 pub mod field_descriptor_proto {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     #[repr(i32)]
     pub enum Type {
         /// 0 is reserved for errors.
@@ -182,7 +182,7 @@ pub mod field_descriptor_proto {
         /// Uses ZigZag encoding.
         Sint64 = 18,
     }
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     #[repr(i32)]
     pub enum Label {
         /// 0 is reserved for errors
@@ -192,7 +192,7 @@ pub mod field_descriptor_proto {
     }
 }
 /// Describes a oneof.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -200,7 +200,7 @@ pub struct OneofDescriptorProto {
     pub options: ::std::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -225,7 +225,7 @@ pub mod enum_descriptor_proto {
     /// Note that this is distinct from DescriptorProto.ReservedRange in that it
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -236,7 +236,7 @@ pub mod enum_descriptor_proto {
     }
 }
 /// Describes a value within an enum.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -246,7 +246,7 @@ pub struct EnumValueDescriptorProto {
     pub options: ::std::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -256,7 +256,7 @@ pub struct ServiceDescriptorProto {
     pub options: ::std::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::std::option::Option<String>,
@@ -307,7 +307,7 @@ pub struct MethodDescriptorProto {
 //   If this turns out to be popular, a web service will be set up
 //   to automatically assign option numbers.
 
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FileOptions {
     /// Sets the Java package where classes generated from this .proto will be
     /// placed.  By default, the proto package is used, but this is often
@@ -417,7 +417,7 @@ pub struct FileOptions {
 }
 pub mod file_options {
     /// Generated classes can be optimized for speed or code size.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     #[repr(i32)]
     pub enum OptimizeMode {
         /// Generate complete code for parsing, serialization,
@@ -430,7 +430,7 @@ pub mod file_options {
         LiteRuntime = 3,
     }
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct MessageOptions {
     /// Set true to use the old proto1 MessageSet wire format for extensions.
     /// This is provided for backwards-compatibility with the MessageSet wire
@@ -490,7 +490,7 @@ pub struct MessageOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FieldOptions {
     /// The ctype option instructs the C++ code generator to use a different
     /// representation of the field than it normally would.  See the specific
@@ -562,7 +562,7 @@ pub struct FieldOptions {
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
 pub mod field_options {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     #[repr(i32)]
     pub enum CType {
         /// Default mode.
@@ -570,7 +570,7 @@ pub mod field_options {
         Cord = 1,
         StringPiece = 2,
     }
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     #[repr(i32)]
     pub enum JsType {
         /// Use the default type.
@@ -581,13 +581,13 @@ pub mod field_options {
         JsNumber = 2,
     }
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
@@ -603,7 +603,7 @@ pub struct EnumOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct EnumValueOptions {
     /// Is this enum value deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -615,7 +615,7 @@ pub struct EnumValueOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct ServiceOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -632,7 +632,7 @@ pub struct ServiceOptions {
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
 }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct MethodOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -655,7 +655,7 @@ pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
     /// or neither? HTTP based RPC implementation may choose GET verb for safe
     /// methods, and PUT verb for idempotent methods instead of the default POST.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     #[repr(i32)]
     pub enum IdempotencyLevel {
         IdempotencyUnknown = 0,
@@ -671,7 +671,7 @@ pub mod method_options {
 /// options protos in descriptor objects (e.g. returned by Descriptor::options(),
 /// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 /// in them.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag="2")]
     pub name: ::std::vec::Vec<uninterpreted_option::NamePart>,
@@ -696,7 +696,7 @@ pub mod uninterpreted_option {
     /// extension (denoted with parentheses in options specs in .proto files).
     /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
     /// "foo.(bar.baz).qux".
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct NamePart {
         #[prost(string, required, tag="1")]
         pub name_part: String,
@@ -709,7 +709,7 @@ pub mod uninterpreted_option {
 
 /// Encapsulates information about the original source file from which a
 /// FileDescriptorProto was generated.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct SourceCodeInfo {
     /// A Location identifies a piece of source code in a .proto file which
     /// corresponds to a particular definition.  This information is intended
@@ -758,7 +758,7 @@ pub struct SourceCodeInfo {
     pub location: ::std::vec::Vec<source_code_info::Location>,
 }
 pub mod source_code_info {
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct Location {
         /// Identifies which part of the FileDescriptorProto was defined at this
         /// location.
@@ -850,7 +850,7 @@ pub mod source_code_info {
 /// Describes the relationship between generated code and its original source
 /// file. A GeneratedCodeInfo message is associated with only one generated
 /// source file, but may contain references to different source .proto files.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
@@ -858,7 +858,7 @@ pub struct GeneratedCodeInfo {
     pub annotation: ::std::vec::Vec<generated_code_info::Annotation>,
 }
 pub mod generated_code_info {
-    #[derive(Clone, PartialEq, Message)]
+    #[derive(Clone, PartialEq, ::prost_derive::Message)]
     pub struct Annotation {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
@@ -958,7 +958,7 @@ pub mod generated_code_info {
 ///       "value": "1.212s"
 ///     }
 ///
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Any {
     /// A URL/resource name that uniquely identifies the type of the serialized
     /// protocol buffer message. The last segment of the URL's path must represent
@@ -995,7 +995,7 @@ pub struct Any {
 }
 /// `SourceContext` represents information about the source of a
 /// protobuf element, like the file in which it is defined.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
@@ -1003,7 +1003,7 @@ pub struct SourceContext {
     pub file_name: String,
 }
 /// A protocol buffer message type.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Type {
     /// The fully qualified message name.
     #[prost(string, tag="1")]
@@ -1025,7 +1025,7 @@ pub struct Type {
     pub syntax: i32,
 }
 /// A single field of a message type.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Field {
     /// The field type.
     #[prost(enumeration="field::Kind", tag="1")]
@@ -1062,7 +1062,7 @@ pub struct Field {
 }
 pub mod field {
     /// Basic field types.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     #[repr(i32)]
     pub enum Kind {
         /// Field type unknown.
@@ -1105,7 +1105,7 @@ pub mod field {
         TypeSint64 = 18,
     }
     /// Whether a field is optional, required, or repeated.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
     #[repr(i32)]
     pub enum Cardinality {
         /// For fields with unknown cardinality.
@@ -1119,7 +1119,7 @@ pub mod field {
     }
 }
 /// Enum type definition.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Enum {
     /// Enum type name.
     #[prost(string, tag="1")]
@@ -1138,7 +1138,7 @@ pub struct Enum {
     pub syntax: i32,
 }
 /// Enum value definition.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct EnumValue {
     /// Enum value name.
     #[prost(string, tag="1")]
@@ -1152,7 +1152,7 @@ pub struct EnumValue {
 }
 /// A protocol buffer option, which can be attached to a message, field,
 /// enumeration, etc.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Option {
     /// The option's name. For protobuf built-in options (options defined in
     /// descriptor.proto), this is the short name. For example, `"map_entry"`.
@@ -1168,7 +1168,7 @@ pub struct Option {
     pub value: ::std::option::Option<Any>,
 }
 /// The syntax in which a protocol buffer element is defined.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
 #[repr(i32)]
 pub enum Syntax {
     /// Syntax `proto2`.
@@ -1185,7 +1185,7 @@ pub enum Syntax {
 /// sometimes simply referred to as "APIs" in other contexts, such as the name of
 /// this message itself. See https://cloud.google.com/apis/design/glossary for
 /// detailed terminology.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
@@ -1232,7 +1232,7 @@ pub struct Api {
     pub syntax: i32,
 }
 /// Method represents a method of an API interface.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Method {
     /// The simple name of this method.
     #[prost(string, tag="1")]
@@ -1334,7 +1334,7 @@ pub struct Method {
 ///       }
 ///       ...
 ///     }
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
     #[prost(string, tag="1")]
@@ -1404,7 +1404,7 @@ pub struct Mixin {
 /// microsecond should be expressed in JSON format as "3.000001s".
 ///
 ///
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
@@ -1627,7 +1627,7 @@ pub struct Duration {
 /// The implementation of any API method which has a FieldMask type field in the
 /// request should verify the included field paths, and return an
 /// `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag="1")]
@@ -1641,7 +1641,7 @@ pub struct FieldMask {
 /// with the proto support for the language.
 ///
 /// The JSON representation for `Struct` is JSON object.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map="string, message", tag="1")]
@@ -1653,7 +1653,7 @@ pub struct Struct {
 /// variants, absence of any variant indicates an error.
 ///
 /// The JSON representation for `Value` is JSON value.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Value {
     /// The kind of value.
     #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
@@ -1661,7 +1661,7 @@ pub struct Value {
 }
 pub mod value {
     /// The kind of value.
-    #[derive(Clone, Oneof, PartialEq)]
+    #[derive(Clone, PartialEq, ::prost_derive::Oneof)]
     pub enum Kind {
         /// Represents a null value.
         #[prost(enumeration="super::NullValue", tag="1")]
@@ -1686,7 +1686,7 @@ pub mod value {
 /// `ListValue` is a wrapper around a repeated field of values.
 ///
 /// The JSON representation for `ListValue` is JSON array.
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct ListValue {
     /// Repeated field of dynamically typed values.
     #[prost(message, repeated, tag="1")]
@@ -1696,7 +1696,7 @@ pub struct ListValue {
 /// `Value` type union.
 ///
 ///  The JSON representation for `NullValue` is JSON `null`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost_derive::Enumeration)]
 #[repr(i32)]
 pub enum NullValue {
     /// Null value.
@@ -1782,7 +1782,7 @@ pub enum NullValue {
 /// ) to obtain a formatter capable of generating timestamps in this format.
 ///
 ///
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost_derive::Message)]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -3,6 +3,7 @@ name = "protobuf"
 version = "0.0.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 publish = false
+edition = "2018"
 
 [dependencies]
 bytes = "0.4.7"

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -1,8 +1,6 @@
-extern crate curl;
-extern crate flate2;
-extern crate prost_build;
-extern crate tar;
-extern crate tempfile;
+use prost_build;
+
+use tempfile;
 
 use std::env;
 use std::fs;
@@ -88,9 +86,6 @@ fn main() {
     // that encode/decode roundtrips can use encoded output for comparison. Otherwise trying to
     // compare based on the Rust PartialEq implementations is difficult, due to presence of NaN
     // values.
-    let mut config = prost_build::Config::new();
-    config.btree_map(&["."]);
-
     prost_build::Config::new()
         .btree_map(&["."])
         .compile_protos(

--- a/protobuf/src/lib.rs
+++ b/protobuf/src/lib.rs
@@ -1,10 +1,3 @@
-extern crate bytes;
-extern crate prost;
-extern crate prost_types;
-
-#[macro_use]
-extern crate prost_derive;
-
 pub mod benchmarks {
     include!(concat!(env!("OUT_DIR"), "/benchmarks.rs"));
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,7 +45,7 @@ impl DecodeError {
 }
 
 impl fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("failed to decode Protobuf message: ")?;
         for &(message, field) in &self.stack {
             write!(f, "{}.{}: ", message, field)?;
@@ -98,7 +98,7 @@ impl EncodeError {
 }
 
 impl fmt::Display for EncodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(error::Error::description(self))?;
         write!(
             f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/prost/0.4.0")]
 
-extern crate bytes;
-
-#[cfg(test)]
-#[macro_use]
-extern crate quickcheck;
-
 mod error;
 mod message;
 mod types;
@@ -13,12 +7,12 @@ mod types;
 #[doc(hidden)]
 pub mod encoding;
 
-pub use error::{DecodeError, EncodeError};
-pub use message::Message;
+pub use crate::error::{DecodeError, EncodeError};
+pub use crate::message::Message;
 
 use bytes::{BufMut, IntoBuf};
 
-use encoding::{decode_varint, encode_varint, encoded_len_varint};
+use crate::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
 /// Encodes a length delimiter to the buffer.
 ///

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 use std::usize;
 
-use bytes::{Buf, BufMut, IntoBuf};
+use ::bytes::{Buf, BufMut, IntoBuf};
 
-use encoding::*;
-use DecodeError;
-use EncodeError;
+use crate::encoding::*;
+use crate::DecodeError;
+use crate::EncodeError;
 
 /// A Protocol Buffers message.
 pub trait Message: Debug + Send + Sync {

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,11 +5,11 @@
 //! the `prost-types` crate in order to avoid a cyclic dependency between `prost` and
 //! `prost-build`.
 
-use bytes::{Buf, BufMut};
+use ::bytes::{Buf, BufMut};
 
-use encoding::*;
-use DecodeError;
-use Message;
+use crate::encoding::*;
+use crate::DecodeError;
+use crate::Message;
 
 /// `google.protobuf.BoolValue`
 impl Message for bool {

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -1,14 +1,19 @@
 [package]
-name = "tests"
+name = "tests-2015"
 version = "0.0.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 publish = false
-edition = "2018"
+edition = "2015"
 
-build = "src/build.rs"
+build = "../tests/src/build.rs"
 
 [lib]
 doctest = false
+path = "../tests/src/lib.rs"
+
+[features]
+default = ["edition-2015"]
+edition-2015 = []
 
 [dependencies]
 bytes = "0.4.7"

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -19,11 +19,10 @@ fn bootstrap() {
         .tempdir()
         .unwrap();
 
-    let mut config = prost_build::Config::new();
-    config.compile_well_known_types();
-    config.btree_map(&["."]);
-    config.out_dir(tempdir.path());
-    config
+    prost_build::Config::new()
+        .compile_well_known_types()
+        .btree_map(&["."])
+        .out_dir(tempdir.path())
         .compile_protos(
             &[
                 // Protobuf Plugins.

--- a/tests/src/debug.rs
+++ b/tests/src/debug.rs
@@ -4,7 +4,7 @@
 //! actual use.
 
 // Borrow some types from other places.
-use message_encoding::{Basic, BasicEnumeration};
+use crate::message_encoding::{Basic, BasicEnumeration};
 
 /// Some real-life message
 #[test]
@@ -62,7 +62,7 @@ fn tuple_struct() {
 }
 */
 
-#[derive(Clone, PartialEq, Oneof)]
+#[derive(Clone, PartialEq, prost_derive::Oneof)]
 pub enum OneofWithEnum {
     #[prost(int32, tag = "8")]
     Int(i32),
@@ -72,7 +72,7 @@ pub enum OneofWithEnum {
     Enumeration(i32),
 }
 
-#[derive(Clone, PartialEq, Message)]
+#[derive(Clone, PartialEq, prost_derive::Message)]
 struct MessageWithOneof {
     #[prost(oneof = "OneofWithEnum", tags = "8, 9, 10")]
     of: Option<OneofWithEnum>,

--- a/tests/src/extern_paths.rs
+++ b/tests/src/extern_paths.rs
@@ -14,8 +14,8 @@ pub mod widget {
 
 #[test]
 fn test() {
-    use packages::gizmo;
-    use packages::DoIt;
+    use crate::packages::gizmo;
+    use crate::packages::DoIt;
     use prost::Message;
 
     let mut widget_factory = widget::factory::WidgetFactory::default();

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,15 +1,20 @@
-extern crate bytes;
-extern crate prost;
-extern crate prost_types;
-extern crate protobuf;
+#[macro_use]
+extern crate cfg_if;
 
 #[macro_use]
 extern crate prost_derive;
 
-#[cfg(test)]
-extern crate prost_build;
-#[cfg(test)]
-extern crate tempfile;
+cfg_if! {
+    if #[cfg(feature = "edition-2015")] {
+        extern crate bytes;
+        extern crate prost;
+        extern crate protobuf;
+        #[cfg(test)]
+        extern crate prost_build;
+        #[cfg(test)]
+        extern crate tempfile;
+    }
+}
 
 pub mod extern_paths;
 pub mod packages;
@@ -78,7 +83,7 @@ pub enum RoundtripResult {
     /// or it could indicate that the input was bogus.
     DecodeError(prost::DecodeError),
     /// Re-encoding or validating the data failed.  This indicates a bug in `prost`.
-    Error(Box<Error + Send + Sync>),
+    Error(Box<dyn Error + Send + Sync>),
 }
 
 impl RoundtripResult {
@@ -269,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_nesting() {
-        use nesting::{A, B};
+        use crate::nesting::{A, B};
         let _ = A {
             a: Some(Box::new(A::default())),
             repeated_a: Vec::<A>::new(),
@@ -282,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_recursive_oneof() {
-        use recursive_oneof::{a, A, B, C};
+        use crate::recursive_oneof::{a, A, B, C};
         let _ = A {
             kind: Some(a::Kind::B(Box::new(B {
                 a: Some(Box::new(A {

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -1,7 +1,7 @@
 use prost::Message;
 
-use check_message;
-use check_serialize_equivalent;
+use crate::check_message;
+use crate::check_serialize_equivalent;
 
 #[derive(Clone, PartialEq, Message)]
 pub struct RepeatedFloats {


### PR DESCRIPTION
Notable changes:

* `prost` crates are now edition 2018
* Code generation is now compatible with edition-2018 crates, as well as
  edition-2015 crates. No explicit configuration is necessary to enable
  edition-2018 support.
* Reserved field names now use raw identifiers instead of adding an
  underscore.
* The tests crate now executes for both 2018 and 2015 edition via
  separate crates with a symlink between the src/ directory.

This is essentially @nrc's work in #147, but with some simplifications and additional tests.