### PR TITLE
Add "std" feature everywhere to support no_std envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
   - osx
 
 rust:
-  - 1.32.0
+  - 1.36.0
   - nightly
 
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,19 +33,20 @@ exclude = [
 ]
 
 [features]
-default = ["prost-derive"]
+default = ["prost-derive", "std"]
+std = ["bytes/std", "prost-derive/std"]
 no-recursion-limit = []
 
 [dependencies]
-bytes = "0.4.7"
-prost-derive = { version = "0.5.0", path = "prost-derive", optional = true }
+bytes = { git = "https://github.com/tokio-rs/bytes.git", default-features = false }
+prost-derive = { version = "0.5.0", path = "prost-derive", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = "0.2"
 env_logger = { version = "0.6", default-features = false }
 failure = "0.1"
 log = "0.4"
-protobuf = { version = "0", path = "protobuf" }
+protobuf = { version = "0", path = "protobuf", default-features = false }
 quickcheck = "0.8"
 
 [[bench]]

--- a/benches/varint.rs
+++ b/benches/varint.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use bytes::IntoBuf;
+use bytes::Buf;
 use prost::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
 macro_rules! varint_bench {
@@ -21,14 +21,12 @@ macro_rules! varint_bench {
         fn $decode_name(b: &mut test::Bencher) {
             let mut buf = Vec::with_capacity(100 * 10);
             $encode(&mut buf);
-            let buf = &buf[..];
 
             let mut values = [0u64; 100];
 
             b.iter(|| {
-                let mut buf = buf.into_buf();
                 for i in 0..100 {
-                    values[i] = decode_varint(&mut buf).unwrap();
+                    values[i] = decode_varint(&buf).unwrap();
                 }
                 test::black_box(&values[..]);
             });
@@ -40,9 +38,8 @@ macro_rules! varint_bench {
             {
                 let mut buf = Vec::with_capacity(100 * 10);
                 $encode(&mut buf);
-                let mut buf = (&buf[..]).into_buf();
                 for i in 0..100 {
-                    values[i] = decode_varint(&mut buf).unwrap();
+                    values[i] = decode_varint(&buf).unwrap();
                 }
             }
 

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -6,9 +6,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "0.4.7"
+bytes = { git = "https://github.com/tokio-rs/bytes.git", default-features = false }
 env_logger = { version = "0.6", default-features = false }
 log = "0.3"
-prost = { path = ".." }
-protobuf = { path = "../protobuf" }
-tests = { path = "../tests" }
+prost = { path = "..", default-features = false }
+protobuf = { path = "../protobuf", default-features = false }
+tests = { path = "../tests", default-features = false }
+
+[features]
+default = ["std"]
+std = ["bytes/std", "prost/std", "protobuf/std", "tests/std"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,8 +10,8 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
-protobuf = { path = "../protobuf" }
-tests = { path = "../tests" }
+protobuf = { path = "../protobuf", default-features = false }
+tests = { path = "../tests", default-features = false }
 
 [[bin]]
 name = "proto3"
@@ -20,3 +20,7 @@ path = "fuzzers/proto3.rs"
 [[bin]]
 name = "proto2"
 path = "fuzzers/proto2.rs"
+
+[features]
+default = ["std"]
+std = ["protobuf/std", "tests/std"]

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -11,14 +11,14 @@ description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2018"
 
 [dependencies]
-bytes = "0.4.7"
+bytes = { git = "https://github.com/tokio-rs/bytes.git", default-features = false }
 heck = "0.3"
 itertools = "0.8"
 log = "0.4"
 multimap = { version = "0.4", default-features = false }
 petgraph = { version = "0.4", default-features = false }
-prost = { version = "0.5.0", path = ".." }
-prost-types = { version = "0.5.0", path = "../prost-types" }
+prost = { version = "0.5.0", path = "..", default-features = false }
+prost-types = { version = "0.5.0", path = "../prost-types", default-features = false }
 tempfile = "3"
 
 [build-dependencies]
@@ -26,3 +26,8 @@ which = "2"
 
 [dev-dependencies]
 env_logger = { version = "0.6", default-features = false }
+
+
+[features]
+default = ["std"]
+std = ["bytes/std", "prost/std", "prost-types/std"]

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -731,8 +731,16 @@ impl<'a> CodeGenerator<'a> {
             Type::Int32 | Type::Sfixed32 | Type::Sint32 | Type::Enum => String::from("i32"),
             Type::Int64 | Type::Sfixed64 | Type::Sint64 => String::from("i64"),
             Type::Bool => String::from("bool"),
-            Type::String => String::from("std::string::String"),
-            Type::Bytes => String::from("std::vec::Vec<u8>"),
+            Type::String => String::from(if self.no_std {
+                "::alloc::string::String"
+            } else {
+                "::std::string::String"
+            }),
+            Type::Bytes => String::from(if self.no_std {
+                "::alloc::vec::Vec<u8>"
+            } else {
+                "::std::vec::Vec<u8>"
+            }),
             Type::Group | Type::Message => self.resolve_ident(field.type_name()),
         }
     }

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -478,7 +478,7 @@ impl<'a> CodeGenerator<'a> {
         self.buf.push_str(&format!(
             "pub {}: ::{}::option::Option<{}>,\n",
             to_snake(oneof.name()),
-            if self.no_std { "alloc" } else { "std" },
+            if self.no_std { "core" } else { "std" },
             name
         ));
     }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -541,7 +541,7 @@ impl Config {
         // We cannot rely on Into<io::Error> here because we might be in no_std mode
         let descriptor_set =
             FileDescriptorSet::decode(&buf[..])
-                .map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
+                .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;
 
         let modules = self.generate(descriptor_set.file)?;
         for (module, content) in modules {

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -538,7 +538,7 @@ impl Config {
 
         let mut buf = Vec::new();
         fs::File::open(descriptor_set)?.read_to_end(&mut buf)?;
-        let descriptor_set = FileDescriptorSet::decode(&buf)?;
+        let descriptor_set = FileDescriptorSet::decode(&buf[..])?;
 
         let modules = self.generate(descriptor_set.file)?;
         for (module, content) in modules {

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -538,7 +538,10 @@ impl Config {
 
         let mut buf = Vec::new();
         fs::File::open(descriptor_set)?.read_to_end(&mut buf)?;
-        let descriptor_set = FileDescriptorSet::decode(&buf[..])?;
+        // We cannot rely on Into<io::Error> here because we might be in no_std mode
+        let descriptor_set =
+            FileDescriptorSet::decode(&buf[..])
+                .map_err(|error| Error::new(ErrorKind::InvalidData, error))?;
 
         let modules = self.generate(descriptor_set.file)?;
         for (module, content) in modules {

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -14,8 +14,12 @@ edition = "2018"
 proc_macro = true
 
 [dependencies]
-failure = { version = "0.1", default-features = false, features = ["std"] }
+failure = { version = "0.1", default-features = false }
 itertools = "0.8"
 proc-macro2 = "0.4.4"
 quote = "0.6.3"
 syn = { version = "0.15", features = [ "extra-traits" ] }
+
+[features]
+default = ["std"]
+std = ["failure/std"]

--- a/prost-derive/src/field/group.rs
+++ b/prost-derive/src/field/group.rs
@@ -4,6 +4,7 @@ use quote::quote;
 use syn::Meta;
 
 use crate::field::{set_bool, set_option, tag_attr, word_attr, Label};
+use crate::core_crate;
 
 #[derive(Clone)]
 pub struct Field {
@@ -119,8 +120,9 @@ impl Field {
     }
 
     pub fn clear(&self, ident: TokenStream) -> TokenStream {
+        let core_crate = core_crate();
         match self.label {
-            Label::Optional => quote!(#ident = ::std::option::Option::None),
+            Label::Optional => quote!(#ident = #core_crate::option::Option::None),
             Label::Required => quote!(#ident.clear()),
             Label::Repeated => quote!(#ident.clear()),
         }

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -4,6 +4,7 @@ use quote::quote;
 use syn::{Ident, Lit, Meta, MetaNameValue, NestedMeta};
 
 use crate::field::{scalar, set_option, tag_attr};
+use crate::{alloc_crate, core_crate};
 
 #[derive(Clone, Debug)]
 pub enum MapTy {
@@ -210,6 +211,7 @@ impl Field {
 
     /// Returns methods to embed in the message.
     pub fn methods(&self, ident: &Ident) -> Option<TokenStream> {
+        let core_crate = core_crate();
         if let ValueTy::Scalar(scalar::Ty::Enumeration(ref ty)) = self.value_ty {
             let key_ty = self.key_ty.rust_type();
             let key_ref_ty = self.key_ty.rust_ref_type();
@@ -223,10 +225,10 @@ impl Field {
             };
 
             Some(quote! {
-                pub fn #get(&self, key: #key_ref_ty) -> ::std::option::Option<#ty> {
+                pub fn #get(&self, key: #key_ref_ty) -> #core_crate::option::Option<#ty> {
                     self.#ident.get(#take_ref key).cloned().and_then(#ty::from_i32)
                 }
-                pub fn #insert(&mut self, key: #key_ty, value: #ty) -> ::std::option::Option<#ty> {
+                pub fn #insert(&mut self, key: #key_ty, value: #ty) -> #core_crate::option::Option<#ty> {
                     self.#ident.insert(key, value as i32).and_then(#ty::from_i32)
                 }
             })
@@ -240,6 +242,8 @@ impl Field {
     /// The Debug tries to convert any enumerations met into the variants if possible, instead of
     /// outputting the raw numbers.
     pub fn debug(&self, wrapper_name: TokenStream) -> TokenStream {
+        let core_crate = core_crate();
+        let alloc_crate = alloc_crate();
         let type_name = match self.map_ty {
             MapTy::HashMap => Ident::new("HashMap", Span::call_site()),
             MapTy::BTreeMap => Ident::new("BTreeMap", Span::call_site()),
@@ -249,7 +253,7 @@ impl Field {
         let key = self.key_ty.rust_type();
         let value_wrapper = self.value_ty.debug();
         let fmt = quote! {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            fn fmt(&self, f: &mut #core_crate::fmt::Formatter) -> #core_crate::fmt::Result {
                 #key_wrapper
                 #value_wrapper
                 let mut builder = f.debug_map();
@@ -263,17 +267,17 @@ impl Field {
             ValueTy::Scalar(ref ty) => {
                 let value = ty.rust_type();
                 quote! {
-                    struct #wrapper_name<'a>(&'a ::std::collections::#type_name<#key, #value>);
-                    impl<'a> ::std::fmt::Debug for #wrapper_name<'a> {
+                    struct #wrapper_name<'a>(&'a #alloc_crate::collections::#type_name<#key, #value>);
+                    impl<'a> #core_crate::fmt::Debug for #wrapper_name<'a> {
                         #fmt
                     }
                 }
             }
             ValueTy::Message => quote! {
-                struct #wrapper_name<'a, V: 'a>(&'a ::std::collections::#type_name<#key, V>);
-                impl<'a, V> ::std::fmt::Debug for #wrapper_name<'a, V>
+                struct #wrapper_name<'a, V: 'a>(&'a #alloc_crate::collections::#type_name<#key, V>);
+                impl<'a, V> #core_crate::fmt::Debug for #wrapper_name<'a, V>
                 where
-                    V: ::std::fmt::Debug + 'a,
+                    V: #core_crate::fmt::Debug + 'a,
                 {
                     #fmt
                 }

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -4,6 +4,7 @@ use quote::quote;
 use syn::Meta;
 
 use crate::field::{set_bool, set_option, tag_attr, word_attr, Label};
+use crate::core_crate;
 
 #[derive(Clone)]
 pub struct Field {
@@ -122,8 +123,9 @@ impl Field {
     }
 
     pub fn clear(&self, ident: TokenStream) -> TokenStream {
+        let core_crate = core_crate();
         match self.label {
-            Label::Optional => quote!(#ident = ::std::option::Option::None),
+            Label::Optional => quote!(#ident = #core_crate::option::Option::None),
             Label::Required => quote!(#ident.clear()),
             Label::Repeated => quote!(#ident.clear()),
         }

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -11,6 +11,7 @@ use failure::{bail, Error};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, Ident, Lit, LitBool, Meta, MetaList, MetaNameValue, NestedMeta};
+use crate::core_crate;
 
 #[derive(Clone)]
 pub enum Field {
@@ -133,9 +134,10 @@ impl Field {
     }
 
     pub fn default(&self) -> TokenStream {
+        let core_crate = core_crate();
         match *self {
             Field::Scalar(ref scalar) => scalar.default(),
-            _ => quote!(::std::default::Default::default()),
+            _ => quote!(#core_crate::default::Default::default()),
         }
     }
 

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -4,6 +4,7 @@ use quote::quote;
 use syn::{parse_str, Lit, Meta, MetaNameValue, NestedMeta, Path};
 
 use crate::field::{set_option, tags_attr};
+use crate::core_crate;
 
 #[derive(Clone)]
 pub struct Field {
@@ -90,6 +91,7 @@ impl Field {
     }
 
     pub fn clear(&self, ident: TokenStream) -> TokenStream {
-        quote!(#ident = ::std::option::Option::None)
+        let core_crate = core_crate();
+        quote!(#ident = #core_crate::option::Option::None)
     }
 }

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -15,5 +15,9 @@ doctest = false
 test = false
 
 [dependencies]
-bytes = "0.4.7"
-prost = { version = "0.5.0", path = ".." }
+bytes = { git = "https://github.com/tokio-rs/bytes.git", default-features = false }
+prost = { version = "0.5.0", path = "..", default-features = false, features = ["prost-derive"] }
+
+[features]
+default = ["std"]
+std = ["bytes/std", "prost/std"]

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -2,15 +2,15 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Version {
     #[prost(int32, optional, tag="1")]
-    pub major: ::std::option::Option<i32>,
+    pub major: crate::lib::option::Option<i32>,
     #[prost(int32, optional, tag="2")]
-    pub minor: ::std::option::Option<i32>,
+    pub minor: crate::lib::option::Option<i32>,
     #[prost(int32, optional, tag="3")]
-    pub patch: ::std::option::Option<i32>,
+    pub patch: crate::lib::option::Option<i32>,
     /// A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
     /// be empty for mainline stable releases.
     #[prost(string, optional, tag="4")]
-    pub suffix: ::std::option::Option<std::string::String>,
+    pub suffix: crate::lib::option::Option<crate::lib::string::String>,
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -19,10 +19,10 @@ pub struct CodeGeneratorRequest {
     /// code generator should generate code only for these files.  Each file's
     /// descriptor will be included in proto_file, below.
     #[prost(string, repeated, tag="1")]
-    pub file_to_generate: ::std::vec::Vec<std::string::String>,
+    pub file_to_generate: crate::lib::vec::Vec<crate::lib::string::String>,
     /// The generator parameter passed on the command-line.
     #[prost(string, optional, tag="2")]
-    pub parameter: ::std::option::Option<std::string::String>,
+    pub parameter: crate::lib::option::Option<crate::lib::string::String>,
     /// FileDescriptorProtos for all files in files_to_generate and everything
     /// they import.  The files will appear in topological order, so each file
     /// appears before any file that imports it.
@@ -38,10 +38,10 @@ pub struct CodeGeneratorRequest {
     /// Type names of fields and extensions in the FileDescriptorProto are always
     /// fully qualified.
     #[prost(message, repeated, tag="15")]
-    pub proto_file: ::std::vec::Vec<super::FileDescriptorProto>,
+    pub proto_file: crate::lib::vec::Vec<super::FileDescriptorProto>,
     /// The version number of protocol compiler.
     #[prost(message, optional, tag="3")]
-    pub compiler_version: ::std::option::Option<Version>,
+    pub compiler_version: crate::lib::option::Option<Version>,
 }
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -55,9 +55,9 @@ pub struct CodeGeneratorResponse {
     /// unparseable -- should be reported by writing a message to stderr and
     /// exiting with a non-zero status code.
     #[prost(string, optional, tag="1")]
-    pub error: ::std::option::Option<std::string::String>,
+    pub error: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(message, repeated, tag="15")]
-    pub file: ::std::vec::Vec<code_generator_response::File>,
+    pub file: crate::lib::vec::Vec<code_generator_response::File>,
 }
 pub mod code_generator_response {
     /// Represents a single generated file.
@@ -75,7 +75,7 @@ pub mod code_generator_response {
         /// this writing protoc does not optimize for this -- it will read the entire
         /// CodeGeneratorResponse before writing files to disk.
         #[prost(string, optional, tag="1")]
-        pub name: ::std::option::Option<std::string::String>,
+        pub name: crate::lib::option::Option<crate::lib::string::String>,
         /// If non-empty, indicates that the named file should already exist, and the
         /// content here is to be inserted into that file at a defined insertion
         /// point.  This feature allows a code generator to extend the output
@@ -114,9 +114,9 @@ pub mod code_generator_response {
         ///
         /// If |insertion_point| is present, |name| must also be present.
         #[prost(string, optional, tag="2")]
-        pub insertion_point: ::std::option::Option<std::string::String>,
+        pub insertion_point: crate::lib::option::Option<crate::lib::string::String>,
         /// The file contents.
         #[prost(string, optional, tag="15")]
-        pub content: ::std::option::Option<std::string::String>,
+        pub content: crate::lib::option::Option<crate::lib::string::String>,
     }
 }

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -3,84 +3,84 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag="1")]
-    pub file: ::std::vec::Vec<FileDescriptorProto>,
+    pub file: crate::lib::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: crate::lib::option::Option<crate::lib::string::String>,
     /// e.g. "foo", "foo.bar", etc.
     #[prost(string, optional, tag="2")]
-    pub package: ::std::option::Option<std::string::String>,
+    pub package: crate::lib::option::Option<crate::lib::string::String>,
     /// Names of files imported by this file.
     #[prost(string, repeated, tag="3")]
-    pub dependency: ::std::vec::Vec<std::string::String>,
+    pub dependency: crate::lib::vec::Vec<crate::lib::string::String>,
     /// Indexes of the public imported files in the dependency list above.
     #[prost(int32, repeated, packed="false", tag="10")]
-    pub public_dependency: ::std::vec::Vec<i32>,
+    pub public_dependency: crate::lib::vec::Vec<i32>,
     /// Indexes of the weak imported files in the dependency list.
     /// For Google-internal migration only. Do not use.
     #[prost(int32, repeated, packed="false", tag="11")]
-    pub weak_dependency: ::std::vec::Vec<i32>,
+    pub weak_dependency: crate::lib::vec::Vec<i32>,
     /// All top-level definitions in this file.
     #[prost(message, repeated, tag="4")]
-    pub message_type: ::std::vec::Vec<DescriptorProto>,
+    pub message_type: crate::lib::vec::Vec<DescriptorProto>,
     #[prost(message, repeated, tag="5")]
-    pub enum_type: ::std::vec::Vec<EnumDescriptorProto>,
+    pub enum_type: crate::lib::vec::Vec<EnumDescriptorProto>,
     #[prost(message, repeated, tag="6")]
-    pub service: ::std::vec::Vec<ServiceDescriptorProto>,
+    pub service: crate::lib::vec::Vec<ServiceDescriptorProto>,
     #[prost(message, repeated, tag="7")]
-    pub extension: ::std::vec::Vec<FieldDescriptorProto>,
+    pub extension: crate::lib::vec::Vec<FieldDescriptorProto>,
     #[prost(message, optional, tag="8")]
-    pub options: ::std::option::Option<FileOptions>,
+    pub options: crate::lib::option::Option<FileOptions>,
     /// This field contains optional information about the original source code.
     /// You may safely remove this entire field without harming runtime
     /// functionality of the descriptors -- the information is needed only by
     /// development tools.
     #[prost(message, optional, tag="9")]
-    pub source_code_info: ::std::option::Option<SourceCodeInfo>,
+    pub source_code_info: crate::lib::option::Option<SourceCodeInfo>,
     /// The syntax of the proto file.
     /// The supported values are "proto2" and "proto3".
     #[prost(string, optional, tag="12")]
-    pub syntax: ::std::option::Option<std::string::String>,
+    pub syntax: crate::lib::option::Option<crate::lib::string::String>,
 }
 /// Describes a message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(message, repeated, tag="2")]
-    pub field: ::std::vec::Vec<FieldDescriptorProto>,
+    pub field: crate::lib::vec::Vec<FieldDescriptorProto>,
     #[prost(message, repeated, tag="6")]
-    pub extension: ::std::vec::Vec<FieldDescriptorProto>,
+    pub extension: crate::lib::vec::Vec<FieldDescriptorProto>,
     #[prost(message, repeated, tag="3")]
-    pub nested_type: ::std::vec::Vec<DescriptorProto>,
+    pub nested_type: crate::lib::vec::Vec<DescriptorProto>,
     #[prost(message, repeated, tag="4")]
-    pub enum_type: ::std::vec::Vec<EnumDescriptorProto>,
+    pub enum_type: crate::lib::vec::Vec<EnumDescriptorProto>,
     #[prost(message, repeated, tag="5")]
-    pub extension_range: ::std::vec::Vec<descriptor_proto::ExtensionRange>,
+    pub extension_range: crate::lib::vec::Vec<descriptor_proto::ExtensionRange>,
     #[prost(message, repeated, tag="8")]
-    pub oneof_decl: ::std::vec::Vec<OneofDescriptorProto>,
+    pub oneof_decl: crate::lib::vec::Vec<OneofDescriptorProto>,
     #[prost(message, optional, tag="7")]
-    pub options: ::std::option::Option<MessageOptions>,
+    pub options: crate::lib::option::Option<MessageOptions>,
     #[prost(message, repeated, tag="9")]
-    pub reserved_range: ::std::vec::Vec<descriptor_proto::ReservedRange>,
+    pub reserved_range: crate::lib::vec::Vec<descriptor_proto::ReservedRange>,
     /// Reserved field names, which may not be used by fields in the same message.
     /// A given name may only be reserved once.
     #[prost(string, repeated, tag="10")]
-    pub reserved_name: ::std::vec::Vec<std::string::String>,
+    pub reserved_name: crate::lib::vec::Vec<crate::lib::string::String>,
 }
 pub mod descriptor_proto {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ExtensionRange {
         #[prost(int32, optional, tag="1")]
-        pub start: ::std::option::Option<i32>,
+        pub start: crate::lib::option::Option<i32>,
         #[prost(int32, optional, tag="2")]
-        pub end: ::std::option::Option<i32>,
+        pub end: crate::lib::option::Option<i32>,
         #[prost(message, optional, tag="3")]
-        pub options: ::std::option::Option<super::ExtensionRangeOptions>,
+        pub options: crate::lib::option::Option<super::ExtensionRangeOptions>,
     }
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
@@ -89,61 +89,61 @@ pub mod descriptor_proto {
     pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
-        pub start: ::std::option::Option<i32>,
+        pub start: crate::lib::option::Option<i32>,
         /// Exclusive.
         #[prost(int32, optional, tag="2")]
-        pub end: ::std::option::Option<i32>,
+        pub end: crate::lib::option::Option<i32>,
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: crate::lib::vec::Vec<UninterpretedOption>,
 }
 /// Describes a field within a message.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(int32, optional, tag="3")]
-    pub number: ::std::option::Option<i32>,
+    pub number: crate::lib::option::Option<i32>,
     #[prost(enumeration="field_descriptor_proto::Label", optional, tag="4")]
-    pub label: ::std::option::Option<i32>,
+    pub label: crate::lib::option::Option<i32>,
     /// If type_name is set, this need not be set.  If both this and type_name
     /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     #[prost(enumeration="field_descriptor_proto::Type", optional, tag="5")]
-    pub r#type: ::std::option::Option<i32>,
+    pub r#type: crate::lib::option::Option<i32>,
     /// For message and enum types, this is the name of the type.  If the name
     /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
     /// rules are used to find the type (i.e. first the nested types within this
     /// message are searched, then within the parent, on up to the root
     /// namespace).
     #[prost(string, optional, tag="6")]
-    pub type_name: ::std::option::Option<std::string::String>,
+    pub type_name: crate::lib::option::Option<crate::lib::string::String>,
     /// For extensions, this is the name of the type being extended.  It is
     /// resolved in the same manner as type_name.
     #[prost(string, optional, tag="2")]
-    pub extendee: ::std::option::Option<std::string::String>,
+    pub extendee: crate::lib::option::Option<crate::lib::string::String>,
     /// For numeric types, contains the original text representation of the value.
     /// For booleans, "true" or "false".
     /// For strings, contains the default text contents (not escaped in any way).
     /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
     /// TODO(kenton):  Base-64 encode?
     #[prost(string, optional, tag="7")]
-    pub default_value: ::std::option::Option<std::string::String>,
+    pub default_value: crate::lib::option::Option<crate::lib::string::String>,
     /// If set, gives the index of a oneof in the containing type's oneof_decl
     /// list.  This field is a member of that oneof.
     #[prost(int32, optional, tag="9")]
-    pub oneof_index: ::std::option::Option<i32>,
+    pub oneof_index: crate::lib::option::Option<i32>,
     /// JSON name of this field. The value is set by protocol compiler. If the
     /// user has set a "json_name" option on this field, that option's value
     /// will be used. Otherwise, it's deduced from the field's name by converting
     /// it to camelCase.
     #[prost(string, optional, tag="10")]
-    pub json_name: ::std::option::Option<std::string::String>,
+    pub json_name: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(message, optional, tag="8")]
-    pub options: ::std::option::Option<FieldOptions>,
+    pub options: crate::lib::option::Option<FieldOptions>,
 }
 pub mod field_descriptor_proto {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -195,28 +195,28 @@ pub mod field_descriptor_proto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(message, optional, tag="2")]
-    pub options: ::std::option::Option<OneofOptions>,
+    pub options: crate::lib::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(message, repeated, tag="2")]
-    pub value: ::std::vec::Vec<EnumValueDescriptorProto>,
+    pub value: crate::lib::vec::Vec<EnumValueDescriptorProto>,
     #[prost(message, optional, tag="3")]
-    pub options: ::std::option::Option<EnumOptions>,
+    pub options: crate::lib::option::Option<EnumOptions>,
     /// Range of reserved numeric values. Reserved numeric values may not be used
     /// by enum values in the same enum declaration. Reserved ranges may not
     /// overlap.
     #[prost(message, repeated, tag="4")]
-    pub reserved_range: ::std::vec::Vec<enum_descriptor_proto::EnumReservedRange>,
+    pub reserved_range: crate::lib::vec::Vec<enum_descriptor_proto::EnumReservedRange>,
     /// Reserved enum value names, which may not be reused. A given name may only
     /// be reserved once.
     #[prost(string, repeated, tag="5")]
-    pub reserved_name: ::std::vec::Vec<std::string::String>,
+    pub reserved_name: crate::lib::vec::Vec<crate::lib::string::String>,
 }
 pub mod enum_descriptor_proto {
     /// Range of reserved numeric values. Reserved values may not be used by
@@ -229,51 +229,51 @@ pub mod enum_descriptor_proto {
     pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
-        pub start: ::std::option::Option<i32>,
+        pub start: crate::lib::option::Option<i32>,
         /// Inclusive.
         #[prost(int32, optional, tag="2")]
-        pub end: ::std::option::Option<i32>,
+        pub end: crate::lib::option::Option<i32>,
     }
 }
 /// Describes a value within an enum.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(int32, optional, tag="2")]
-    pub number: ::std::option::Option<i32>,
+    pub number: crate::lib::option::Option<i32>,
     #[prost(message, optional, tag="3")]
-    pub options: ::std::option::Option<EnumValueOptions>,
+    pub options: crate::lib::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(message, repeated, tag="2")]
-    pub method: ::std::vec::Vec<MethodDescriptorProto>,
+    pub method: crate::lib::vec::Vec<MethodDescriptorProto>,
     #[prost(message, optional, tag="3")]
-    pub options: ::std::option::Option<ServiceOptions>,
+    pub options: crate::lib::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: crate::lib::option::Option<crate::lib::string::String>,
     /// Input and output type names.  These are resolved in the same way as
     /// FieldDescriptorProto.type_name, but must refer to a message type.
     #[prost(string, optional, tag="2")]
-    pub input_type: ::std::option::Option<std::string::String>,
+    pub input_type: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(string, optional, tag="3")]
-    pub output_type: ::std::option::Option<std::string::String>,
+    pub output_type: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(message, optional, tag="4")]
-    pub options: ::std::option::Option<MethodOptions>,
+    pub options: crate::lib::option::Option<MethodOptions>,
     /// Identifies if client streams multiple client messages
     #[prost(bool, optional, tag="5", default="false")]
-    pub client_streaming: ::std::option::Option<bool>,
+    pub client_streaming: crate::lib::option::Option<bool>,
     /// Identifies if server streams multiple server messages
     #[prost(bool, optional, tag="6", default="false")]
-    pub server_streaming: ::std::option::Option<bool>,
+    pub server_streaming: crate::lib::option::Option<bool>,
 }
 // ===================================================================
 // Options
@@ -314,14 +314,14 @@ pub struct FileOptions {
     /// inappropriate because proto packages do not normally start with backwards
     /// domain names.
     #[prost(string, optional, tag="1")]
-    pub java_package: ::std::option::Option<std::string::String>,
+    pub java_package: crate::lib::option::Option<crate::lib::string::String>,
     /// If set, all the classes from the .proto file are wrapped in a single
     /// outer class with the given name.  This applies to both Proto1
     /// (equivalent to the old "--one_java_file" option) and Proto2 (where
     /// a .proto always translates to a single class, but you may want to
     /// explicitly choose the class name).
     #[prost(string, optional, tag="8")]
-    pub java_outer_classname: ::std::option::Option<std::string::String>,
+    pub java_outer_classname: crate::lib::option::Option<crate::lib::string::String>,
     /// If set true, then the Java code generator will generate a separate .java
     /// file for each top-level message, enum, and service defined in the .proto
     /// file.  Thus, these types will *not* be nested inside the outer class
@@ -329,10 +329,10 @@ pub struct FileOptions {
     /// generated to contain the file's getDescriptor() method as well as any
     /// top-level extensions defined in the file.
     #[prost(bool, optional, tag="10", default="false")]
-    pub java_multiple_files: ::std::option::Option<bool>,
+    pub java_multiple_files: crate::lib::option::Option<bool>,
     /// This option does nothing.
     #[prost(bool, optional, tag="20")]
-    pub java_generate_equals_and_hash: ::std::option::Option<bool>,
+    pub java_generate_equals_and_hash: crate::lib::option::Option<bool>,
     /// If set true, then the Java2 code generator will generate code that
     /// throws an exception whenever an attempt is made to assign a non-UTF-8
     /// byte sequence to a string field.
@@ -340,16 +340,16 @@ pub struct FileOptions {
     /// However, an extension field still accepts non-UTF-8 byte sequences.
     /// This option has no effect on when used with the lite runtime.
     #[prost(bool, optional, tag="27", default="false")]
-    pub java_string_check_utf8: ::std::option::Option<bool>,
+    pub java_string_check_utf8: crate::lib::option::Option<bool>,
     #[prost(enumeration="file_options::OptimizeMode", optional, tag="9", default="Speed")]
-    pub optimize_for: ::std::option::Option<i32>,
+    pub optimize_for: crate::lib::option::Option<i32>,
     /// Sets the Go package where structs generated from this .proto will be
     /// placed. If omitted, the Go package will be derived from the following:
     ///   - The basename of the package import path, if provided.
     ///   - Otherwise, the package statement in the .proto file, if present.
     ///   - Otherwise, the basename of the .proto file, without extension.
     #[prost(string, optional, tag="11")]
-    pub go_package: ::std::option::Option<std::string::String>,
+    pub go_package: crate::lib::option::Option<crate::lib::string::String>,
     /// Should generic services be generated in each language?  "Generic" services
     /// are not specific to any particular RPC system.  They are generated by the
     /// main code generators in each language (without additional plugins).
@@ -361,59 +361,59 @@ pub struct FileOptions {
     /// these default to false.  Old code which depends on generic services should
     /// explicitly set them to true.
     #[prost(bool, optional, tag="16", default="false")]
-    pub cc_generic_services: ::std::option::Option<bool>,
+    pub cc_generic_services: crate::lib::option::Option<bool>,
     #[prost(bool, optional, tag="17", default="false")]
-    pub java_generic_services: ::std::option::Option<bool>,
+    pub java_generic_services: crate::lib::option::Option<bool>,
     #[prost(bool, optional, tag="18", default="false")]
-    pub py_generic_services: ::std::option::Option<bool>,
+    pub py_generic_services: crate::lib::option::Option<bool>,
     #[prost(bool, optional, tag="42", default="false")]
-    pub php_generic_services: ::std::option::Option<bool>,
+    pub php_generic_services: crate::lib::option::Option<bool>,
     /// Is this file deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for everything in the file, or it will be completely ignored; in the very
     /// least, this is a formalization for deprecating files.
     #[prost(bool, optional, tag="23", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: crate::lib::option::Option<bool>,
     /// Enables the use of arenas for the proto messages in this file. This applies
     /// only to generated classes for C++.
     #[prost(bool, optional, tag="31", default="false")]
-    pub cc_enable_arenas: ::std::option::Option<bool>,
+    pub cc_enable_arenas: crate::lib::option::Option<bool>,
     /// Sets the objective c class prefix which is prepended to all objective c
     /// generated classes from this .proto. There is no default.
     #[prost(string, optional, tag="36")]
-    pub objc_class_prefix: ::std::option::Option<std::string::String>,
+    pub objc_class_prefix: crate::lib::option::Option<crate::lib::string::String>,
     /// Namespace for generated classes; defaults to the package.
     #[prost(string, optional, tag="37")]
-    pub csharp_namespace: ::std::option::Option<std::string::String>,
+    pub csharp_namespace: crate::lib::option::Option<crate::lib::string::String>,
     /// By default Swift generators will take the proto package and CamelCase it
     /// replacing '.' with underscore and use that to prefix the types/symbols
     /// defined. When this options is provided, they will use this value instead
     /// to prefix the types/symbols defined.
     #[prost(string, optional, tag="39")]
-    pub swift_prefix: ::std::option::Option<std::string::String>,
+    pub swift_prefix: crate::lib::option::Option<crate::lib::string::String>,
     /// Sets the php class prefix which is prepended to all php generated classes
     /// from this .proto. Default is empty.
     #[prost(string, optional, tag="40")]
-    pub php_class_prefix: ::std::option::Option<std::string::String>,
+    pub php_class_prefix: crate::lib::option::Option<crate::lib::string::String>,
     /// Use this option to change the namespace of php generated classes. Default
     /// is empty. When this option is empty, the package name will be used for
     /// determining the namespace.
     #[prost(string, optional, tag="41")]
-    pub php_namespace: ::std::option::Option<std::string::String>,
+    pub php_namespace: crate::lib::option::Option<crate::lib::string::String>,
     /// Use this option to change the namespace of php generated metadata classes.
     /// Default is empty. When this option is empty, the proto file name will be used
     /// for determining the namespace.
     #[prost(string, optional, tag="44")]
-    pub php_metadata_namespace: ::std::option::Option<std::string::String>,
+    pub php_metadata_namespace: crate::lib::option::Option<crate::lib::string::String>,
     /// Use this option to change the package of ruby generated classes. Default
     /// is empty. When this option is not set, the package name will be used for
     /// determining the ruby package.
     #[prost(string, optional, tag="45")]
-    pub ruby_package: ::std::option::Option<std::string::String>,
+    pub ruby_package: crate::lib::option::Option<crate::lib::string::String>,
     /// The parser stores options it doesn't recognize here.
     /// See the documentation for the "Options" section above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: crate::lib::vec::Vec<UninterpretedOption>,
 }
 pub mod file_options {
     /// Generated classes can be optimized for speed or code size.
@@ -451,18 +451,18 @@ pub struct MessageOptions {
     /// Because this is an option, the above two restrictions are not enforced by
     /// the protocol compiler.
     #[prost(bool, optional, tag="1", default="false")]
-    pub message_set_wire_format: ::std::option::Option<bool>,
+    pub message_set_wire_format: crate::lib::option::Option<bool>,
     /// Disables the generation of the standard "descriptor()" accessor, which can
     /// conflict with a field of the same name.  This is meant to make migration
     /// from proto1 easier; new code should avoid fields named "descriptor".
     #[prost(bool, optional, tag="2", default="false")]
-    pub no_standard_descriptor_accessor: ::std::option::Option<bool>,
+    pub no_standard_descriptor_accessor: crate::lib::option::Option<bool>,
     /// Is this message deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the message, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating messages.
     #[prost(bool, optional, tag="3", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: crate::lib::option::Option<bool>,
     /// Whether the message is an automatically generated map entry type for the
     /// maps field.
     ///
@@ -485,10 +485,10 @@ pub struct MessageOptions {
     /// instead. The option should only be implicitly set by the proto compiler
     /// parser.
     #[prost(bool, optional, tag="7")]
-    pub map_entry: ::std::option::Option<bool>,
+    pub map_entry: crate::lib::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: crate::lib::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldOptions {
@@ -497,14 +497,14 @@ pub struct FieldOptions {
     /// options below.  This option is not yet implemented in the open source
     /// release -- sorry, we'll try to include it in a future version!
     #[prost(enumeration="field_options::CType", optional, tag="1", default="String")]
-    pub ctype: ::std::option::Option<i32>,
+    pub ctype: crate::lib::option::Option<i32>,
     /// The packed option can be enabled for repeated primitive fields to enable
     /// a more efficient representation on the wire. Rather than repeatedly
     /// writing the tag and type for each element, the entire array is encoded as
     /// a single length-delimited blob. In proto3, only explicit setting it to
     /// false will avoid using packed encoding.
     #[prost(bool, optional, tag="2")]
-    pub packed: ::std::option::Option<bool>,
+    pub packed: crate::lib::option::Option<bool>,
     /// The jstype option determines the JavaScript type used for values of the
     /// field.  The option is permitted only for 64 bit integral and fixed types
     /// (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
@@ -517,7 +517,7 @@ pub struct FieldOptions {
     /// This option is an enum to permit additional types to be added, e.g.
     /// goog.math.Integer.
     #[prost(enumeration="field_options::JsType", optional, tag="6", default="JsNormal")]
-    pub jstype: ::std::option::Option<i32>,
+    pub jstype: crate::lib::option::Option<i32>,
     /// Should this field be parsed lazily?  Lazy applies only to message-type
     /// fields.  It means that when the outer message is initially parsed, the
     /// inner message's contents will not be parsed but instead stored in encoded
@@ -547,19 +547,19 @@ pub struct FieldOptions {
     /// check its required fields, regardless of whether or not the message has
     /// been parsed.
     #[prost(bool, optional, tag="5", default="false")]
-    pub lazy: ::std::option::Option<bool>,
+    pub lazy: crate::lib::option::Option<bool>,
     /// Is this field deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for accessors, or it will be completely ignored; in the very least, this
     /// is a formalization for deprecating fields.
     #[prost(bool, optional, tag="3", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: crate::lib::option::Option<bool>,
     /// For Google-internal migration only. Do not use.
     #[prost(bool, optional, tag="10", default="false")]
-    pub weak: ::std::option::Option<bool>,
+    pub weak: crate::lib::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: crate::lib::vec::Vec<UninterpretedOption>,
 }
 pub mod field_options {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -585,23 +585,23 @@ pub mod field_options {
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: crate::lib::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
     #[prost(bool, optional, tag="2")]
-    pub allow_alias: ::std::option::Option<bool>,
+    pub allow_alias: crate::lib::option::Option<bool>,
     /// Is this enum deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the enum, or it will be completely ignored; in the very least, this
     /// is a formalization for deprecating enums.
     #[prost(bool, optional, tag="3", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: crate::lib::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: crate::lib::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueOptions {
@@ -610,10 +610,10 @@ pub struct EnumValueOptions {
     /// for the enum value, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating enum values.
     #[prost(bool, optional, tag="1", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: crate::lib::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: crate::lib::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceOptions {
@@ -627,10 +627,10 @@ pub struct ServiceOptions {
     /// for the service, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating services.
     #[prost(bool, optional, tag="33", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: crate::lib::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: crate::lib::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodOptions {
@@ -644,12 +644,12 @@ pub struct MethodOptions {
     /// for the method, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating methods.
     #[prost(bool, optional, tag="33", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: crate::lib::option::Option<bool>,
     #[prost(enumeration="method_options::IdempotencyLevel", optional, tag="34", default="IdempotencyUnknown")]
-    pub idempotency_level: ::std::option::Option<i32>,
+    pub idempotency_level: crate::lib::option::Option<i32>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: crate::lib::vec::Vec<UninterpretedOption>,
 }
 pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
@@ -674,21 +674,21 @@ pub mod method_options {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag="2")]
-    pub name: ::std::vec::Vec<uninterpreted_option::NamePart>,
+    pub name: crate::lib::vec::Vec<uninterpreted_option::NamePart>,
     /// The value of the uninterpreted option, in whatever type the tokenizer
     /// identified it as during parsing. Exactly one of these should be set.
     #[prost(string, optional, tag="3")]
-    pub identifier_value: ::std::option::Option<std::string::String>,
+    pub identifier_value: crate::lib::option::Option<crate::lib::string::String>,
     #[prost(uint64, optional, tag="4")]
-    pub positive_int_value: ::std::option::Option<u64>,
+    pub positive_int_value: crate::lib::option::Option<u64>,
     #[prost(int64, optional, tag="5")]
-    pub negative_int_value: ::std::option::Option<i64>,
+    pub negative_int_value: crate::lib::option::Option<i64>,
     #[prost(double, optional, tag="6")]
-    pub double_value: ::std::option::Option<f64>,
+    pub double_value: crate::lib::option::Option<f64>,
     #[prost(bytes, optional, tag="7")]
-    pub string_value: ::std::option::Option<std::vec::Vec<u8>>,
+    pub string_value: crate::lib::option::Option<crate::lib::vec::Vec<u8>>,
     #[prost(string, optional, tag="8")]
-    pub aggregate_value: ::std::option::Option<std::string::String>,
+    pub aggregate_value: crate::lib::option::Option<crate::lib::string::String>,
 }
 pub mod uninterpreted_option {
     /// The name of the uninterpreted option.  Each string represents a segment in
@@ -699,7 +699,7 @@ pub mod uninterpreted_option {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NamePart {
         #[prost(string, required, tag="1")]
-        pub name_part: std::string::String,
+        pub name_part: crate::lib::string::String,
         #[prost(bool, required, tag="2")]
         pub is_extension: bool,
     }
@@ -755,7 +755,7 @@ pub struct SourceCodeInfo {
     ///   ignore those that it doesn't understand, as more types of locations could
     ///   be recorded in the future.
     #[prost(message, repeated, tag="1")]
-    pub location: ::std::vec::Vec<source_code_info::Location>,
+    pub location: crate::lib::vec::Vec<source_code_info::Location>,
 }
 pub mod source_code_info {
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -784,14 +784,14 @@ pub mod source_code_info {
         /// this path refers to the whole field declaration (from the beginning
         /// of the label to the terminating semicolon).
         #[prost(int32, repeated, tag="1")]
-        pub path: ::std::vec::Vec<i32>,
+        pub path: crate::lib::vec::Vec<i32>,
         /// Always has exactly three or four elements: start line, start column,
         /// end line (optional, otherwise assumed same as start line), end column.
         /// These are packed into a single field for efficiency.  Note that line
         /// and column numbers are zero-based -- typically you will want to add
         /// 1 to each before displaying to a user.
         #[prost(int32, repeated, tag="2")]
-        pub span: ::std::vec::Vec<i32>,
+        pub span: crate::lib::vec::Vec<i32>,
         /// If this SourceCodeInfo represents a complete declaration, these are any
         /// comments appearing before and after the declaration which appear to be
         /// attached to the declaration.
@@ -840,11 +840,11 @@ pub mod source_code_info {
         ///
         ///   // ignored detached comments.
         #[prost(string, optional, tag="3")]
-        pub leading_comments: ::std::option::Option<std::string::String>,
+        pub leading_comments: crate::lib::option::Option<crate::lib::string::String>,
         #[prost(string, optional, tag="4")]
-        pub trailing_comments: ::std::option::Option<std::string::String>,
+        pub trailing_comments: crate::lib::option::Option<crate::lib::string::String>,
         #[prost(string, repeated, tag="6")]
-        pub leading_detached_comments: ::std::vec::Vec<std::string::String>,
+        pub leading_detached_comments: crate::lib::vec::Vec<crate::lib::string::String>,
     }
 }
 /// Describes the relationship between generated code and its original source
@@ -855,7 +855,7 @@ pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
     #[prost(message, repeated, tag="1")]
-    pub annotation: ::std::vec::Vec<generated_code_info::Annotation>,
+    pub annotation: crate::lib::vec::Vec<generated_code_info::Annotation>,
 }
 pub mod generated_code_info {
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -863,19 +863,19 @@ pub mod generated_code_info {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
         #[prost(int32, repeated, tag="1")]
-        pub path: ::std::vec::Vec<i32>,
+        pub path: crate::lib::vec::Vec<i32>,
         /// Identifies the filesystem path to the original source .proto.
         #[prost(string, optional, tag="2")]
-        pub source_file: ::std::option::Option<std::string::String>,
+        pub source_file: crate::lib::option::Option<crate::lib::string::String>,
         /// Identifies the starting offset in bytes in the generated code
         /// that relates to the identified object.
         #[prost(int32, optional, tag="3")]
-        pub begin: ::std::option::Option<i32>,
+        pub begin: crate::lib::option::Option<i32>,
         /// Identifies the ending offset in bytes in the generated code that
         /// relates to the identified offset. The end offset should be one past
         /// the last relevant byte (so the length of the text = end - begin).
         #[prost(int32, optional, tag="4")]
-        pub end: ::std::option::Option<i32>,
+        pub end: crate::lib::option::Option<i32>,
     }
 }
 /// `Any` contains an arbitrary serialized protocol buffer message along with a
@@ -989,10 +989,10 @@ pub struct Any {
     /// used with implementation specific semantics.
     ///
     #[prost(string, tag="1")]
-    pub type_url: std::string::String,
+    pub type_url: crate::lib::string::String,
     /// Must be a valid serialized protocol buffer of the above specified type.
     #[prost(bytes, tag="2")]
-    pub value: std::vec::Vec<u8>,
+    pub value: crate::lib::vec::Vec<u8>,
 }
 /// `SourceContext` represents information about the source of a
 /// protobuf element, like the file in which it is defined.
@@ -1001,26 +1001,26 @@ pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
     #[prost(string, tag="1")]
-    pub file_name: std::string::String,
+    pub file_name: crate::lib::string::String,
 }
 /// A protocol buffer message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Type {
     /// The fully qualified message name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: crate::lib::string::String,
     /// The list of fields.
     #[prost(message, repeated, tag="2")]
-    pub fields: ::std::vec::Vec<Field>,
+    pub fields: crate::lib::vec::Vec<Field>,
     /// The list of types appearing in `oneof` definitions in this type.
     #[prost(string, repeated, tag="3")]
-    pub oneofs: ::std::vec::Vec<std::string::String>,
+    pub oneofs: crate::lib::vec::Vec<crate::lib::string::String>,
     /// The protocol buffer options.
     #[prost(message, repeated, tag="4")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: crate::lib::vec::Vec<Option>,
     /// The source context.
     #[prost(message, optional, tag="5")]
-    pub source_context: ::std::option::Option<SourceContext>,
+    pub source_context: crate::lib::option::Option<SourceContext>,
     /// The source syntax.
     #[prost(enumeration="Syntax", tag="6")]
     pub syntax: i32,
@@ -1039,11 +1039,11 @@ pub struct Field {
     pub number: i32,
     /// The field name.
     #[prost(string, tag="4")]
-    pub name: std::string::String,
+    pub name: crate::lib::string::String,
     /// The field type URL, without the scheme, for message or enumeration
     /// types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
     #[prost(string, tag="6")]
-    pub type_url: std::string::String,
+    pub type_url: crate::lib::string::String,
     /// The index of the field type in `Type.oneofs`, for message or enumeration
     /// types. The first type has index 1; zero means the type is not in the list.
     #[prost(int32, tag="7")]
@@ -1053,13 +1053,13 @@ pub struct Field {
     pub packed: bool,
     /// The protocol buffer options.
     #[prost(message, repeated, tag="9")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: crate::lib::vec::Vec<Option>,
     /// The field JSON name.
     #[prost(string, tag="10")]
-    pub json_name: std::string::String,
+    pub json_name: crate::lib::string::String,
     /// The string value of the default value of this field. Proto2 syntax only.
     #[prost(string, tag="11")]
-    pub default_value: std::string::String,
+    pub default_value: crate::lib::string::String,
 }
 pub mod field {
     /// Basic field types.
@@ -1124,16 +1124,16 @@ pub mod field {
 pub struct Enum {
     /// Enum type name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: crate::lib::string::String,
     /// Enum value definitions.
     #[prost(message, repeated, tag="2")]
-    pub enumvalue: ::std::vec::Vec<EnumValue>,
+    pub enumvalue: crate::lib::vec::Vec<EnumValue>,
     /// Protocol buffer options.
     #[prost(message, repeated, tag="3")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: crate::lib::vec::Vec<Option>,
     /// The source context.
     #[prost(message, optional, tag="4")]
-    pub source_context: ::std::option::Option<SourceContext>,
+    pub source_context: crate::lib::option::Option<SourceContext>,
     /// The source syntax.
     #[prost(enumeration="Syntax", tag="5")]
     pub syntax: i32,
@@ -1143,13 +1143,13 @@ pub struct Enum {
 pub struct EnumValue {
     /// Enum value name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: crate::lib::string::String,
     /// Enum value number.
     #[prost(int32, tag="2")]
     pub number: i32,
     /// Protocol buffer options.
     #[prost(message, repeated, tag="3")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: crate::lib::vec::Vec<Option>,
 }
 /// A protocol buffer option, which can be attached to a message, field,
 /// enumeration, etc.
@@ -1160,13 +1160,13 @@ pub struct Option {
     /// For custom options, it should be the fully-qualified name. For example,
     /// `"google.api.http"`.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: crate::lib::string::String,
     /// The option's value packed in an Any message. If the value is a primitive,
     /// the corresponding wrapper type defined in google/protobuf/wrappers.proto
     /// should be used. If the value is an enum, it should be stored as an int32
     /// value using the google.protobuf.Int32Value type.
     #[prost(message, optional, tag="2")]
-    pub value: ::std::option::Option<Any>,
+    pub value: crate::lib::option::Option<Any>,
 }
 /// The syntax in which a protocol buffer element is defined.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -1191,13 +1191,13 @@ pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: crate::lib::string::String,
     /// The methods of this interface, in unspecified order.
     #[prost(message, repeated, tag="2")]
-    pub methods: ::std::vec::Vec<Method>,
+    pub methods: crate::lib::vec::Vec<Method>,
     /// Any metadata attached to the interface.
     #[prost(message, repeated, tag="3")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: crate::lib::vec::Vec<Option>,
     /// A version string for this interface. If specified, must have the form
     /// `major-version.minor-version`, as in `1.10`. If the minor version is
     /// omitted, it defaults to zero. If the entire version field is empty, the
@@ -1220,14 +1220,14 @@ pub struct Api {
     ///
     ///
     #[prost(string, tag="4")]
-    pub version: std::string::String,
+    pub version: crate::lib::string::String,
     /// Source context for the protocol buffer service represented by this
     /// message.
     #[prost(message, optional, tag="5")]
-    pub source_context: ::std::option::Option<SourceContext>,
+    pub source_context: crate::lib::option::Option<SourceContext>,
     /// Included interfaces. See [Mixin][].
     #[prost(message, repeated, tag="6")]
-    pub mixins: ::std::vec::Vec<Mixin>,
+    pub mixins: crate::lib::vec::Vec<Mixin>,
     /// The source syntax of the service.
     #[prost(enumeration="Syntax", tag="7")]
     pub syntax: i32,
@@ -1237,22 +1237,22 @@ pub struct Api {
 pub struct Method {
     /// The simple name of this method.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: crate::lib::string::String,
     /// A URL of the input message type.
     #[prost(string, tag="2")]
-    pub request_type_url: std::string::String,
+    pub request_type_url: crate::lib::string::String,
     /// If true, the request is streamed.
     #[prost(bool, tag="3")]
     pub request_streaming: bool,
     /// The URL of the output message type.
     #[prost(string, tag="4")]
-    pub response_type_url: std::string::String,
+    pub response_type_url: crate::lib::string::String,
     /// If true, the response is streamed.
     #[prost(bool, tag="5")]
     pub response_streaming: bool,
     /// Any metadata attached to the method.
     #[prost(message, repeated, tag="6")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: crate::lib::vec::Vec<Option>,
     /// The source syntax of this method.
     #[prost(enumeration="Syntax", tag="7")]
     pub syntax: i32,
@@ -1339,11 +1339,11 @@ pub struct Method {
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: crate::lib::string::String,
     /// If non-empty specifies a path under which inherited HTTP paths
     /// are rooted.
     #[prost(string, tag="2")]
-    pub root: std::string::String,
+    pub root: crate::lib::string::String,
 }
 /// A Duration represents a signed, fixed-length span of time represented
 /// as a count of seconds and fractions of seconds at nanosecond
@@ -1624,7 +1624,7 @@ pub struct Duration {
 pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag="1")]
-    pub paths: ::std::vec::Vec<std::string::String>,
+    pub paths: crate::lib::vec::Vec<crate::lib::string::String>,
 }
 /// `Struct` represents a structured data value, consisting of fields
 /// which map to dynamically typed values. In some languages, `Struct`
@@ -1638,7 +1638,7 @@ pub struct FieldMask {
 pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map="string, message", tag="1")]
-    pub fields: ::std::collections::BTreeMap<std::string::String, Value>,
+    pub fields: crate::lib::collections::BTreeMap<crate::lib::string::String, Value>,
 }
 /// `Value` represents a dynamically typed value which can be either
 /// null, a number, a string, a boolean, a recursive struct value, or a
@@ -1650,7 +1650,7 @@ pub struct Struct {
 pub struct Value {
     /// The kind of value.
     #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
-    pub kind: ::std::option::Option<value::Kind>,
+    pub kind: crate::lib::option::Option<value::Kind>,
 }
 pub mod value {
     /// The kind of value.
@@ -1664,7 +1664,7 @@ pub mod value {
         NumberValue(f64),
         /// Represents a string value.
         #[prost(string, tag="3")]
-        StringValue(std::string::String),
+        StringValue(crate::lib::string::String),
         /// Represents a boolean value.
         #[prost(bool, tag="4")]
         BoolValue(bool),
@@ -1683,7 +1683,7 @@ pub mod value {
 pub struct ListValue {
     /// Repeated field of dynamically typed values.
     #[prost(message, repeated, tag="1")]
-    pub values: ::std::vec::Vec<Value>,
+    pub values: crate::lib::vec::Vec<Value>,
 }
 /// `NullValue` is a singleton enumeration to represent the null value for the
 /// `Value` type union.

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -6,14 +6,18 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "0.4.7"
-prost = { path = ".." }
-prost-types = { path = "../prost-types" }
+bytes = { git = "https://github.com/tokio-rs/bytes.git", default-features = false }
+prost = { path = ".." , default-features = false }
+prost-types = { path = "../prost-types", default-features = false }
 
 [build-dependencies]
 cfg-if = "0.1"
 curl = "0.4"
 flate2 = "1.0"
-prost-build = { path = "../prost-build" }
+prost-build = { path = "../prost-build", default-features = false }
 tar = "0.4"
 tempfile = "3"
+
+[features]
+default = ["std"]
+std = ["bytes/std", "prost/std", "prost-types/std", "prost-build/std"]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -2,10 +2,17 @@
 //!
 //! Meant to be used only from `Message` implementations.
 
-use std::cmp::min;
-use std::mem;
-use std::u32;
-use std::usize;
+#[cfg(not(feature = "std"))]
+use alloc::format;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use core::cmp::min;
+use core::mem;
+use core::u32;
+use core::usize;
 
 use ::bytes::{Buf, BufMut};
 
@@ -1040,8 +1047,11 @@ pub mod group {
 /// generic over `HashMap` and `BTreeMap`.
 macro_rules! map {
     ($map_ty:ident) => {
+        #[cfg(not(feature = "std"))]
+        use alloc::collections::$map_ty;
+        #[cfg(feature = "std")]
         use std::collections::$map_ty;
-        use std::hash::Hash;
+        use core::hash::Hash;
 
         use crate::encoding::*;
 
@@ -1225,6 +1235,7 @@ macro_rules! map {
     };
 }
 
+#[cfg(feature = "std")]
 pub mod hash_map {
     map!(HashMap);
 }
@@ -1240,7 +1251,7 @@ mod test {
     use std::io::Cursor;
     use std::u64;
 
-    use ::bytes::{Bytes, BytesMut, IntoBuf};
+    use ::bytes::{Bytes, BytesMut};
     use quickcheck::TestResult;
 
     use crate::encoding::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,15 @@
 //! Protobuf encoding and decoding errors.
 
+#[cfg(not(feature = "std"))]
+use alloc::borrow::Cow;
+#[cfg(feature = "std")]
 use std::borrow::Cow;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt;
+use core::fmt;
+#[cfg(feature = "std")]
 use std::io;
 
 /// A Protobuf message decoding error.
@@ -54,12 +61,14 @@ impl fmt::Display for DecodeError {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for DecodeError {
     fn description(&self) -> &str {
         &self.description
     }
 }
 
+#[cfg(feature = "std")]
 impl From<DecodeError> for io::Error {
     fn from(error: DecodeError) -> io::Error {
         io::Error::new(io::ErrorKind::InvalidData, error)
@@ -95,11 +104,15 @@ impl EncodeError {
     pub fn remaining(&self) -> usize {
         self.remaining
     }
+
+    fn description(&self) -> &str {
+        "failed to encode Protobuf message: insufficient buffer capacity"
+    }
 }
 
 impl fmt::Display for EncodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(error::Error::description(self))?;
+        f.write_str(self.description())?;
         write!(
             f,
             " (required: {}, remaining: {})",
@@ -108,12 +121,14 @@ impl fmt::Display for EncodeError {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for EncodeError {
     fn description(&self) -> &str {
-        "failed to encode Protobuf message: insufficient buffer capacity"
+        EncodeError::description(self)
     }
 }
 
+#[cfg(feature = "std")]
 impl From<EncodeError> for io::Error {
     fn from(error: EncodeError) -> io::Error {
         io::Error::new(io::ErrorKind::InvalidInput, error)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,10 @@
 #![doc(html_root_url = "https://docs.rs/prost/0.5.0")]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 mod error;
 mod message;
 mod types;
@@ -10,7 +15,7 @@ pub mod encoding;
 pub use crate::error::{DecodeError, EncodeError};
 pub use crate::message::Message;
 
-use bytes::{BufMut, IntoBuf};
+use bytes::{BufMut, Buf};
 
 use crate::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
@@ -58,11 +63,10 @@ pub fn length_delimiter_len(length: usize) -> usize {
 ///    input is required to decode the full delimiter.
 ///  * If the supplied buffer contains more than 10 bytes, then the buffer contains an invalid
 ///    delimiter, and typically the buffer should be considered corrupt.
-pub fn decode_length_delimiter<B>(buf: B) -> Result<usize, DecodeError>
+pub fn decode_length_delimiter<B>(mut buf: B) -> Result<usize, DecodeError>
 where
-    B: IntoBuf,
+    B: Buf,
 {
-    let mut buf = buf.into_buf();
     let length = decode_varint(&mut buf)?;
     if length > usize::max_value() as u64 {
         return Err(DecodeError::new(

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,10 @@
-use std::fmt::Debug;
-use std::usize;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
 
-use ::bytes::{Buf, BufMut, IntoBuf};
+use core::fmt::Debug;
+use core::usize;
+
+use ::bytes::{Buf, BufMut};
 
 use crate::encoding::*;
 use crate::DecodeError;
@@ -78,19 +81,19 @@ pub trait Message: Debug + Send + Sync {
     /// Decodes an instance of the message from a buffer.
     ///
     /// The entire buffer will be consumed.
-    fn decode<B>(buf: B) -> Result<Self, DecodeError>
+    fn decode<B>(mut buf: B) -> Result<Self, DecodeError>
     where
-        B: IntoBuf,
+        B: Buf,
         Self: Default,
     {
         let mut message = Self::default();
-        Self::merge(&mut message, &mut buf.into_buf()).map(|_| message)
+        Self::merge(&mut message, &mut buf).map(|_| message)
     }
 
     /// Decodes a length-delimited instance of the message from the buffer.
     fn decode_length_delimited<B>(buf: B) -> Result<Self, DecodeError>
     where
-        B: IntoBuf,
+        B: Buf,
         Self: Default,
     {
         let mut message = Self::default();
@@ -101,12 +104,11 @@ pub trait Message: Debug + Send + Sync {
     /// Decodes an instance of the message from a buffer, and merges it into `self`.
     ///
     /// The entire buffer will be consumed.
-    fn merge<B>(&mut self, buf: B) -> Result<(), DecodeError>
+    fn merge<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
     where
-        B: IntoBuf,
+        B: Buf,
         Self: Sized,
     {
-        let mut buf = buf.into_buf();
         let ctx = DecodeContext::default();
         while buf.has_remaining() {
             let (tag, wire_type) = decode_key(&mut buf)?;
@@ -117,15 +119,15 @@ pub trait Message: Debug + Send + Sync {
 
     /// Decodes a length-delimited instance of the message from buffer, and
     /// merges it into `self`.
-    fn merge_length_delimited<B>(&mut self, buf: B) -> Result<(), DecodeError>
+    fn merge_length_delimited<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
     where
-        B: IntoBuf,
+        B: Buf,
         Self: Sized,
     {
         message::merge(
             WireType::LengthDelimited,
             self,
-            &mut buf.into_buf(),
+            &mut buf,
             DecodeContext::default(),
         )
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,11 @@
 //! the `prost-types` crate in order to avoid a cyclic dependency between `prost` and
 //! `prost-build`.
 
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use ::bytes::{Buf, BufMut};
 
 use crate::encoding::*;

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -12,23 +12,24 @@ doctest = false
 path = "../tests/src/lib.rs"
 
 [features]
-default = ["edition-2015"]
+default = ["edition-2015", "std"]
 edition-2015 = []
+std = ["bytes/std", "prost/std", "prost-types/std", "protobuf/std", "prost-build/std"]
 
 [dependencies]
-bytes = "0.4.7"
+bytes = { git = "https://github.com/tokio-rs/bytes.git", default-features = false }
 cfg-if = "0.1"
-prost = { path = ".." }
-prost-types = { path = "../prost-types" }
-protobuf = { path = "../protobuf" }
+prost = { path = "..", default-features = false  }
+prost-types = { path = "../prost-types", default-features = false  }
+protobuf = { path = "../protobuf", default-features = false  }
 
 [dev-dependencies]
 diff = "0.1"
-prost-build = { path = "../prost-build" }
+prost-build = { path = "../prost-build", default-features = false }
 tempfile = "3"
 
 [build-dependencies]
 cfg-if = "0.1"
 env_logger = { version = "0.6", default-features = false }
-prost-build = { path = "../prost-build" }
-protobuf = { path = "../protobuf" }
+prost-build = { path = "../prost-build", default-features = false  }
+protobuf = { path = "../protobuf", default-features = false  }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,19 +11,23 @@ build = "src/build.rs"
 doctest = false
 
 [dependencies]
-bytes = "0.4.7"
+bytes = { git = "https://github.com/tokio-rs/bytes.git", default-features = false }
 cfg-if = "0.1"
-prost = { path = ".." }
-prost-types = { path = "../prost-types" }
-protobuf = { path = "../protobuf" }
+prost = { path = "..", default-features = false }
+prost-types = { path = "../prost-types", default-features = false }
+protobuf = { path = "../protobuf", default-features = false }
 
 [dev-dependencies]
 diff = "0.1"
-prost-build = { path = "../prost-build" }
+prost-build = { path = "../prost-build", default-features = false }
 tempfile = "3"
 
 [build-dependencies]
 cfg-if = "0.1"
 env_logger = { version = "0.6", default-features = false }
-prost-build = { path = "../prost-build" }
-protobuf = { path = "../protobuf" }
+prost-build = { path = "../prost-build", default-features = false }
+protobuf = { path = "../protobuf", default-features = false }
+
+[features]
+default = ["std"]
+std = ["bytes/std", "prost/std", "prost-types/std", "prost-build/std"]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -76,7 +76,7 @@ pub mod groups {
 
 use std::error::Error;
 
-use bytes::{Buf, IntoBuf};
+use bytes::Buf;
 
 use prost::Message;
 


### PR DESCRIPTION
I made these changes to be able to run prost in a no_std environment where alloc is still available.

This is similar to #215 except it uses slightly different naming conventions in different places (i.e. the feature is called `std` instead of `use_std` consistently and so on).  Truth be told, I created this version without being aware of the other one. Maybe the two approaches could be combined!