### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ default = ["prost-derive"]
 no-recursion-limit = []
 
 [dependencies]
-byteorder = "1"
 bytes = "0.4.7"
 prost-derive = { version = "0.5.0", path = "prost-derive", optional = true }
 


### PR DESCRIPTION
This removes the byteorder-dependency, which does not seem to be referenced anywhere