### PR TITLE
Experiment with using `bytes::Bytes` to back bytes and string fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default = ["prost-derive"]
 
 [dependencies]
 byteorder = "1"
-bytes = "0.4.7"
+bytes = "0.4"
 prost-derive = { version = "0.5.0", path = "prost-derive", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Scalar value types are converted as follows:
 | `sfixed64` | `i64` |
 | `bool` | `bool` |
 | `string` | `String` |
-| `bytes` | `Vec<u8>` |
+| `bytes` | `Bytes` |
 
 #### Enumerations
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::Read;
 use std::result;
 
+use bytes::Bytes;
 use criterion::{Benchmark, Criterion, Throughput};
 use failure::bail;
 use prost::Message;
@@ -13,7 +14,7 @@ fn benchmark_dataset<M>(criterion: &mut Criterion, dataset: BenchmarkDataset) ->
 where
     M: prost::Message + Default + 'static,
 {
-    let payload_len = dataset.payload.iter().map(Vec::len).sum::<usize>();
+    let payload_len = dataset.payload.iter().map(Bytes::len).sum::<usize>();
 
     let messages = dataset
         .payload
@@ -82,7 +83,7 @@ fn main() -> Result {
             protobuf::benchmarks::BenchmarkDataset::decode(buf)?
         };
 
-        match dataset.message_name.as_str() {
+        match dataset.message_name.as_ref() {
             "benchmarks.proto2.GoogleMessage1" => {
                 benchmark_dataset::<proto2::GoogleMessage1>(&mut criterion, dataset)?
             }

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.4"
 env_logger = { version = "0.6", default-features = false }
 log = "0.3"
 prost = { path = ".." }

--- a/conformance/src/main.rs
+++ b/conformance/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
 
         let result = match ConformanceRequest::decode(&bytes) {
             Ok(request) => handle_request(request),
-            Err(error) => conformance_response::Result::ParseError(format!("{:?}", error)),
+            Err(error) => conformance_response::Result::ParseError(format!("{:?}", error).into()),
         };
 
         let mut response = ConformanceResponse::default();
@@ -52,42 +52,42 @@ fn handle_request(request: ConformanceRequest) -> conformance_response::Result {
     match request.requested_output_format() {
         WireFormat::Unspecified => {
             return conformance_response::Result::ParseError(
-                "output format unspecified".to_string(),
+                "output format unspecified".to_string().into(),
             );
         }
         WireFormat::Json => {
             return conformance_response::Result::Skipped(
-                "JSON output is not supported".to_string(),
+                "JSON output is not supported".to_string().into(),
             );
         }
         WireFormat::Jspb => {
             return conformance_response::Result::Skipped(
-                "JSPB output is not supported".to_string(),
+                "JSPB output is not supported".to_string().into(),
             );
         }
         WireFormat::TextFormat => {
             return conformance_response::Result::Skipped(
-                "TEXT_FORMAT output is not supported".to_string(),
+                "TEXT_FORMAT output is not supported".to_string().into(),
             );
         }
         WireFormat::Protobuf => (),
     };
 
     let buf = match request.payload {
-        None => return conformance_response::Result::ParseError("no payload".to_string()),
+        None => return conformance_response::Result::ParseError("no payload".to_string().into()),
         Some(conformance_request::Payload::JsonPayload(_)) => {
             return conformance_response::Result::Skipped(
-                "JSON input is not supported".to_string(),
+                "JSON input is not supported".to_string().into(),
             );
         }
         Some(conformance_request::Payload::JspbPayload(_)) => {
             return conformance_response::Result::Skipped(
-                "JSON input is not supported".to_string(),
+                "JSON input is not supported".to_string().into(),
             );
         }
         Some(conformance_request::Payload::TextPayload(_)) => {
             return conformance_response::Result::Skipped(
-                "JSON input is not supported".to_string(),
+                "JSON input is not supported".to_string().into(),
             );
         }
         Some(conformance_request::Payload::ProtobufPayload(buf)) => buf,
@@ -97,20 +97,19 @@ fn handle_request(request: ConformanceRequest) -> conformance_response::Result {
         "protobuf_test_messages.proto2.TestAllTypesProto2" => roundtrip::<TestAllTypesProto2>(&buf),
         "protobuf_test_messages.proto3.TestAllTypesProto3" => roundtrip::<TestAllTypesProto3>(&buf),
         _ => {
-            return conformance_response::Result::ParseError(format!(
-                "unknown message type: {}",
-                request.message_type
-            ));
+            return conformance_response::Result::ParseError(
+                format!("unknown message type: {}", request.message_type).into(),
+            );
         }
     };
 
     match roundtrip {
-        RoundtripResult::Ok(buf) => conformance_response::Result::ProtobufPayload(buf),
+        RoundtripResult::Ok(buf) => conformance_response::Result::ProtobufPayload(buf.into()),
         RoundtripResult::DecodeError(error) => {
-            conformance_response::Result::ParseError(error.to_string())
+            conformance_response::Result::ParseError(error.to_string().into())
         }
         RoundtripResult::Error(error) => {
-            conformance_response::Result::RuntimeError(error.to_string())
+            conformance_response::Result::RuntimeError(error.to_string().into())
         }
     }
 }

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -714,7 +714,7 @@ impl<'a> CodeGenerator<'a> {
             Type::Int64 | Type::Sfixed64 | Type::Sint64 => String::from("i64"),
             Type::Bool => String::from("bool"),
             Type::String => String::from("std::string::String"),
-            Type::Bytes => String::from("std::vec::Vec<u8>"),
+            Type::Bytes => String::from("::bytes::Bytes"),
             Type::Group | Type::Message => self.resolve_ident(field.type_name()),
         }
     }

--- a/prost-build/src/extern_paths.rs
+++ b/prost-build/src/extern_paths.rs
@@ -37,7 +37,7 @@ impl ExternPaths {
             extern_paths.insert(".google.protobuf.BoolValue".to_string(), "bool".to_string())?;
             extern_paths.insert(
                 ".google.protobuf.BytesValue".to_string(),
-                "::std::vec::Vec<u8>".to_string(),
+                "::bytes::Bytes".to_string(),
             )?;
             extern_paths.insert(
                 ".google.protobuf.DoubleValue".to_string(),
@@ -49,7 +49,7 @@ impl ExternPaths {
             extern_paths.insert(".google.protobuf.Int64Value".to_string(), "i64".to_string())?;
             extern_paths.insert(
                 ".google.protobuf.StringValue".to_string(),
-                "::std::string::String".to_string(),
+                "prost::BytesString".to_string(),
             )?;
             extern_paths.insert(
                 ".google.protobuf.UInt32Value".to_string(),

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -4,14 +4,15 @@ use petgraph::algo::has_path_connecting;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 
+use prost::BytesString;
 use prost_types::{field_descriptor_proto, DescriptorProto, FileDescriptorProto};
 
 /// `MessageGraph` builds a graph of messages whose edges correspond to nesting.
 /// The goal is to recognize when message types are recursively nested, so
 /// that fields can be boxed when necessary.
 pub struct MessageGraph {
-    index: HashMap<String, NodeIndex>,
-    graph: Graph<String, ()>,
+    index: HashMap<BytesString, NodeIndex>,
+    graph: Graph<BytesString, ()>,
 }
 
 impl MessageGraph {
@@ -31,7 +32,7 @@ impl MessageGraph {
         msg_graph
     }
 
-    fn get_or_insert_index(&mut self, msg_name: String) -> NodeIndex {
+    fn get_or_insert_index(&mut self, msg_name: BytesString) -> NodeIndex {
         let MessageGraph {
             ref mut index,
             ref mut graph,
@@ -49,7 +50,7 @@ impl MessageGraph {
     /// Since repeated messages are already put in a Vec, boxing them isn’t necessary even if the reference is recursive.
     fn add_message(&mut self, package: &str, msg: &DescriptorProto) {
         let msg_name = format!("{}.{}", package, msg.name.as_ref().unwrap());
-        let msg_index = self.get_or_insert_index(msg_name.clone());
+        let msg_index = self.get_or_insert_index(msg_name.clone().into());
 
         for field in &msg.field {
             if field.r#type() == field_descriptor_proto::Type::Message

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -50,7 +50,8 @@ impl MessageGraph {
     /// Since repeated messages are already put in a Vec, boxing them isn’t necessary even if the reference is recursive.
     fn add_message(&mut self, package: &str, msg: &DescriptorProto) {
         let msg_name = format!("{}.{}", package, msg.name.as_ref().unwrap());
-        let msg_index = self.get_or_insert_index(msg_name.clone().into());
+        let k = msg_name.clone().into();
+        let msg_index = self.get_or_insert_index(k);
 
         for field in &msg.field {
             if field.r#type() == field_descriptor_proto::Type::Message
@@ -67,12 +68,12 @@ impl MessageGraph {
     }
 
     /// Returns true if message type `inner` is nested in message type `outer`.
-    pub fn is_nested(&self, outer: &str, inner: &str) -> bool {
-        let outer = match self.index.get(outer) {
+    pub fn is_nested(&self, _outer: &str, _inner: &str) -> bool {
+        let outer = match self.index.get(_outer) {
             Some(outer) => *outer,
             None => return false,
         };
-        let inner = match self.index.get(inner) {
+        let inner = match self.index.get(_inner) {
             Some(inner) => *inner,
             None => return false,
         };

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -112,7 +112,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
             .into_iter()
             .map(|tag| quote!(#tag))
             .intersperse(quote!(|));
-        quote!(#(#tags)* => #merge.map_err(|mut error| {
+        quote!(#(#tags)* => #merge.map_err(|mut error: _prost::DecodeError| {
             error.push(STRUCT_NAME, stringify!(#field_ident));
             error
         }),)

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -10,7 +10,7 @@ pub struct Version {
     /// A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
     /// be empty for mainline stable releases.
     #[prost(string, optional, tag="4")]
-    pub suffix: ::std::option::Option<std::string::String>,
+    pub suffix: ::std::option::Option<::prost::BytesString>,
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -19,10 +19,10 @@ pub struct CodeGeneratorRequest {
     /// code generator should generate code only for these files.  Each file's
     /// descriptor will be included in proto_file, below.
     #[prost(string, repeated, tag="1")]
-    pub file_to_generate: ::std::vec::Vec<std::string::String>,
+    pub file_to_generate: ::std::vec::Vec<::prost::BytesString>,
     /// The generator parameter passed on the command-line.
     #[prost(string, optional, tag="2")]
-    pub parameter: ::std::option::Option<std::string::String>,
+    pub parameter: ::std::option::Option<::prost::BytesString>,
     /// FileDescriptorProtos for all files in files_to_generate and everything
     /// they import.  The files will appear in topological order, so each file
     /// appears before any file that imports it.
@@ -55,7 +55,7 @@ pub struct CodeGeneratorResponse {
     /// unparseable -- should be reported by writing a message to stderr and
     /// exiting with a non-zero status code.
     #[prost(string, optional, tag="1")]
-    pub error: ::std::option::Option<std::string::String>,
+    pub error: ::std::option::Option<::prost::BytesString>,
     #[prost(message, repeated, tag="15")]
     pub file: ::std::vec::Vec<code_generator_response::File>,
 }
@@ -75,7 +75,7 @@ pub mod code_generator_response {
         /// this writing protoc does not optimize for this -- it will read the entire
         /// CodeGeneratorResponse before writing files to disk.
         #[prost(string, optional, tag="1")]
-        pub name: ::std::option::Option<std::string::String>,
+        pub name: ::std::option::Option<::prost::BytesString>,
         /// If non-empty, indicates that the named file should already exist, and the
         /// content here is to be inserted into that file at a defined insertion
         /// point.  This feature allows a code generator to extend the output
@@ -114,9 +114,9 @@ pub mod code_generator_response {
         ///
         /// If |insertion_point| is present, |name| must also be present.
         #[prost(string, optional, tag="2")]
-        pub insertion_point: ::std::option::Option<std::string::String>,
+        pub insertion_point: ::std::option::Option<::prost::BytesString>,
         /// The file contents.
         #[prost(string, optional, tag="15")]
-        pub content: ::std::option::Option<std::string::String>,
+        pub content: ::std::option::Option<::prost::BytesString>,
     }
 }

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -10,13 +10,13 @@ pub struct FileDescriptorSet {
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::std::option::Option<::prost::BytesString>,
     /// e.g. "foo", "foo.bar", etc.
     #[prost(string, optional, tag="2")]
-    pub package: ::std::option::Option<std::string::String>,
+    pub package: ::std::option::Option<::prost::BytesString>,
     /// Names of files imported by this file.
     #[prost(string, repeated, tag="3")]
-    pub dependency: ::std::vec::Vec<std::string::String>,
+    pub dependency: ::std::vec::Vec<::prost::BytesString>,
     /// Indexes of the public imported files in the dependency list above.
     #[prost(int32, repeated, packed="false", tag="10")]
     pub public_dependency: ::std::vec::Vec<i32>,
@@ -44,13 +44,13 @@ pub struct FileDescriptorProto {
     /// The syntax of the proto file.
     /// The supported values are "proto2" and "proto3".
     #[prost(string, optional, tag="12")]
-    pub syntax: ::std::option::Option<std::string::String>,
+    pub syntax: ::std::option::Option<::prost::BytesString>,
 }
 /// Describes a message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::std::option::Option<::prost::BytesString>,
     #[prost(message, repeated, tag="2")]
     pub field: ::std::vec::Vec<FieldDescriptorProto>,
     #[prost(message, repeated, tag="6")]
@@ -70,7 +70,7 @@ pub struct DescriptorProto {
     /// Reserved field names, which may not be used by fields in the same message.
     /// A given name may only be reserved once.
     #[prost(string, repeated, tag="10")]
-    pub reserved_name: ::std::vec::Vec<std::string::String>,
+    pub reserved_name: ::std::vec::Vec<::prost::BytesString>,
 }
 pub mod descriptor_proto {
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -105,7 +105,7 @@ pub struct ExtensionRangeOptions {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::std::option::Option<::prost::BytesString>,
     #[prost(int32, optional, tag="3")]
     pub number: ::std::option::Option<i32>,
     #[prost(enumeration="field_descriptor_proto::Label", optional, tag="4")]
@@ -120,18 +120,18 @@ pub struct FieldDescriptorProto {
     /// message are searched, then within the parent, on up to the root
     /// namespace).
     #[prost(string, optional, tag="6")]
-    pub type_name: ::std::option::Option<std::string::String>,
+    pub type_name: ::std::option::Option<::prost::BytesString>,
     /// For extensions, this is the name of the type being extended.  It is
     /// resolved in the same manner as type_name.
     #[prost(string, optional, tag="2")]
-    pub extendee: ::std::option::Option<std::string::String>,
+    pub extendee: ::std::option::Option<::prost::BytesString>,
     /// For numeric types, contains the original text representation of the value.
     /// For booleans, "true" or "false".
     /// For strings, contains the default text contents (not escaped in any way).
     /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
     /// TODO(kenton):  Base-64 encode?
     #[prost(string, optional, tag="7")]
-    pub default_value: ::std::option::Option<std::string::String>,
+    pub default_value: ::std::option::Option<::prost::BytesString>,
     /// If set, gives the index of a oneof in the containing type's oneof_decl
     /// list.  This field is a member of that oneof.
     #[prost(int32, optional, tag="9")]
@@ -141,7 +141,7 @@ pub struct FieldDescriptorProto {
     /// will be used. Otherwise, it's deduced from the field's name by converting
     /// it to camelCase.
     #[prost(string, optional, tag="10")]
-    pub json_name: ::std::option::Option<std::string::String>,
+    pub json_name: ::std::option::Option<::prost::BytesString>,
     #[prost(message, optional, tag="8")]
     pub options: ::std::option::Option<FieldOptions>,
 }
@@ -195,7 +195,7 @@ pub mod field_descriptor_proto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::std::option::Option<::prost::BytesString>,
     #[prost(message, optional, tag="2")]
     pub options: ::std::option::Option<OneofOptions>,
 }
@@ -203,7 +203,7 @@ pub struct OneofDescriptorProto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::std::option::Option<::prost::BytesString>,
     #[prost(message, repeated, tag="2")]
     pub value: ::std::vec::Vec<EnumValueDescriptorProto>,
     #[prost(message, optional, tag="3")]
@@ -216,7 +216,7 @@ pub struct EnumDescriptorProto {
     /// Reserved enum value names, which may not be reused. A given name may only
     /// be reserved once.
     #[prost(string, repeated, tag="5")]
-    pub reserved_name: ::std::vec::Vec<std::string::String>,
+    pub reserved_name: ::std::vec::Vec<::prost::BytesString>,
 }
 pub mod enum_descriptor_proto {
     /// Range of reserved numeric values. Reserved values may not be used by
@@ -239,7 +239,7 @@ pub mod enum_descriptor_proto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::std::option::Option<::prost::BytesString>,
     #[prost(int32, optional, tag="2")]
     pub number: ::std::option::Option<i32>,
     #[prost(message, optional, tag="3")]
@@ -249,7 +249,7 @@ pub struct EnumValueDescriptorProto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::std::option::Option<::prost::BytesString>,
     #[prost(message, repeated, tag="2")]
     pub method: ::std::vec::Vec<MethodDescriptorProto>,
     #[prost(message, optional, tag="3")]
@@ -259,13 +259,13 @@ pub struct ServiceDescriptorProto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::std::option::Option<::prost::BytesString>,
     /// Input and output type names.  These are resolved in the same way as
     /// FieldDescriptorProto.type_name, but must refer to a message type.
     #[prost(string, optional, tag="2")]
-    pub input_type: ::std::option::Option<std::string::String>,
+    pub input_type: ::std::option::Option<::prost::BytesString>,
     #[prost(string, optional, tag="3")]
-    pub output_type: ::std::option::Option<std::string::String>,
+    pub output_type: ::std::option::Option<::prost::BytesString>,
     #[prost(message, optional, tag="4")]
     pub options: ::std::option::Option<MethodOptions>,
     /// Identifies if client streams multiple client messages
@@ -314,14 +314,14 @@ pub struct FileOptions {
     /// inappropriate because proto packages do not normally start with backwards
     /// domain names.
     #[prost(string, optional, tag="1")]
-    pub java_package: ::std::option::Option<std::string::String>,
+    pub java_package: ::std::option::Option<::prost::BytesString>,
     /// If set, all the classes from the .proto file are wrapped in a single
     /// outer class with the given name.  This applies to both Proto1
     /// (equivalent to the old "--one_java_file" option) and Proto2 (where
     /// a .proto always translates to a single class, but you may want to
     /// explicitly choose the class name).
     #[prost(string, optional, tag="8")]
-    pub java_outer_classname: ::std::option::Option<std::string::String>,
+    pub java_outer_classname: ::std::option::Option<::prost::BytesString>,
     /// If set true, then the Java code generator will generate a separate .java
     /// file for each top-level message, enum, and service defined in the .proto
     /// file.  Thus, these types will *not* be nested inside the outer class
@@ -349,7 +349,7 @@ pub struct FileOptions {
     ///   - Otherwise, the package statement in the .proto file, if present.
     ///   - Otherwise, the basename of the .proto file, without extension.
     #[prost(string, optional, tag="11")]
-    pub go_package: ::std::option::Option<std::string::String>,
+    pub go_package: ::std::option::Option<::prost::BytesString>,
     /// Should generic services be generated in each language?  "Generic" services
     /// are not specific to any particular RPC system.  They are generated by the
     /// main code generators in each language (without additional plugins).
@@ -381,35 +381,35 @@ pub struct FileOptions {
     /// Sets the objective c class prefix which is prepended to all objective c
     /// generated classes from this .proto. There is no default.
     #[prost(string, optional, tag="36")]
-    pub objc_class_prefix: ::std::option::Option<std::string::String>,
+    pub objc_class_prefix: ::std::option::Option<::prost::BytesString>,
     /// Namespace for generated classes; defaults to the package.
     #[prost(string, optional, tag="37")]
-    pub csharp_namespace: ::std::option::Option<std::string::String>,
+    pub csharp_namespace: ::std::option::Option<::prost::BytesString>,
     /// By default Swift generators will take the proto package and CamelCase it
     /// replacing '.' with underscore and use that to prefix the types/symbols
     /// defined. When this options is provided, they will use this value instead
     /// to prefix the types/symbols defined.
     #[prost(string, optional, tag="39")]
-    pub swift_prefix: ::std::option::Option<std::string::String>,
+    pub swift_prefix: ::std::option::Option<::prost::BytesString>,
     /// Sets the php class prefix which is prepended to all php generated classes
     /// from this .proto. Default is empty.
     #[prost(string, optional, tag="40")]
-    pub php_class_prefix: ::std::option::Option<std::string::String>,
+    pub php_class_prefix: ::std::option::Option<::prost::BytesString>,
     /// Use this option to change the namespace of php generated classes. Default
     /// is empty. When this option is empty, the package name will be used for
     /// determining the namespace.
     #[prost(string, optional, tag="41")]
-    pub php_namespace: ::std::option::Option<std::string::String>,
+    pub php_namespace: ::std::option::Option<::prost::BytesString>,
     /// Use this option to change the namespace of php generated metadata classes.
     /// Default is empty. When this option is empty, the proto file name will be used
     /// for determining the namespace.
     #[prost(string, optional, tag="44")]
-    pub php_metadata_namespace: ::std::option::Option<std::string::String>,
+    pub php_metadata_namespace: ::std::option::Option<::prost::BytesString>,
     /// Use this option to change the package of ruby generated classes. Default
     /// is empty. When this option is not set, the package name will be used for
     /// determining the ruby package.
     #[prost(string, optional, tag="45")]
-    pub ruby_package: ::std::option::Option<std::string::String>,
+    pub ruby_package: ::std::option::Option<::prost::BytesString>,
     /// The parser stores options it doesn't recognize here.
     /// See the documentation for the "Options" section above.
     #[prost(message, repeated, tag="999")]
@@ -678,7 +678,7 @@ pub struct UninterpretedOption {
     /// The value of the uninterpreted option, in whatever type the tokenizer
     /// identified it as during parsing. Exactly one of these should be set.
     #[prost(string, optional, tag="3")]
-    pub identifier_value: ::std::option::Option<std::string::String>,
+    pub identifier_value: ::std::option::Option<::prost::BytesString>,
     #[prost(uint64, optional, tag="4")]
     pub positive_int_value: ::std::option::Option<u64>,
     #[prost(int64, optional, tag="5")]
@@ -688,7 +688,7 @@ pub struct UninterpretedOption {
     #[prost(bytes, optional, tag="7")]
     pub string_value: ::std::option::Option<::bytes::Bytes>,
     #[prost(string, optional, tag="8")]
-    pub aggregate_value: ::std::option::Option<std::string::String>,
+    pub aggregate_value: ::std::option::Option<::prost::BytesString>,
 }
 pub mod uninterpreted_option {
     /// The name of the uninterpreted option.  Each string represents a segment in
@@ -699,7 +699,7 @@ pub mod uninterpreted_option {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NamePart {
         #[prost(string, required, tag="1")]
-        pub name_part: std::string::String,
+        pub name_part: ::prost::BytesString,
         #[prost(bool, required, tag="2")]
         pub is_extension: bool,
     }
@@ -840,11 +840,11 @@ pub mod source_code_info {
         ///
         ///   // ignored detached comments.
         #[prost(string, optional, tag="3")]
-        pub leading_comments: ::std::option::Option<std::string::String>,
+        pub leading_comments: ::std::option::Option<::prost::BytesString>,
         #[prost(string, optional, tag="4")]
-        pub trailing_comments: ::std::option::Option<std::string::String>,
+        pub trailing_comments: ::std::option::Option<::prost::BytesString>,
         #[prost(string, repeated, tag="6")]
-        pub leading_detached_comments: ::std::vec::Vec<std::string::String>,
+        pub leading_detached_comments: ::std::vec::Vec<::prost::BytesString>,
     }
 }
 /// Describes the relationship between generated code and its original source
@@ -866,7 +866,7 @@ pub mod generated_code_info {
         pub path: ::std::vec::Vec<i32>,
         /// Identifies the filesystem path to the original source .proto.
         #[prost(string, optional, tag="2")]
-        pub source_file: ::std::option::Option<std::string::String>,
+        pub source_file: ::std::option::Option<::prost::BytesString>,
         /// Identifies the starting offset in bytes in the generated code
         /// that relates to the identified object.
         #[prost(int32, optional, tag="3")]
@@ -989,7 +989,7 @@ pub struct Any {
     /// used with implementation specific semantics.
     ///
     #[prost(string, tag="1")]
-    pub type_url: std::string::String,
+    pub type_url: ::prost::BytesString,
     /// Must be a valid serialized protocol buffer of the above specified type.
     #[prost(bytes, tag="2")]
     pub value: ::bytes::Bytes,
@@ -1001,20 +1001,20 @@ pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
     #[prost(string, tag="1")]
-    pub file_name: std::string::String,
+    pub file_name: ::prost::BytesString,
 }
 /// A protocol buffer message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Type {
     /// The fully qualified message name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::BytesString,
     /// The list of fields.
     #[prost(message, repeated, tag="2")]
     pub fields: ::std::vec::Vec<Field>,
     /// The list of types appearing in `oneof` definitions in this type.
     #[prost(string, repeated, tag="3")]
-    pub oneofs: ::std::vec::Vec<std::string::String>,
+    pub oneofs: ::std::vec::Vec<::prost::BytesString>,
     /// The protocol buffer options.
     #[prost(message, repeated, tag="4")]
     pub options: ::std::vec::Vec<Option>,
@@ -1039,11 +1039,11 @@ pub struct Field {
     pub number: i32,
     /// The field name.
     #[prost(string, tag="4")]
-    pub name: std::string::String,
+    pub name: ::prost::BytesString,
     /// The field type URL, without the scheme, for message or enumeration
     /// types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
     #[prost(string, tag="6")]
-    pub type_url: std::string::String,
+    pub type_url: ::prost::BytesString,
     /// The index of the field type in `Type.oneofs`, for message or enumeration
     /// types. The first type has index 1; zero means the type is not in the list.
     #[prost(int32, tag="7")]
@@ -1056,10 +1056,10 @@ pub struct Field {
     pub options: ::std::vec::Vec<Option>,
     /// The field JSON name.
     #[prost(string, tag="10")]
-    pub json_name: std::string::String,
+    pub json_name: ::prost::BytesString,
     /// The string value of the default value of this field. Proto2 syntax only.
     #[prost(string, tag="11")]
-    pub default_value: std::string::String,
+    pub default_value: ::prost::BytesString,
 }
 pub mod field {
     /// Basic field types.
@@ -1124,7 +1124,7 @@ pub mod field {
 pub struct Enum {
     /// Enum type name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::BytesString,
     /// Enum value definitions.
     #[prost(message, repeated, tag="2")]
     pub enumvalue: ::std::vec::Vec<EnumValue>,
@@ -1143,7 +1143,7 @@ pub struct Enum {
 pub struct EnumValue {
     /// Enum value name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::BytesString,
     /// Enum value number.
     #[prost(int32, tag="2")]
     pub number: i32,
@@ -1160,7 +1160,7 @@ pub struct Option {
     /// For custom options, it should be the fully-qualified name. For example,
     /// `"google.api.http"`.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::BytesString,
     /// The option's value packed in an Any message. If the value is a primitive,
     /// the corresponding wrapper type defined in google/protobuf/wrappers.proto
     /// should be used. If the value is an enum, it should be stored as an int32
@@ -1191,7 +1191,7 @@ pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::BytesString,
     /// The methods of this interface, in unspecified order.
     #[prost(message, repeated, tag="2")]
     pub methods: ::std::vec::Vec<Method>,
@@ -1220,7 +1220,7 @@ pub struct Api {
     ///
     ///
     #[prost(string, tag="4")]
-    pub version: std::string::String,
+    pub version: ::prost::BytesString,
     /// Source context for the protocol buffer service represented by this
     /// message.
     #[prost(message, optional, tag="5")]
@@ -1237,16 +1237,16 @@ pub struct Api {
 pub struct Method {
     /// The simple name of this method.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::BytesString,
     /// A URL of the input message type.
     #[prost(string, tag="2")]
-    pub request_type_url: std::string::String,
+    pub request_type_url: ::prost::BytesString,
     /// If true, the request is streamed.
     #[prost(bool, tag="3")]
     pub request_streaming: bool,
     /// The URL of the output message type.
     #[prost(string, tag="4")]
-    pub response_type_url: std::string::String,
+    pub response_type_url: ::prost::BytesString,
     /// If true, the response is streamed.
     #[prost(bool, tag="5")]
     pub response_streaming: bool,
@@ -1339,11 +1339,11 @@ pub struct Method {
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::BytesString,
     /// If non-empty specifies a path under which inherited HTTP paths
     /// are rooted.
     #[prost(string, tag="2")]
-    pub root: std::string::String,
+    pub root: ::prost::BytesString,
 }
 /// A Duration represents a signed, fixed-length span of time represented
 /// as a count of seconds and fractions of seconds at nanosecond
@@ -1624,7 +1624,7 @@ pub struct Duration {
 pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag="1")]
-    pub paths: ::std::vec::Vec<std::string::String>,
+    pub paths: ::std::vec::Vec<::prost::BytesString>,
 }
 /// `Struct` represents a structured data value, consisting of fields
 /// which map to dynamically typed values. In some languages, `Struct`
@@ -1638,7 +1638,7 @@ pub struct FieldMask {
 pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map="string, message", tag="1")]
-    pub fields: ::std::collections::BTreeMap<std::string::String, Value>,
+    pub fields: ::std::collections::BTreeMap<::prost::BytesString, Value>,
 }
 /// `Value` represents a dynamically typed value which can be either
 /// null, a number, a string, a boolean, a recursive struct value, or a
@@ -1664,7 +1664,7 @@ pub mod value {
         NumberValue(f64),
         /// Represents a string value.
         #[prost(string, tag="3")]
-        StringValue(std::string::String),
+        StringValue(::prost::BytesString),
         /// Represents a boolean value.
         #[prost(bool, tag="4")]
         BoolValue(bool),

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -686,7 +686,7 @@ pub struct UninterpretedOption {
     #[prost(double, optional, tag="6")]
     pub double_value: ::std::option::Option<f64>,
     #[prost(bytes, optional, tag="7")]
-    pub string_value: ::std::option::Option<std::vec::Vec<u8>>,
+    pub string_value: ::std::option::Option<::bytes::Bytes>,
     #[prost(string, optional, tag="8")]
     pub aggregate_value: ::std::option::Option<std::string::String>,
 }
@@ -992,7 +992,7 @@ pub struct Any {
     pub type_url: std::string::String,
     /// Must be a valid serialized protocol buffer of the above specified type.
     #[prost(bytes, tag="2")]
-    pub value: std::vec::Vec<u8>,
+    pub value: ::bytes::Bytes,
 }
 /// `SourceContext` represents information about the source of a
 /// protobuf element, like the file in which it is defined.

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.4"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -689,26 +689,6 @@ macro_rules! length_delimited {
                     .map(|value| encoded_len_varint(value.len() as u64) + value.len())
                     .sum::<usize>()
         }
-
-        #[cfg(test)]
-        mod test {
-            use quickcheck::{quickcheck, TestResult};
-
-            use super::super::test::{check_collection_type, check_type};
-            use super::*;
-
-            quickcheck! {
-                fn check(value: $ty, tag: u32) -> TestResult {
-                    super::test::check_type(value, tag, WireType::LengthDelimited,
-                                            encode, merge, encoded_len)
-                }
-                fn check_repeated(value: Vec<$ty>, tag: u32) -> TestResult {
-                    super::test::check_collection_type(value, tag, WireType::LengthDelimited,
-                                                       encode_repeated, merge_repeated,
-                                                       encoded_len_repeated)
-                }
-            }
-        }
     };
 }
 
@@ -744,6 +724,26 @@ pub mod string {
     }
 
     length_delimited!(BytesString);
+
+    #[cfg(test)]
+    mod test {
+        use quickcheck::{quickcheck, TestResult};
+
+        use super::super::test::{check_collection_type, check_type};
+        use super::*;
+
+        quickcheck! {
+            fn check(value: BytesString, tag: u32) -> TestResult {
+                super::test::check_type(value, tag, WireType::LengthDelimited,
+                                        encode, merge, encoded_len)
+            }
+            fn check_repeated(value: Vec<BytesString>, tag: u32) -> TestResult {
+                super::test::check_collection_type(value, tag, WireType::LengthDelimited,
+                                                   encode_repeated, merge_repeated,
+                                                   encoded_len_repeated)
+            }
+        }
+    }
 }
 
 pub mod bytes {
@@ -1464,7 +1464,7 @@ mod test {
                    (i32, sfixed32),
                    (i64, sfixed64),
                    (bool, bool),
-                   (String, string)
+                   (BytesString, string)
                ],
                vals: [
                    (f32, float),
@@ -1480,7 +1480,6 @@ mod test {
                    (i32, sfixed32),
                    (i64, sfixed64),
                    (bool, bool),
-                   (String, string),
-                   (Bytes, bytes)
+                   (BytesString, string)
                ]);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod error;
 mod message;
+mod string;
 mod types;
 
 #[doc(hidden)]
@@ -9,6 +10,7 @@ pub mod encoding;
 
 pub use crate::error::{DecodeError, EncodeError};
 pub use crate::message::Message;
+pub use crate::string::{BytesMutString, BytesString, StringError};
 
 use bytes::{BufMut, IntoBuf};
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,353 @@
+//! String types which wrap `Bytes`/`BytesMut`.
+//!
+//! `BytesString` and `BytesMutString` are backed by `Bytes` and `BytesMut`
+//! respectively, and should be sued in a similar manner.
+//!
+//! The provided trait impls do not clone (except `FromStr`).
+//!
+//! UTF8 invariants are checked when strings are created (or bytes are added).
+
+use bytes::{BufMut, Bytes, BytesMut};
+use std::borrow::Borrow;
+use std::convert::{AsRef, Infallible, TryFrom};
+use std::fmt;
+use std::ops::Deref;
+use std::str::{self, FromStr};
+
+#[derive(Clone, Debug)]
+pub enum StringError {
+    Utf8ErrorBytes(Bytes),
+    Utf8ErrorVec(Vec<u8>),
+    BytesMutConversionError(Bytes),
+}
+
+impl From<Bytes> for StringError {
+    fn from(b: Bytes) -> StringError {
+        StringError::BytesMutConversionError(b)
+    }
+}
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, PartialOrd, Eq, Ord)]
+pub struct BytesString {
+    bytes: Bytes,
+}
+
+impl BytesString {
+    #[inline]
+    pub fn new() -> BytesString {
+        BytesString {
+            bytes: Bytes::new(),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bytes.len() == 0
+    }
+
+    #[inline]
+    pub fn from_str_cloned<S: AsRef<str>>(s: &S) -> BytesString {
+        BytesString {
+            bytes: s.as_ref().as_bytes().into(),
+        }
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.bytes.clear();
+    }
+
+    #[inline]
+    pub unsafe fn as_bytes_mut(&mut self) -> &mut Bytes {
+        &mut self.bytes
+    }
+
+    #[inline]
+    pub fn try_mut(self) -> Result<BytesMutString, BytesString> {
+        match self.bytes.try_mut() {
+            Ok(b) => Ok(BytesMutString { bytes: b }),
+            Err(b) => Err(BytesString { bytes: b }),
+        }
+    }
+
+    #[inline]
+    unsafe fn from_bytes_unchecked(bytes: Bytes) -> BytesString {
+        BytesString { bytes }
+    }
+}
+
+impl<'a> Into<&'a str> for &'a BytesString {
+    fn into(self) -> &'a str {
+        // Safe because we establish the utf8 invariants when we move bytes into
+        // BytesString.
+        unsafe { str::from_utf8_unchecked(self.bytes.as_ref()) }
+    }
+}
+
+impl Into<Bytes> for BytesString {
+    fn into(self) -> Bytes {
+        self.bytes
+    }
+}
+
+impl<'a> Into<&'a [u8]> for &'a BytesString {
+    fn into(self) -> &'a [u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl From<String> for BytesString {
+    fn from(s: String) -> BytesString {
+        unsafe { Self::from_bytes_unchecked(s.into_bytes().into()) }
+    }
+}
+
+impl TryFrom<Bytes> for BytesString {
+    type Error = StringError;
+    fn try_from(b: Bytes) -> Result<BytesString, StringError> {
+        if str::from_utf8(b.as_ref()).is_err() {
+            return Err(StringError::Utf8ErrorBytes(b));
+        }
+        unsafe { Ok(Self::from_bytes_unchecked(b)) }
+    }
+}
+
+impl TryFrom<BytesMut> for BytesString {
+    type Error = StringError;
+    fn try_from(b: BytesMut) -> Result<BytesString, StringError> {
+        if str::from_utf8(b.as_ref()).is_err() {
+            return Err(StringError::Utf8ErrorBytes(b.freeze()));
+        }
+        unsafe { Ok(Self::from_bytes_unchecked(b.freeze())) }
+    }
+}
+
+impl TryFrom<Vec<u8>> for BytesString {
+    type Error = StringError;
+    fn try_from(v: Vec<u8>) -> Result<BytesString, StringError> {
+        let b = v.into();
+        unsafe { Ok(Self::from_bytes_unchecked(b)) }
+    }
+}
+
+impl FromStr for BytesString {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<BytesString, Infallible> {
+        Ok(s.to_owned().into())
+    }
+}
+
+impl Deref for BytesString {
+    type Target = str;
+    fn deref(&self) -> &str {
+        self.into()
+    }
+}
+
+impl AsRef<str> for BytesString {
+    fn as_ref(&self) -> &str {
+        self.into()
+    }
+}
+
+impl AsRef<[u8]> for BytesString {
+    fn as_ref(&self) -> &[u8] {
+        self.into()
+    }
+}
+
+impl Borrow<str> for BytesString {
+    fn borrow(&self) -> &str {
+        self.into()
+    }
+}
+
+impl fmt::Display for BytesString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let s: &str = self.into();
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, PartialOrd, Eq, Ord)]
+pub struct BytesMutString {
+    bytes: BytesMut,
+}
+
+impl BytesMutString {
+    #[inline]
+    pub fn new() -> BytesMutString {
+        BytesMutString {
+            bytes: BytesMut::new(),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    #[inline]
+    pub fn freeze(self) -> BytesString {
+        BytesString {
+            bytes: self.bytes.freeze(),
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bytes.len() == 0
+    }
+
+    #[inline]
+    pub fn push(&mut self, c: char) {
+        // Adapted from the std implementation of `String::push`
+        let len = c.len_utf8();
+        // `BytesMut` does not automatically grow its buffer.
+        self.reserve(len);
+        match len {
+            1 => self.bytes.put_u8(c as u8),
+            _ => self
+                .bytes
+                .extend_from_slice(c.encode_utf8(&mut [0; 4]).as_bytes()),
+        }
+    }
+
+    #[inline]
+    pub fn push_str(&mut self, s: &str) {
+        self.bytes.reserve(s.len());
+        self.bytes.extend_from_slice(s.as_bytes());
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.bytes.reserve(additional);
+    }
+
+    #[inline]
+    pub fn from_str_cloned<S: AsRef<str>>(s: &S) -> BytesMutString {
+        BytesMutString {
+            bytes: s.as_ref().as_bytes().into(),
+        }
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.bytes.clear();
+    }
+
+    #[inline]
+    pub unsafe fn as_bytes_mut(&mut self) -> &mut BytesMut {
+        &mut self.bytes
+    }
+
+    #[inline]
+    unsafe fn from_bytes_unchecked(bytes: BytesMut) -> BytesMutString {
+        BytesMutString { bytes }
+    }
+}
+
+impl<'a> Into<&'a str> for &'a BytesMutString {
+    fn into(self) -> &'a str {
+        // Safe because we establish the utf8 invariants when we move bytes into
+        // BytesMutString.
+        unsafe { str::from_utf8_unchecked(self.bytes.as_ref()) }
+    }
+}
+
+impl Into<Bytes> for BytesMutString {
+    fn into(self) -> Bytes {
+        self.bytes.freeze()
+    }
+}
+
+impl Into<BytesMut> for BytesMutString {
+    fn into(self) -> BytesMut {
+        self.bytes
+    }
+}
+
+impl<'a> Into<&'a [u8]> for &'a BytesMutString {
+    fn into(self) -> &'a [u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl From<String> for BytesMutString {
+    fn from(s: String) -> BytesMutString {
+        unsafe { Self::from_bytes_unchecked(s.into_bytes().into()) }
+    }
+}
+
+impl TryFrom<Bytes> for BytesMutString {
+    type Error = StringError;
+    fn try_from(b: Bytes) -> Result<BytesMutString, StringError> {
+        if str::from_utf8(b.as_ref()).is_err() {
+            return Err(StringError::Utf8ErrorBytes(b));
+        }
+        let b = b.try_mut()?;
+        unsafe { Ok(Self::from_bytes_unchecked(b)) }
+    }
+}
+
+impl TryFrom<BytesMut> for BytesMutString {
+    type Error = StringError;
+    fn try_from(b: BytesMut) -> Result<BytesMutString, StringError> {
+        if str::from_utf8(b.as_ref()).is_err() {
+            return Err(StringError::Utf8ErrorBytes(b.freeze()));
+        }
+        unsafe { Ok(Self::from_bytes_unchecked(b)) }
+    }
+}
+
+impl TryFrom<Vec<u8>> for BytesMutString {
+    type Error = StringError;
+    fn try_from(v: Vec<u8>) -> Result<BytesMutString, StringError> {
+        let b = v.into();
+        unsafe { Ok(Self::from_bytes_unchecked(b)) }
+    }
+}
+
+impl FromStr for BytesMutString {
+    type Err = Infallible;
+    fn from_str(s: &str) -> Result<BytesMutString, Infallible> {
+        Ok(s.to_owned().into())
+    }
+}
+
+impl Deref for BytesMutString {
+    type Target = str;
+    fn deref(&self) -> &str {
+        self.into()
+    }
+}
+
+impl AsRef<str> for BytesMutString {
+    fn as_ref(&self) -> &str {
+        self.into()
+    }
+}
+
+impl AsRef<[u8]> for BytesMutString {
+    fn as_ref(&self) -> &[u8] {
+        self.into()
+    }
+}
+
+impl Borrow<str> for BytesMutString {
+    fn borrow(&self) -> &str {
+        self.into()
+    }
+}
+
+impl fmt::Display for BytesMutString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let s: &str = self.into();
+        write!(f, "{}", s)
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,7 +9,7 @@ use ::bytes::{Buf, BufMut, Bytes};
 
 use crate::encoding::*;
 use crate::DecodeError;
-use crate::Message;
+use crate::{BytesString, Message};
 
 /// `google.protobuf.BoolValue`
 impl Message for bool {
@@ -271,7 +271,7 @@ impl Message for f64 {
 }
 
 /// `google.protobuf.StringValue`
-impl Message for String {
+impl Message for BytesString {
     fn encode_raw<B>(&self, buf: &mut B)
     where
         B: BufMut,

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@
 //! the `prost-types` crate in order to avoid a cyclic dependency between `prost` and
 //! `prost-build`.
 
-use ::bytes::{Buf, BufMut};
+use ::bytes::{Buf, BufMut, Bytes};
 
 use crate::encoding::*;
 use crate::DecodeError;
@@ -308,7 +308,7 @@ impl Message for String {
 }
 
 /// `google.protobuf.BytesValue`
-impl Message for Vec<u8> {
+impl Message for Bytes {
     fn encode_raw<B>(&self, buf: &mut B)
     where
         B: BufMut,

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -16,7 +16,7 @@ default = ["edition-2015"]
 edition-2015 = []
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.4"
 cfg-if = "0.1"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,7 +11,7 @@ build = "src/build.rs"
 doctest = false
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.4"
 cfg-if = "0.1"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }

--- a/tests/src/debug.rs
+++ b/tests/src/debug.rs
@@ -15,7 +15,7 @@ fn basic() {
         "Basic { \
          int32: 0, \
          bools: [], \
-         string: \"\", \
+         string: BytesString { bytes: b\"\" }, \
          optional_string: None, \
          enumeration: ZERO, \
          enumeration_map: {}, \
@@ -34,7 +34,7 @@ fn basic() {
         "Basic { \
          int32: 0, \
          bools: [], \
-         string: \"\", \
+         string: BytesString { bytes: b\"\" }, \
          optional_string: None, \
          enumeration: 42, \
          enumeration_map: {0: TWO}, \
@@ -67,7 +67,7 @@ pub enum OneofWithEnum {
     #[prost(int32, tag = "8")]
     Int(i32),
     #[prost(string, tag = "9")]
-    String(String),
+    String(::prost::BytesString),
     #[prost(enumeration = "BasicEnumeration", tag = "10")]
     Enumeration(i32),
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -415,7 +415,7 @@ mod tests {
     fn test_group_oneof() {
         let msg = groups::OneofGroup {
             i1: Some(42),
-            field: Some(groups::oneof_group::Field::S2("foo".to_string())),
+            field: Some(groups::oneof_group::Field::S2("foo".to_string().into())),
         };
         check_message(&msg);
 
@@ -423,7 +423,7 @@ mod tests {
             i1: Some(42),
             field: Some(groups::oneof_group::Field::G(groups::oneof_group::G {
                 i2: None,
-                s1: "foo".to_string(),
+                s1: "foo".to_string().into(),
                 t1: None,
             })),
         };
@@ -433,7 +433,7 @@ mod tests {
             i1: Some(42),
             field: Some(groups::oneof_group::Field::G(groups::oneof_group::G {
                 i2: Some(99),
-                s1: "foo".to_string(),
+                s1: "foo".to_string().into(),
                 t1: Some(groups::Test1 {
                     groupa: Some(groups::test1::GroupA { i2: None }),
                 }),

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -58,9 +58,9 @@ pub struct ScalarTypes {
     #[prost(bool, tag = "013")]
     pub _bool: bool,
     #[prost(string, tag = "014")]
-    pub string: String,
+    pub string: ::prost::BytesString,
     #[prost(bytes, tag = "015")]
-    pub bytes: Vec<u8>,
+    pub bytes: ::bytes::Bytes,
 
     #[prost(int32, required, tag = "101")]
     pub required_int32: i32,
@@ -89,9 +89,9 @@ pub struct ScalarTypes {
     #[prost(bool, required, tag = "113")]
     pub required_bool: bool,
     #[prost(string, required, tag = "114")]
-    pub required_string: String,
+    pub required_string: ::prost::BytesString,
     #[prost(bytes, required, tag = "115")]
-    pub required_bytes: Vec<u8>,
+    pub required_bytes: ::bytes::Bytes,
 
     #[prost(int32, optional, tag = "201")]
     pub optional_int32: Option<i32>,
@@ -121,9 +121,9 @@ pub struct ScalarTypes {
     #[prost(bool, optional, tag = "213")]
     pub optional_bool: Option<bool>,
     #[prost(string, optional, tag = "214")]
-    pub optional_string: Option<String>,
+    pub optional_string: Option<::prost::BytesString>,
     #[prost(bytes, optional, tag = "215")]
-    pub optional_bytes: Option<Vec<u8>>,
+    pub optional_bytes: Option<::bytes::Bytes>,
 
     #[prost(int32, repeated, packed = "false", tag = "301")]
     pub repeated_int32: Vec<i32>,
@@ -152,9 +152,9 @@ pub struct ScalarTypes {
     #[prost(bool, repeated, packed = "false", tag = "313")]
     pub repeated_bool: Vec<bool>,
     #[prost(string, repeated, packed = "false", tag = "315")]
-    pub repeated_string: Vec<String>,
+    pub repeated_string: Vec<::prost::BytesString>,
     #[prost(bytes, repeated, packed = "false", tag = "316")]
-    pub repeated_bytes: Vec<Vec<u8>>,
+    pub repeated_bytes: Vec<::bytes::Bytes>,
 
     #[prost(int32, repeated, tag = "401")]
     pub packed_int32: Vec<i32>,
@@ -184,9 +184,9 @@ pub struct ScalarTypes {
     #[prost(bool, repeated, tag = "413")]
     pub packed_bool: Vec<bool>,
     #[prost(string, repeated, tag = "415")]
-    pub packed_string: Vec<String>,
+    pub packed_string: Vec<::prost::BytesString>,
     #[prost(bytes, repeated, tag = "416")]
-    pub packed_bytes: Vec<Vec<u8>>,
+    pub packed_bytes: Vec<::bytes::Bytes>,
 }
 
 #[test]
@@ -205,14 +205,14 @@ pub struct TagsInferred {
     pub three: Vec<f32>,
 
     #[prost(tag = "9", string, required)]
-    pub skip_to_nine: String,
+    pub skip_to_nine: ::prost::BytesString,
     #[prost(enumeration = "BasicEnumeration", default = "ONE")]
     pub ten: i32,
     #[prost(map = "string, string")]
-    pub eleven: ::std::collections::HashMap<String, String>,
+    pub eleven: ::std::collections::HashMap<::prost::BytesString, ::prost::BytesString>,
 
     #[prost(tag = "5", bytes)]
-    pub back_to_five: Vec<u8>,
+    pub back_to_five: ::bytes::Bytes,
     #[prost(message, required)]
     pub six: Basic,
 }
@@ -227,16 +227,16 @@ pub struct TagsQualified {
     pub three: Vec<f32>,
 
     #[prost(tag = "5", bytes)]
-    pub five: Vec<u8>,
+    pub five: ::bytes::Bytes,
     #[prost(tag = "6", message, required)]
     pub six: Basic,
 
     #[prost(tag = "9", string, required)]
-    pub nine: String,
+    pub nine: ::prost::BytesString,
     #[prost(tag = "10", enumeration = "BasicEnumeration", default = "ONE")]
     pub ten: i32,
     #[prost(tag = "11", map = "string, string")]
-    pub eleven: ::std::collections::HashMap<String, String>,
+    pub eleven: ::std::collections::HashMap<::prost::BytesString, ::prost::BytesString>,
 }
 
 /// A prost message with default value.
@@ -249,7 +249,7 @@ pub struct DefaultValues {
     pub optional_int32: Option<i32>,
 
     #[prost(string, tag = "3", default = "fourty two")]
-    pub string: String,
+    pub string: ::prost::BytesString,
 
     #[prost(enumeration = "BasicEnumeration", tag = "4", default = "ONE")]
     pub enumeration: i32,
@@ -266,7 +266,7 @@ fn check_default_values() {
     let default = DefaultValues::default();
     assert_eq!(default.int32, 42);
     assert_eq!(default.optional_int32, None);
-    assert_eq!(&default.string, "fourty two");
+    assert_eq!(&*default.string, "fourty two");
     assert_eq!(default.enumeration, BasicEnumeration::ONE as i32);
     assert_eq!(default.optional_enumeration, None);
     assert_eq!(&default.repeated_enumeration, &[]);
@@ -291,10 +291,10 @@ pub struct Basic {
     pub bools: Vec<bool>,
 
     #[prost(string, tag = "3")]
-    pub string: String,
+    pub string: ::prost::BytesString,
 
     #[prost(string, optional, tag = "4")]
-    pub optional_string: Option<String>,
+    pub optional_string: Option<::prost::BytesString>,
 
     #[prost(enumeration = "BasicEnumeration", tag = "5")]
     pub enumeration: i32,
@@ -303,13 +303,13 @@ pub struct Basic {
     pub enumeration_map: ::std::collections::HashMap<i32, i32>,
 
     #[prost(hash_map = "string, string", tag = "7")]
-    pub string_map: ::std::collections::HashMap<String, String>,
+    pub string_map: ::std::collections::HashMap<::prost::BytesString, ::prost::BytesString>,
 
     #[prost(btree_map = "int32, enumeration(BasicEnumeration)", tag = "10")]
     pub enumeration_btree_map: ::std::collections::BTreeMap<i32, i32>,
 
     #[prost(btree_map = "string, string", tag = "11")]
-    pub string_btree_map: ::std::collections::BTreeMap<String, String>,
+    pub string_btree_map: ::std::collections::BTreeMap<::prost::BytesString, ::prost::BytesString>,
 
     #[prost(oneof = "BasicOneof", tags = "8, 9")]
     pub oneof: Option<BasicOneof>,
@@ -338,5 +338,5 @@ pub enum BasicOneof {
     #[prost(int32, tag = "8")]
     Int(i32),
     #[prost(string, tag = "9")]
-    String(String),
+    String(::prost::BytesString),
 }


### PR DESCRIPTION
This PR uses `bytes::Bytes` as the type for `bytes` and a new type `BytesString` as the type for `string` (rather than `Vec<u8>` and `String`). `BytesString`is a wrapper around `Bytes` in the same way that `String` is a wrapper around `Vec<u8>`. Obviously this is a severe breaking change.

This idea has been discussed in #31 and #35.

This PR improves performance by 25% (!) on Mac OS, 9% on Ubuntu, and 2% on CentOS. This was tested using a fairly realistic benchmark dervied from TiKV, however, the bytes and string values were all quite small. I expect the performance improvements would be smaller for larger values. I also tested a multi-threaded version of the benchmark on Ubuntu, there the average improvement was only 1.5%, however, the worst-performing thread improved by 14%, so the overall time to completion was significantly improved.

If we should go forward with this PR, then I think there are few open questions, but I thought I'd post early to get feedback about whether it was possible to land at all, given the back-compat situation.

If we do land, I think we can probably get rid of the `BytesMutString` type and just use `BytesString` -  I didn't see any performance benefit or usability benefit in using the `BytesMut` version.

One option might be to land the change to `bytes` but not to `string`. I feel like that is a less invasive change but will get a decent benefit for some users.

@danburkert what do you think?