### PR TITLE
Implement a recursion limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ exclude = [
 ]
 
 [features]
-default = ["prost-derive"]
+default = ["prost-derive", "recursion-limit"]
+recursion-limit = []
 
 [dependencies]
 byteorder = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ exclude = [
 ]
 
 [features]
-default = ["prost-derive", "recursion-limit"]
-recursion-limit = []
+default = ["prost-derive"]
+no-recursion-limit = []
 
 [dependencies]
 byteorder = "1"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -5,6 +5,7 @@ use std::result;
 use criterion::{Benchmark, Criterion, Throughput};
 use failure::bail;
 use prost::Message;
+use prost::encoding::DecodeContext;
 use protobuf::benchmarks::{google_message3, google_message4, proto2, proto3, BenchmarkDataset};
 
 type Result = result::Result<(), failure::Error>;
@@ -48,12 +49,13 @@ where
     .throughput(Throughput::Bytes(payload_len as u32));
 
     let payload = dataset.payload.clone();
+    let mut ctx = DecodeContext::default();
     let merge = Benchmark::new("merge", move |b| {
         let mut message = M::default();
         b.iter(|| {
             for buf in &payload {
                 message.clear();
-                message.merge(buf).unwrap();
+                message.merge(buf, &mut ctx).unwrap();
                 criterion::black_box(&message);
             }
         })

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -4,7 +4,6 @@ use std::result;
 
 use criterion::{Benchmark, Criterion, Throughput};
 use failure::bail;
-use prost::Message;
 use prost::encoding::DecodeContext;
 use protobuf::benchmarks::{google_message3, google_message4, proto2, proto3, BenchmarkDataset};
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -54,7 +54,7 @@ where
         b.iter(|| {
             for buf in &payload {
                 message.clear();
-                message.merge(buf, DecodeContext::default()).unwrap();
+                message.merge(buf).unwrap();
                 criterion::black_box(&message);
             }
         })

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -5,6 +5,7 @@ use std::result;
 use criterion::{Benchmark, Criterion, Throughput};
 use failure::bail;
 use prost::encoding::DecodeContext;
+use prost::Message;
 use protobuf::benchmarks::{google_message3, google_message4, proto2, proto3, BenchmarkDataset};
 
 type Result = result::Result<(), failure::Error>;
@@ -48,13 +49,12 @@ where
     .throughput(Throughput::Bytes(payload_len as u32));
 
     let payload = dataset.payload.clone();
-    let mut ctx = DecodeContext::default();
     let merge = Benchmark::new("merge", move |b| {
         let mut message = M::default();
         b.iter(|| {
             for buf in &payload {
                 message.clear();
-                message.merge(buf, &mut ctx).unwrap();
+                message.merge(buf, DecodeContext::default()).unwrap();
                 criterion::black_box(&message);
             }
         })

--- a/prost-derive/src/field/group.rs
+++ b/prost-derive/src/field/group.rs
@@ -91,13 +91,14 @@ impl Field {
             Label::Optional => quote! {
                 _prost::encoding::group::merge(tag, wire_type,
                                                  #ident.get_or_insert_with(Default::default),
-                                                 buf)
+                                                 buf,
+                                                 ctx)
             },
             Label::Required => quote! {
-                _prost::encoding::group::merge(tag, wire_type, &mut #ident, buf)
+                _prost::encoding::group::merge(tag, wire_type, &mut #ident, buf, ctx)
             },
             Label::Repeated => quote! {
-                _prost::encoding::group::merge_repeated(tag, wire_type, &mut #ident, buf)
+                _prost::encoding::group::merge_repeated(tag, wire_type, &mut #ident, buf, ctx)
             },
         }
     }

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -162,17 +162,17 @@ impl Field {
                 let default = quote!(#ty::default() as i32);
                 quote! {
                     _prost::encoding::#module::merge_with_default(#km, _prost::encoding::int32::merge,
-                                                                  #default, &mut #ident, buf)
+                                                                  #default, &mut #ident, buf, ctx)
                 }
             }
             ValueTy::Scalar(ref value_ty) => {
                 let val_mod = value_ty.module();
                 let vm = quote!(_prost::encoding::#val_mod::merge);
-                quote!(_prost::encoding::#module::merge(#km, #vm, &mut #ident, buf))
+                quote!(_prost::encoding::#module::merge(#km, #vm, &mut #ident, buf, ctx))
             }
             ValueTy::Message => {
                 quote!(_prost::encoding::#module::merge(#km, _prost::encoding::message::merge,
-                                                        &mut #ident, buf))
+                                                        &mut #ident, buf, ctx))
             }
         }
     }

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -94,13 +94,14 @@ impl Field {
             Label::Optional => quote! {
                 _prost::encoding::message::merge(wire_type,
                                                  #ident.get_or_insert_with(Default::default),
-                                                 buf)
+                                                 buf,
+                                                 ctx)
             },
             Label::Required => quote! {
-                _prost::encoding::message::merge(wire_type, &mut #ident, buf)
+                _prost::encoding::message::merge(wire_type, &mut #ident, buf, ctx)
             },
             Label::Repeated => quote! {
-                _prost::encoding::message::merge_repeated(wire_type, &mut #ident, buf)
+                _prost::encoding::message::merge_repeated(wire_type, &mut #ident, buf, ctx)
             },
         }
     }

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -77,7 +77,7 @@ impl Field {
     pub fn merge(&self, ident: TokenStream) -> TokenStream {
         let ty = &self.ty;
         quote! {
-            #ty::merge(&mut #ident, tag, wire_type, buf)
+            #ty::merge(&mut #ident, tag, wire_type, buf, ctx)
         }
     }
 

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -153,12 +153,13 @@ impl Field {
 
         match self.kind {
             Kind::Plain(..) | Kind::Required(..) | Kind::Repeated | Kind::Packed => quote! {
-                #merge_fn(wire_type, &mut #ident, buf)
+                #merge_fn(wire_type, &mut #ident, buf, ctx)
             },
             Kind::Optional(..) => quote! {
                 #merge_fn(wire_type,
                           #ident.get_or_insert_with(Default::default),
-                          buf)
+                          buf,
+                          ctx)
             },
         }
     }

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -189,7 +189,9 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                 fn merge_field<B>(&mut self,
                                   tag: u32,
                                   wire_type: _prost::encoding::WireType,
-                                  buf: &mut B) -> ::std::result::Result<(), _prost::DecodeError>
+                                  buf: &mut B,
+                                  ctx: &mut _prost::encoding::DecodeContext,
+                ) -> ::std::result::Result<(), _prost::DecodeError>
                 where B: _bytes::Buf {
                     #struct_name
                     match tag {
@@ -446,8 +448,9 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
                 pub fn merge<B>(field: &mut ::std::option::Option<#ident>,
                                 tag: u32,
                                 wire_type: _prost::encoding::WireType,
-                                buf: &mut B)
-                                -> ::std::result::Result<(), _prost::DecodeError>
+                                buf: &mut B,
+                                ctx: &mut _prost::encoding::DecodeContext,
+                ) -> ::std::result::Result<(), _prost::DecodeError>
                 where B: _bytes::Buf {
                     match tag {
                         #(#merge,)*

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -190,7 +190,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                                   tag: u32,
                                   wire_type: _prost::encoding::WireType,
                                   buf: &mut B,
-                                  ctx: &mut _prost::encoding::DecodeContext,
+                                  ctx: _prost::encoding::DecodeContext,
                 ) -> ::std::result::Result<(), _prost::DecodeError>
                 where B: _bytes::Buf {
                     #struct_name
@@ -449,7 +449,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
                                 tag: u32,
                                 wire_type: _prost::encoding::WireType,
                                 buf: &mut B,
-                                ctx: &mut _prost::encoding::DecodeContext,
+                                ctx: _prost::encoding::DecodeContext,
                 ) -> ::std::result::Result<(), _prost::DecodeError>
                 where B: _bytes::Buf {
                     match tag {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -77,15 +77,17 @@ where
     }
 }
 
+/// Additional information passed to every decode/merge function.
 #[derive(Clone, Debug)]
 pub struct DecodeContext {
     #[cfg(feature = "recursion-limit")]
+    /// How many times we can recurse in the current decode stack before we hit
+    /// the recursion limit.
+    ///
+    /// The recursion limit is defined by `RECURSION_LIMIT` and cannot be
+    /// customized. The recursion limit can be ignored by building the Prost
+    /// crate without the `recursion-limit` feature (which is set by default).
     recurse_count: u32,
-}
-
-pub(crate) struct RecursionGuard {
-    #[cfg(feature = "recursion-limit")]
-    ctx: *mut DecodeContext,
 }
 
 impl Default for DecodeContext {
@@ -95,23 +97,21 @@ impl Default for DecodeContext {
             recurse_count: crate::RECURSION_LIMIT,
         }
     }
+
     #[cfg(not(feature = "recursion-limit"))]
     fn default() -> DecodeContext {
         DecodeContext {}
     }
 }
 
-#[cfg(feature = "recursion-limit")]
-impl Drop for RecursionGuard {
-    fn drop(&mut self) {
-        unsafe {
-            (*self.ctx).recurse_count += 1;
-        }
-    }
-}
-
 impl DecodeContext {
     #[cfg(feature = "recursion-limit")]
+    /// Call this function before recursively decoding.
+    ///
+    /// This function returns a guard object which will automatically restore
+    /// the recursion counter when it is destroyed by going out of scope.
+    ///
+    /// See the safety note on `RecursionGuard` for important information.
     pub(crate) fn enter_recursion(&mut self) -> RecursionGuard {
         self.recurse_count -= 1;
         RecursionGuard { ctx: self }
@@ -124,8 +124,49 @@ impl DecodeContext {
     }
 }
 
+/// RAII guard created by `DecodeContext::enter_recursion` to ensure recursion is
+/// tracked correctly.
+///
+/// ## Safety note
+///
+/// This object uses a raw pointer and unsafe code to avoid dynamic ownership
+/// checking of it's reference to a `DecodeContext`. This could be implemented
+/// using `Rc` and `RefCell` or closures, but that could be expensive since we
+/// might expect decoding to be in a program's hot path.
+///
+/// Usage is safe under normal usage patterns:
+///
+/// ```ignore
+/// fn foo(..., ctx: &mut DecodeContext) {
+///     let _guard = ctx.enter_recursion();  // `_guard` keeps a mutable reference to ctx.
+///     some_recusive_fn(..., ctx);          // `ctx` is passed to `some_recusive_fn`.
+/// }
+/// ```
+///
+/// In the above scenario, `ctx.recurse_count` must be the same before and after
+/// the call to `some_recusive_fn`. In particular, it must still be valid memory.
+/// `_guard` should not be passed out of `foo` nor should it be stored.
+pub(crate) struct RecursionGuard {
+    #[cfg(feature = "recursion-limit")]
+    ctx: *mut DecodeContext,
+}
+
+#[cfg(feature = "recursion-limit")]
+impl Drop for RecursionGuard {
+    fn drop(&mut self) {
+        unsafe {
+            (*self.ctx).recurse_count += 1;
+        }
+    }
+}
+
 impl RecursionGuard {
     #[cfg(feature = "recursion-limit")]
+    /// Checks whether the recursion limit has been reached in the stack of
+    /// decodes described by the `DecodeContext` at `self.ctx`.
+    ///
+    /// Returns `Ok<()>` if it is ok to continue recursing.
+    /// Returns `Err<DecodeError>` if the recursion limit has been reached.
     pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
         unsafe {
             if (*self.ctx).recurse_count == 0 {
@@ -142,6 +183,7 @@ impl RecursionGuard {
         Ok(())
     }
 }
+
 /// Decodes a LEB128-encoded variable length integer from the slice, returning the value and the
 /// number of bytes read.
 ///

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -184,13 +184,13 @@ where
 /// to a function which is decoding a nested object, then use `enter_recursion`.
 #[derive(Clone, Debug)]
 pub struct DecodeContext {
-    #[cfg(not(feature = "no-recursion-limit"))]
     /// How many times we can recurse in the current decode stack before we hit
     /// the recursion limit.
     ///
     /// The recursion limit is defined by `RECURSION_LIMIT` and cannot be
     /// customized. The recursion limit can be ignored by building the Prost
     /// crate with the `no-recursion-limit` feature (which is set by default).
+    #[cfg(not(feature = "no-recursion-limit"))]
     recurse_count: u32,
 }
 
@@ -211,12 +211,12 @@ impl Default for DecodeContext {
 }
 
 impl DecodeContext {
-    #[cfg(not(feature = "no-recursion-limit"))]
     /// Call this function before recursively decoding.
     ///
     /// There is no `exit` function since this function creates a new `DecodeContext`
     /// to be used at the next level of recursion. Continue to use the old context
     // at the previous level of recursion.
+    #[cfg(not(feature = "no-recursion-limit"))]
     #[inline(always)]
     pub(crate) fn enter_recursion(&self) -> DecodeContext {
         DecodeContext {
@@ -230,12 +230,12 @@ impl DecodeContext {
         DecodeContext {}
     }
 
-    #[cfg(not(feature = "no-recursion-limit"))]
     /// Checks whether the recursion limit has been reached in the stack of
     /// decodes described by the `DecodeContext` at `self.ctx`.
     ///
     /// Returns `Ok<()>` if it is ok to continue recursing.
     /// Returns `Err<DecodeError>` if the recursion limit has been reached.
+    #[cfg(not(feature = "no-recursion-limit"))]
     #[inline(always)]
     pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
         if self.recurse_count == 0 {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -80,56 +80,60 @@ where
 /// Additional information passed to every decode/merge function.
 #[derive(Clone, Debug)]
 pub struct DecodeContext {
-    #[cfg(feature = "recursion-limit")]
+    #[cfg(not(feature = "no-recursion-limit"))]
     /// How many times we can recurse in the current decode stack before we hit
     /// the recursion limit.
     ///
     /// The recursion limit is defined by `RECURSION_LIMIT` and cannot be
     /// customized. The recursion limit can be ignored by building the Prost
-    /// crate without the `recursion-limit` feature (which is set by default).
+    /// crate without the `no-recursion-limit` feature (which is set by default).
     recurse_count: u32,
 }
 
 impl Default for DecodeContext {
-    #[cfg(feature = "recursion-limit")]
+    #[cfg(not(feature = "no-recursion-limit"))]
+    #[inline(always)]
     fn default() -> DecodeContext {
         DecodeContext {
             recurse_count: crate::RECURSION_LIMIT,
         }
     }
 
-    #[cfg(not(feature = "recursion-limit"))]
+    #[cfg(feature = "no-recursion-limit")]
+    #[inline(always)]
     fn default() -> DecodeContext {
         DecodeContext {}
     }
 }
 
 impl DecodeContext {
-    #[cfg(feature = "recursion-limit")]
+    #[cfg(not(feature = "no-recursion-limit"))]
     /// Call this function before recursively decoding.
     ///
     /// This function returns a guard object which will automatically restore
     /// the recursion counter when it is destroyed by going out of scope.
     ///
     /// See the safety note on `RecursionGuard` for important information.
+    #[inline(always)]
     pub(crate) fn enter_recursion(&self) -> DecodeContext {
         DecodeContext {
             recurse_count: self.recurse_count - 1,
         }
     }
 
-    #[cfg(not(feature = "recursion-limit"))]
+    #[cfg(feature = "no-recursion-limit")]
     #[inline(always)]
     pub(crate) fn enter_recursion(&self) -> DecodeContext {
         DecodeContext {}
     }
 
-    #[cfg(feature = "recursion-limit")]
+    #[cfg(not(feature = "no-recursion-limit"))]
     /// Checks whether the recursion limit has been reached in the stack of
     /// decodes described by the `DecodeContext` at `self.ctx`.
     ///
     /// Returns `Ok<()>` if it is ok to continue recursing.
     /// Returns `Err<DecodeError>` if the recursion limit has been reached.
+    #[inline(always)]
     pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
         if self.recurse_count == 0 {
             Err(DecodeError::new("Recursion limit reached"))
@@ -138,7 +142,7 @@ impl DecodeContext {
         }
     }
 
-    #[cfg(not(feature = "recursion-limit"))]
+    #[cfg(feature = "no-recursion-limit")]
     #[inline(always)]
     pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
         Ok(())

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -189,14 +189,14 @@ pub struct DecodeContext {
     ///
     /// The recursion limit is defined by `RECURSION_LIMIT` and cannot be
     /// customized. The recursion limit can be ignored by building the Prost
-    /// crate with the `no-recursion-limit` feature (which is set by default).
+    /// crate with the `no-recursion-limit` feature.
     #[cfg(not(feature = "no-recursion-limit"))]
     recurse_count: u32,
 }
 
 impl Default for DecodeContext {
     #[cfg(not(feature = "no-recursion-limit"))]
-    #[inline(always)]
+    #[inline]
     fn default() -> DecodeContext {
         DecodeContext {
             recurse_count: crate::RECURSION_LIMIT,
@@ -204,7 +204,7 @@ impl Default for DecodeContext {
     }
 
     #[cfg(feature = "no-recursion-limit")]
-    #[inline(always)]
+    #[inline]
     fn default() -> DecodeContext {
         DecodeContext {}
     }
@@ -217,7 +217,7 @@ impl DecodeContext {
     /// to be used at the next level of recursion. Continue to use the old context
     // at the previous level of recursion.
     #[cfg(not(feature = "no-recursion-limit"))]
-    #[inline(always)]
+    #[inline]
     pub(crate) fn enter_recursion(&self) -> DecodeContext {
         DecodeContext {
             recurse_count: self.recurse_count - 1,
@@ -225,7 +225,7 @@ impl DecodeContext {
     }
 
     #[cfg(feature = "no-recursion-limit")]
-    #[inline(always)]
+    #[inline]
     pub(crate) fn enter_recursion(&self) -> DecodeContext {
         DecodeContext {}
     }
@@ -236,17 +236,17 @@ impl DecodeContext {
     /// Returns `Ok<()>` if it is ok to continue recursing.
     /// Returns `Err<DecodeError>` if the recursion limit has been reached.
     #[cfg(not(feature = "no-recursion-limit"))]
-    #[inline(always)]
+    #[inline]
     pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
         if self.recurse_count == 0 {
-            Err(DecodeError::new("Recursion limit reached"))
+            Err(DecodeError::new("recursion limit reached"))
         } else {
             Ok(())
         }
     }
 
     #[cfg(feature = "no-recursion-limit")]
-    #[inline(always)]
+    #[inline]
     pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
         Ok(())
     }
@@ -1424,7 +1424,12 @@ mod test {
     fn string_merge_failure() {
         let mut s = String::new();
         let mut buf = Cursor::new(b"\x80\x80");
-        let r = string::merge(WireType::LengthDelimited, &mut s, &mut buf);
+        let r = string::merge(
+            WireType::LengthDelimited,
+            &mut s,
+            &mut buf,
+            DecodeContext::default(),
+        );
         r.expect_err("must be an error");
         assert!(s.is_empty());
     }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -77,78 +77,6 @@ where
     }
 }
 
-/// Additional information passed to every decode/merge function.
-#[derive(Clone, Debug)]
-pub struct DecodeContext {
-    #[cfg(not(feature = "no-recursion-limit"))]
-    /// How many times we can recurse in the current decode stack before we hit
-    /// the recursion limit.
-    ///
-    /// The recursion limit is defined by `RECURSION_LIMIT` and cannot be
-    /// customized. The recursion limit can be ignored by building the Prost
-    /// crate without the `no-recursion-limit` feature (which is set by default).
-    recurse_count: u32,
-}
-
-impl Default for DecodeContext {
-    #[cfg(not(feature = "no-recursion-limit"))]
-    #[inline(always)]
-    fn default() -> DecodeContext {
-        DecodeContext {
-            recurse_count: crate::RECURSION_LIMIT,
-        }
-    }
-
-    #[cfg(feature = "no-recursion-limit")]
-    #[inline(always)]
-    fn default() -> DecodeContext {
-        DecodeContext {}
-    }
-}
-
-impl DecodeContext {
-    #[cfg(not(feature = "no-recursion-limit"))]
-    /// Call this function before recursively decoding.
-    ///
-    /// This function returns a guard object which will automatically restore
-    /// the recursion counter when it is destroyed by going out of scope.
-    ///
-    /// See the safety note on `RecursionGuard` for important information.
-    #[inline(always)]
-    pub(crate) fn enter_recursion(&self) -> DecodeContext {
-        DecodeContext {
-            recurse_count: self.recurse_count - 1,
-        }
-    }
-
-    #[cfg(feature = "no-recursion-limit")]
-    #[inline(always)]
-    pub(crate) fn enter_recursion(&self) -> DecodeContext {
-        DecodeContext {}
-    }
-
-    #[cfg(not(feature = "no-recursion-limit"))]
-    /// Checks whether the recursion limit has been reached in the stack of
-    /// decodes described by the `DecodeContext` at `self.ctx`.
-    ///
-    /// Returns `Ok<()>` if it is ok to continue recursing.
-    /// Returns `Err<DecodeError>` if the recursion limit has been reached.
-    #[inline(always)]
-    pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
-        if self.recurse_count == 0 {
-            Err(DecodeError::new("Recursion limit reached"))
-        } else {
-            Ok(())
-        }
-    }
-
-    #[cfg(feature = "no-recursion-limit")]
-    #[inline(always)]
-    pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
-        Ok(())
-    }
-}
-
 /// Decodes a LEB128-encoded variable length integer from the slice, returning the value and the
 /// number of bytes read.
 ///
@@ -248,6 +176,78 @@ where
     }
 
     Err(DecodeError::new("invalid varint"))
+}
+
+/// Additional information passed to every decode/merge function.
+#[derive(Clone, Debug)]
+pub struct DecodeContext {
+    #[cfg(not(feature = "no-recursion-limit"))]
+    /// How many times we can recurse in the current decode stack before we hit
+    /// the recursion limit.
+    ///
+    /// The recursion limit is defined by `RECURSION_LIMIT` and cannot be
+    /// customized. The recursion limit can be ignored by building the Prost
+    /// crate without the `no-recursion-limit` feature (which is set by default).
+    recurse_count: u32,
+}
+
+impl Default for DecodeContext {
+    #[cfg(not(feature = "no-recursion-limit"))]
+    #[inline(always)]
+    fn default() -> DecodeContext {
+        DecodeContext {
+            recurse_count: crate::RECURSION_LIMIT,
+        }
+    }
+
+    #[cfg(feature = "no-recursion-limit")]
+    #[inline(always)]
+    fn default() -> DecodeContext {
+        DecodeContext {}
+    }
+}
+
+impl DecodeContext {
+    #[cfg(not(feature = "no-recursion-limit"))]
+    /// Call this function before recursively decoding.
+    ///
+    /// This function returns a guard object which will automatically restore
+    /// the recursion counter when it is destroyed by going out of scope.
+    ///
+    /// See the safety note on `RecursionGuard` for important information.
+    #[inline(always)]
+    pub(crate) fn enter_recursion(&self) -> DecodeContext {
+        DecodeContext {
+            recurse_count: self.recurse_count - 1,
+        }
+    }
+
+    #[cfg(feature = "no-recursion-limit")]
+    #[inline(always)]
+    pub(crate) fn enter_recursion(&self) -> DecodeContext {
+        DecodeContext {}
+    }
+
+    #[cfg(not(feature = "no-recursion-limit"))]
+    /// Checks whether the recursion limit has been reached in the stack of
+    /// decodes described by the `DecodeContext` at `self.ctx`.
+    ///
+    /// Returns `Ok<()>` if it is ok to continue recursing.
+    /// Returns `Err<DecodeError>` if the recursion limit has been reached.
+    #[inline(always)]
+    pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
+        if self.recurse_count == 0 {
+            Err(DecodeError::new("Recursion limit reached"))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(feature = "no-recursion-limit")]
+    #[inline(always)]
+    pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
+        Ok(())
+    }
 }
 
 /// Returns the encoded length of the value in LEB128 variable length format.

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -179,6 +179,9 @@ where
 }
 
 /// Additional information passed to every decode/merge function.
+///
+/// The context should be passed by value and can be freely cloned. When passing
+/// to a function which is decoding a nested object, then use `enter_recursion`.
 #[derive(Clone, Debug)]
 pub struct DecodeContext {
     #[cfg(not(feature = "no-recursion-limit"))]
@@ -187,7 +190,7 @@ pub struct DecodeContext {
     ///
     /// The recursion limit is defined by `RECURSION_LIMIT` and cannot be
     /// customized. The recursion limit can be ignored by building the Prost
-    /// crate without the `no-recursion-limit` feature (which is set by default).
+    /// crate with the `no-recursion-limit` feature (which is set by default).
     recurse_count: u32,
 }
 
@@ -211,10 +214,9 @@ impl DecodeContext {
     #[cfg(not(feature = "no-recursion-limit"))]
     /// Call this function before recursively decoding.
     ///
-    /// This function returns a guard object which will automatically restore
-    /// the recursion counter when it is destroyed by going out of scope.
-    ///
-    /// See the safety note on `RecursionGuard` for important information.
+    /// There is no `exit` function since this function creates a new `DecodeContext`
+    /// to be used at the next level of recursion. Continue to use the old context
+    // at the previous level of recursion.
     #[inline(always)]
     pub(crate) fn enter_recursion(&self) -> DecodeContext {
         DecodeContext {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -927,7 +927,7 @@ pub mod message {
         M: Message,
     {
         let len = msg.encoded_len();
-        key_len(tag) + encoded_len_varint(len as u64) + msg.encoded_len()
+        key_len(tag) + encoded_len_varint(len as u64) + len
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use bytes::{BufMut, IntoBuf};
 
 use crate::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
+// See `encoding::DecodeContext` for more info.
 // 100 is the default recursion limit in the C++ implementation.
 #[cfg(feature = "recursion-limit")]
 const RECURSION_LIMIT: u32 = 100;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ use bytes::{BufMut, IntoBuf};
 
 use crate::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
+#[cfg(feature = "recursion-limit")]
+const RECURSION_LIMIT: u32 = 128
+
 /// Encodes a length delimiter to the buffer.
 ///
 /// See [Message.encode_length_delimited] for more info.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,9 @@ use bytes::{BufMut, IntoBuf};
 
 use crate::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
+// 100 is the default recursion limit in the C++ implementation.
 #[cfg(feature = "recursion-limit")]
-const RECURSION_LIMIT: u32 = 128;
+const RECURSION_LIMIT: u32 = 100;
 
 /// Encodes a length delimiter to the buffer.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use bytes::{BufMut, IntoBuf};
 use crate::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
 #[cfg(feature = "recursion-limit")]
-const RECURSION_LIMIT: u32 = 128
+const RECURSION_LIMIT: u32 = 128;
 
 /// Encodes a length delimiter to the buffer.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use crate::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
 // See `encoding::DecodeContext` for more info.
 // 100 is the default recursion limit in the C++ implementation.
-#[cfg(feature = "recursion-limit")]
+#[cfg(not(feature = "no-recursion-limit"))]
 const RECURSION_LIMIT: u32 = 100;
 
 /// Encodes a length delimiter to the buffer.

--- a/src/message.rs
+++ b/src/message.rs
@@ -121,7 +121,12 @@ pub trait Message: Debug + Send + Sync {
         B: IntoBuf,
         Self: Sized,
     {
-        message::merge(WireType::LengthDelimited, self, &mut buf.into_buf(), DecodeContext::default())
+        message::merge(
+            WireType::LengthDelimited,
+            self,
+            &mut buf.into_buf(),
+            DecodeContext::default(),
+        )
     }
 
     /// Clears the message, resetting all fields to their default.

--- a/src/message.rs
+++ b/src/message.rs
@@ -106,20 +106,8 @@ pub trait Message: Debug + Send + Sync {
         B: IntoBuf,
         Self: Sized,
     {
-        self.merge_with_context(buf, DecodeContext::default())
-    }
-
-    /// Decodes an instance of the message from a buffer, and merges it into `self`.
-    /// This version takes a `DecodeContext` which contains some state for the
-    /// current decoding. Most users will want to use `merge` without the context.
-    ///
-    /// The entire buffer will be consumed.
-    fn merge_with_context<B>(&mut self, buf: B, ctx: DecodeContext) -> Result<(), DecodeError>
-    where
-        B: IntoBuf,
-        Self: Sized,
-    {
         let mut buf = buf.into_buf();
+        let ctx = DecodeContext::default();
         while buf.has_remaining() {
             let (tag, wire_type) = decode_key(&mut buf)?;
             self.merge_field(tag, wire_type, &mut buf, ctx.clone())?;

--- a/src/message.rs
+++ b/src/message.rs
@@ -94,7 +94,7 @@ pub trait Message: Debug + Send + Sync {
         Self: Default,
     {
         let mut message = Self::default();
-        message.merge_length_delimited(buf, DecodeContext::default())?;
+        message.merge_length_delimited(buf)?;
         Ok(message)
     }
 
@@ -116,12 +116,12 @@ pub trait Message: Debug + Send + Sync {
 
     /// Decodes a length-delimited instance of the message from buffer, and
     /// merges it into `self`.
-    fn merge_length_delimited<B>(&mut self, buf: B, ctx: DecodeContext) -> Result<(), DecodeError>
+    fn merge_length_delimited<B>(&mut self, buf: B) -> Result<(), DecodeError>
     where
         B: IntoBuf,
         Self: Sized,
     {
-        message::merge(WireType::LengthDelimited, self, &mut buf.into_buf(), ctx)
+        message::merge(WireType::LengthDelimited, self, &mut buf.into_buf(), DecodeContext::default())
     }
 
     /// Clears the message, resetting all fields to their default.

--- a/src/message.rs
+++ b/src/message.rs
@@ -84,7 +84,7 @@ pub trait Message: Debug + Send + Sync {
         Self: Default,
     {
         let mut message = Self::default();
-        Self::merge(&mut message, &mut buf.into_buf(), DecodeContext::default()).map(|_| message)
+        Self::merge(&mut message, &mut buf.into_buf()).map(|_| message)
     }
 
     /// Decodes a length-delimited instance of the message from the buffer.
@@ -101,7 +101,20 @@ pub trait Message: Debug + Send + Sync {
     /// Decodes an instance of the message from a buffer, and merges it into `self`.
     ///
     /// The entire buffer will be consumed.
-    fn merge<B>(&mut self, buf: B, ctx: DecodeContext) -> Result<(), DecodeError>
+    fn merge<B>(&mut self, buf: B) -> Result<(), DecodeError>
+    where
+        B: IntoBuf,
+        Self: Sized,
+    {
+        self.merge_with_context(buf, DecodeContext::default())
+    }
+
+    /// Decodes an instance of the message from a buffer, and merges it into `self`.
+    /// This version takes a `DecodeContext` which contains some state for the
+    /// current decoding. Most users will want to use `merge` without the context.
+    ///
+    /// The entire buffer will be consumed.
+    fn merge_with_context<B>(&mut self, buf: B, ctx: DecodeContext) -> Result<(), DecodeError>
     where
         B: IntoBuf,
         Self: Sized,

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,12 +26,13 @@ impl Message for bool {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
+        ctx: &mut DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
     {
         if tag == 1 {
-            bool::merge(wire_type, self, buf)
+            bool::merge(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf)
         }
@@ -63,12 +64,13 @@ impl Message for u32 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
+        ctx: &mut DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
     {
         if tag == 1 {
-            uint32::merge(wire_type, self, buf)
+            uint32::merge(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf)
         }
@@ -100,12 +102,13 @@ impl Message for u64 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
+        ctx: &mut DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
     {
         if tag == 1 {
-            uint64::merge(wire_type, self, buf)
+            uint64::merge(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf)
         }
@@ -137,12 +140,13 @@ impl Message for i32 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
+        ctx: &mut DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
     {
         if tag == 1 {
-            int32::merge(wire_type, self, buf)
+            int32::merge(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf)
         }
@@ -174,12 +178,13 @@ impl Message for i64 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
+        ctx: &mut DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
     {
         if tag == 1 {
-            int64::merge(wire_type, self, buf)
+            int64::merge(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf)
         }
@@ -211,12 +216,13 @@ impl Message for f32 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
+        ctx: &mut DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
     {
         if tag == 1 {
-            float::merge(wire_type, self, buf)
+            float::merge(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf)
         }
@@ -248,12 +254,13 @@ impl Message for f64 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
+        ctx: &mut DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
     {
         if tag == 1 {
-            double::merge(wire_type, self, buf)
+            double::merge(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf)
         }
@@ -285,12 +292,13 @@ impl Message for String {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
+        ctx: &mut DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
     {
         if tag == 1 {
-            string::merge(wire_type, self, buf)
+            string::merge(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf)
         }
@@ -322,12 +330,13 @@ impl Message for Vec<u8> {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
+        ctx: &mut DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
     {
         if tag == 1 {
-            bytes::merge(wire_type, self, buf)
+            bytes::merge(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf)
         }
@@ -356,6 +365,7 @@ impl Message for () {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
+        _ctx: &mut DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,7 +26,7 @@ impl Message for bool {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
-        ctx: &mut DecodeContext,
+        ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
@@ -64,7 +64,7 @@ impl Message for u32 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
-        ctx: &mut DecodeContext,
+        ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
@@ -102,7 +102,7 @@ impl Message for u64 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
-        ctx: &mut DecodeContext,
+        ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
@@ -140,7 +140,7 @@ impl Message for i32 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
-        ctx: &mut DecodeContext,
+        ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
@@ -178,7 +178,7 @@ impl Message for i64 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
-        ctx: &mut DecodeContext,
+        ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
@@ -216,7 +216,7 @@ impl Message for f32 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
-        ctx: &mut DecodeContext,
+        ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
@@ -254,7 +254,7 @@ impl Message for f64 {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
-        ctx: &mut DecodeContext,
+        ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
@@ -292,7 +292,7 @@ impl Message for String {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
-        ctx: &mut DecodeContext,
+        ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
@@ -330,7 +330,7 @@ impl Message for Vec<u8> {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
-        ctx: &mut DecodeContext,
+        ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,
@@ -365,7 +365,7 @@ impl Message for () {
         tag: u32,
         wire_type: WireType,
         buf: &mut B,
-        _ctx: &mut DecodeContext,
+        _ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
         B: Buf,

--- a/tests/src/groups.proto
+++ b/tests/src/groups.proto
@@ -49,3 +49,9 @@ message NestedGroup {
         }
     }
 }
+
+message NestedGroup2 {
+    optional group OptionalGroup = 1 {
+        optional NestedGroup2 nested_group = 1;
+    }
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -342,6 +342,27 @@ mod tests {
     }
 
     #[test]
+    fn test_deep_nesting() {
+        fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+            use crate::nesting::A;
+
+            let mut top = A::default();
+            let mut a = &mut top;
+            for _ in 0..depth {
+                a.a = Some(Box::new(A::default()));
+                a = a.a.as_mut().unwrap().as_mut();
+            }
+
+            let mut buf = Vec::new();
+            top.encode(&mut buf).unwrap();
+            A::decode(buf).map(|_| ())
+        }
+
+        assert!(build_and_roundtrip(99).is_ok());
+        assert!(build_and_roundtrip(100).is_err());
+    }
+
+    #[test]
     fn test_recursive_oneof() {
         use crate::recursive_oneof::{a, A, B, C};
         let _ = A {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -358,8 +358,8 @@ mod tests {
             A::decode(buf).map(|_| ())
         }
 
-        assert!(build_and_roundtrip(99).is_ok());
-        assert!(build_and_roundtrip(100).is_err());
+        assert!(build_and_roundtrip(100).is_ok());
+        assert!(build_and_roundtrip(101).is_err());
     }
 
     #[test]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -346,20 +346,108 @@ mod tests {
         fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
             use crate::nesting::A;
 
-            let mut top = A::default();
-            let mut a = &mut top;
+            let mut a = Box::new(A::default());
             for _ in 0..depth {
-                a.a = Some(Box::new(A::default()));
-                a = a.a.as_mut().unwrap().as_mut();
+                let mut next = Box::new(A::default());
+                next.a = Some(a);
+                a = next;
             }
 
             let mut buf = Vec::new();
-            top.encode(&mut buf).unwrap();
+            a.encode(&mut buf).unwrap();
             A::decode(buf).map(|_| ())
         }
 
         assert!(build_and_roundtrip(100).is_ok());
         assert!(build_and_roundtrip(101).is_err());
+    }
+
+    #[test]
+    fn test_deep_nesting_oneof() {
+        fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+            use crate::recursive_oneof::{a, A, C};
+
+            let mut a = Box::new(A {
+                kind: Some(a::Kind::C(C {})),
+            });
+            for _ in 0..depth {
+                a = Box::new(A {
+                    kind: Some(a::Kind::A(a)),
+                });
+            }
+
+            let mut buf = Vec::new();
+            a.encode(&mut buf).unwrap();
+            A::decode(buf).map(|_| ())
+        }
+
+        assert!(build_and_roundtrip(99).is_ok());
+        assert!(build_and_roundtrip(100).is_err());
+    }
+
+    #[test]
+    fn test_deep_nesting_group() {
+        fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+            use crate::groups::{nested_group2::OptionalGroup, NestedGroup2};
+
+            let mut a = NestedGroup2::default();
+            for _ in 0..depth {
+                a = NestedGroup2 {
+                    optionalgroup: Some(Box::new(OptionalGroup {
+                        nested_group: Some(a),
+                    })),
+                };
+            }
+
+            let mut buf = Vec::new();
+            a.encode(&mut buf).unwrap();
+            NestedGroup2::decode(buf).map(|_| ())
+        }
+
+        assert!(build_and_roundtrip(50).is_ok());
+        assert!(build_and_roundtrip(51).is_err());
+    }
+
+    #[test]
+    fn test_deep_nesting_repeated() {
+        fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+            use crate::nesting::C;
+
+            let mut c = C::default();
+            for _ in 0..depth {
+                let mut next = C::default();
+                next.r.push(c);
+                c = next;
+            }
+
+            let mut buf = Vec::new();
+            c.encode(&mut buf).unwrap();
+            C::decode(buf).map(|_| ())
+        }
+
+        assert!(build_and_roundtrip(100).is_ok());
+        assert!(build_and_roundtrip(101).is_err());
+    }
+
+    #[test]
+    fn test_deep_nesting_map() {
+        fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+            use crate::nesting::D;
+
+            let mut d = D::default();
+            for _ in 0..depth {
+                let mut next = D::default();
+                next.m.insert("foo".to_owned(), d);
+                d = next;
+            }
+
+            let mut buf = Vec::new();
+            d.encode(&mut buf).unwrap();
+            D::decode(buf).map(|_| ())
+        }
+
+        assert!(build_and_roundtrip(50).is_ok());
+        assert!(build_and_roundtrip(51).is_err());
     }
 
     #[test]

--- a/tests/src/nesting.proto
+++ b/tests/src/nesting.proto
@@ -15,3 +15,11 @@ message A {
 message B {
     A a = 1;
 }
+
+message C {
+    repeated C r = 1;
+}
+
+message D {
+    map<string, D> m = 1;
+}


### PR DESCRIPTION
This PR implements a recursion limit, which can be disabled by not setting a Cargo feature (which is on by default). This change is technically not backwards compatible, but in practice very few programs should hit the recursion limit.

Although adding a context argument complicates the API somewhat, most clients would not implement or use the methods with the added argument and would instead only use `decode`, which is not changed.

Fixes #176 

r? @danburkert 