### PR TITLE
Update proc-macro2, syn and quote to 1.0

### DIFF
--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -16,6 +16,6 @@ proc_macro = true
 [dependencies]
 failure = { version = "0.1", default-features = false, features = ["std"] }
 itertools = "0.8"
-proc-macro2 = "0.4.4"
-quote = "0.6.3"
-syn = { version = "0.15", features = [ "extra-traits" ] }
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = [ "extra-traits" ] }

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -53,7 +53,11 @@ impl Field {
         for attr in attrs {
             if let Some(t) = tag_attr(attr)? {
                 set_option(&mut tag, t, "duplicate tag attributes")?;
-            } else if let Some(map_ty) = MapTy::from_str(&attr.name().to_string()) {
+            } else if let Some(Some(map_ty)) = attr
+                .path()
+                .get_ident()
+                .map(|ident| MapTy::from_str(&ident.to_string()))
+            {
                 let (k, v): (String, String) = match *attr {
                     Meta::NameValue(MetaNameValue {
                         lit: Lit::Str(ref lit),
@@ -77,11 +81,15 @@ impl Field {
                             bail!("invalid map attribute: must contain key and value types");
                         }
                         let k = match &meta_list.nested[0] {
-                            &NestedMeta::Meta(Meta::Word(ref k)) => k.to_string(),
+                            &NestedMeta::Meta(Meta::Path(ref k)) if k.get_ident().is_some() => {
+                                k.get_ident().unwrap().to_string()
+                            }
                             _ => bail!("invalid map attribute: key must be an identifier"),
                         };
                         let v = match &meta_list.nested[1] {
-                            &NestedMeta::Meta(Meta::Word(ref v)) => v.to_string(),
+                            &NestedMeta::Meta(Meta::Path(ref v)) if v.get_ident().is_some() => {
+                                v.get_ident().unwrap().to_string()
+                            }
                             _ => bail!("invalid map attribute: value must be an identifier"),
                         };
                         (k, v)

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -1,9 +1,9 @@
 use failure::{bail, Error};
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::Meta;
 
-use crate::field::{set_bool, set_option, tag_attr, word_attr, Label};
+use crate::field::{path_attr, set_bool, set_option, tag_attr, Label};
 
 #[derive(Clone)]
 pub struct Field {
@@ -21,9 +21,9 @@ impl Field {
         let mut unknown_attrs = Vec::new();
 
         for attr in attrs {
-            if word_attr("message", attr) {
+            if path_attr("message", attr) {
                 set_bool(&mut message, "duplicate message attribute")?;
-            } else if word_attr("boxed", attr) {
+            } else if path_attr("boxed", attr) {
                 set_bool(&mut boxed, "duplicate boxed attribute")?;
             } else if let Some(t) = tag_attr(attr)? {
                 set_option(&mut tag, t, "duplicate tag attributes")?;
@@ -61,7 +61,10 @@ impl Field {
     pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
         if let Some(mut field) = Field::new(attrs, None)? {
             if let Some(attr) = attrs.iter().find(|attr| Label::from_attr(attr).is_some()) {
-                bail!("invalid atribute for oneof field: {}", attr.name());
+                bail!(
+                    "invalid atribute for oneof field: {}",
+                    attr.path().into_token_stream()
+                );
             }
             field.label = Label::Required;
             Ok(Some(field))

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -200,9 +200,9 @@ impl Label {
     /// Parses a string into a field label.
     /// If the string doesn't match a field label, `None` is returned.
     fn from_attr(attr: &Meta) -> Option<Label> {
-        if let Meta::Word(ref ident) = *attr {
+        if let Meta::Path(ref path) = *attr {
             for &label in Label::variants() {
-                if ident == label.as_str() {
+                if path.is_ident(label.as_str()) {
                     return Some(label);
                 }
             }
@@ -227,10 +227,10 @@ impl fmt::Display for Label {
 pub(super) fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
     Ok(attrs
         .iter()
-        .flat_map(Attribute::interpret_meta)
+        .flat_map(Attribute::parse_meta)
         .flat_map(|meta| match meta {
-            Meta::List(MetaList { ident, nested, .. }) => {
-                if ident == "prost" {
+            Meta::List(MetaList { path, nested, .. }) => {
+                if path.is_ident("prost") {
                     nested.into_iter().collect()
                 } else {
                     Vec::new()
@@ -241,7 +241,7 @@ pub(super) fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
         .flat_map(|attr| -> Result<_, _> {
             match attr {
                 NestedMeta::Meta(attr) => Ok(attr),
-                NestedMeta::Literal(lit) => bail!("invalid prost attribute: {:?}", lit),
+                NestedMeta::Lit(lit) => bail!("invalid prost attribute: {:?}", lit),
             }
         })
         .collect())
@@ -270,15 +270,15 @@ pub fn set_bool(b: &mut bool, message: &str) -> Result<(), Error> {
 /// Unpacks an attribute into a (key, boolean) pair, returning the boolean value.
 /// If the key doesn't match the attribute, `None` is returned.
 fn bool_attr(key: &str, attr: &Meta) -> Result<Option<bool>, Error> {
-    if attr.name() != key {
+    if !attr.path().is_ident(key) {
         return Ok(None);
     }
     match *attr {
-        Meta::Word(..) => Ok(Some(true)),
+        Meta::Path(..) => Ok(Some(true)),
         Meta::List(ref meta_list) => {
             // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
             if meta_list.nested.len() == 1 {
-                if let NestedMeta::Literal(Lit::Bool(LitBool { value, .. })) = meta_list.nested[0] {
+                if let NestedMeta::Lit(Lit::Bool(LitBool { value, .. })) = meta_list.nested[0] {
                     return Ok(Some(value));
                 }
             }
@@ -300,25 +300,25 @@ fn bool_attr(key: &str, attr: &Meta) -> Result<Option<bool>, Error> {
     }
 }
 
-/// Checks if an attribute matches a word.
-fn word_attr(key: &str, attr: &Meta) -> bool {
-    if let Meta::Word(ref ident) = *attr {
-        ident == key
+/// Checks if an attribute matches a path.
+fn path_attr(key: &str, attr: &Meta) -> bool {
+    if let Meta::Path(ref path) = *attr {
+        path.is_ident(key)
     } else {
         false
     }
 }
 
 pub(super) fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
-    if attr.name() != "tag" {
+    if !attr.path().is_ident("tag") {
         return Ok(None);
     }
     match *attr {
         Meta::List(ref meta_list) => {
             // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
             if meta_list.nested.len() == 1 {
-                if let NestedMeta::Literal(Lit::Int(ref lit)) = meta_list.nested[0] {
-                    return Ok(Some(lit.value() as u32));
+                if let NestedMeta::Lit(Lit::Int(ref lit)) = meta_list.nested[0] {
+                    return Ok(Some(lit.base10_parse::<u32>()?));
                 }
             }
             bail!("invalid tag attribute: {:?}", attr);
@@ -329,7 +329,7 @@ pub(super) fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
                 .parse::<u32>()
                 .map_err(Error::from)
                 .map(Option::Some),
-            Lit::Int(ref lit) => Ok(Some(lit.value() as u32)),
+            Lit::Int(ref lit) => Ok(Some(lit.base10_parse::<u32>()?)),
             _ => bail!("invalid tag attribute: {:?}", attr),
         },
         _ => bail!("invalid tag attribute: {:?}", attr),
@@ -337,15 +337,15 @@ pub(super) fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
 }
 
 fn tags_attr(attr: &Meta) -> Result<Option<Vec<u32>>, Error> {
-    if attr.name() != "tags" {
+    if !attr.path().is_ident("tags") {
         return Ok(None);
     }
     match *attr {
         Meta::List(ref meta_list) => {
             let mut tags = Vec::with_capacity(meta_list.nested.len());
             for item in &meta_list.nested {
-                if let NestedMeta::Literal(Lit::Int(ref lit)) = *item {
-                    tags.push(lit.value() as u32);
+                if let NestedMeta::Lit(Lit::Int(ref lit)) = *item {
+                    tags.push(lit.base10_parse::<u32>()?);
                 } else {
                     bail!("invalid tag attribute: {:?}", attr);
                 }

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -18,7 +18,7 @@ impl Field {
         let mut unknown_attrs = Vec::new();
 
         for attr in attrs {
-            if attr.name() == "oneof" {
+            if attr.path().is_ident("oneof") {
                 let t = match *attr {
                     Meta::NameValue(MetaNameValue {
                         lit: Lit::Str(ref lit),
@@ -26,8 +26,8 @@ impl Field {
                     }) => parse_str::<Path>(&lit.value())?,
                     Meta::List(ref list) if list.nested.len() == 1 => {
                         // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
-                        if let NestedMeta::Meta(Meta::Word(ref ident)) = list.nested[0] {
-                            Path::from(ident.clone())
+                        if let NestedMeta::Meta(Meta::Path(ref path)) = list.nested[0] {
+                            path.clone()
                         } else {
                             bail!("invalid oneof attribute: item must be an identifier");
                         }


### PR DESCRIPTION
CLOSES #218

The biggest changes in syn 1.0 relevant to prost are the switch from `ident` to `path` in `Meta`, and the removal of `.value()` on literals.

The biggest logical change I had to make is how negative default values are parsed. Apart from that the printing of an attribute via `attr.path().into_token_stream()` (since nothing straightforward printable like `.name()` exists that I could find), is the only other logical change.

Everything else should be the 1:1 equivalent to the old logic after renaming.