### PR TITLE
Update to `syn`/`quote`/`proc-macro2` 1.0

### DIFF
--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -16,6 +16,6 @@ proc_macro = true
 [dependencies]
 failure = { version = "0.1", default-features = false, features = ["std"] }
 itertools = "0.8"
-proc-macro2 = "0.4.4"
-quote = "0.6.3"
-syn = { version = "0.15", features = [ "extra-traits" ] }
+proc-macro2 = "1.0"
+quote = "1.0.2"
+syn = { version = "1.0.8", features = [ "extra-traits" ] }

--- a/prost-derive/src/field/group.rs
+++ b/prost-derive/src/field/group.rs
@@ -1,6 +1,6 @@
 use failure::{bail, Error};
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::Meta;
 
 use crate::field::{set_bool, set_option, tag_attr, word_attr, Label};
@@ -58,7 +58,10 @@ impl Field {
     pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
         if let Some(mut field) = Field::new(attrs, None)? {
             if let Some(attr) = attrs.iter().find(|attr| Label::from_attr(attr).is_some()) {
-                bail!("invalid atribute for oneof field: {}", attr.name());
+                bail!(
+                    "invalid attribute for oneof field: {}",
+                    attr.path().into_token_stream()
+                );
             }
             field.label = Label::Required;
             Ok(Some(field))

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -1,6 +1,6 @@
 use failure::{bail, Error};
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::Meta;
 
 use crate::field::{set_bool, set_option, tag_attr, word_attr, Label};
@@ -61,7 +61,10 @@ impl Field {
     pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
         if let Some(mut field) = Field::new(attrs, None)? {
             if let Some(attr) = attrs.iter().find(|attr| Label::from_attr(attr).is_some()) {
-                bail!("invalid atribute for oneof field: {}", attr.name());
+                bail!(
+                    "invalid attribute for oneof field: {}",
+                    attr.path().into_token_stream()
+                );
             }
             field.label = Label::Required;
             Ok(Some(field))

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -200,9 +200,9 @@ impl Label {
     /// Parses a string into a field label.
     /// If the string doesn't match a field label, `None` is returned.
     fn from_attr(attr: &Meta) -> Option<Label> {
-        if let Meta::Word(ref ident) = *attr {
+        if let Meta::Path(ref path) = *attr {
             for &label in Label::variants() {
-                if ident == label.as_str() {
+                if path.is_ident(label.as_str()) {
                     return Some(label);
                 }
             }
@@ -227,10 +227,10 @@ impl fmt::Display for Label {
 pub(super) fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
     Ok(attrs
         .iter()
-        .flat_map(Attribute::interpret_meta)
+        .flat_map(Attribute::parse_meta)
         .flat_map(|meta| match meta {
-            Meta::List(MetaList { ident, nested, .. }) => {
-                if ident == "prost" {
+            Meta::List(MetaList { path, nested, .. }) => {
+                if path.is_ident("prost") {
                     nested.into_iter().collect()
                 } else {
                     Vec::new()
@@ -241,7 +241,7 @@ pub(super) fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
         .flat_map(|attr| -> Result<_, _> {
             match attr {
                 NestedMeta::Meta(attr) => Ok(attr),
-                NestedMeta::Literal(lit) => bail!("invalid prost attribute: {:?}", lit),
+                NestedMeta::Lit(lit) => bail!("invalid prost attribute: {:?}", lit),
             }
         })
         .collect())
@@ -270,15 +270,15 @@ pub fn set_bool(b: &mut bool, message: &str) -> Result<(), Error> {
 /// Unpacks an attribute into a (key, boolean) pair, returning the boolean value.
 /// If the key doesn't match the attribute, `None` is returned.
 fn bool_attr(key: &str, attr: &Meta) -> Result<Option<bool>, Error> {
-    if attr.name() != key {
+    if !attr.path().is_ident(key) {
         return Ok(None);
     }
     match *attr {
-        Meta::Word(..) => Ok(Some(true)),
+        Meta::Path(..) => Ok(Some(true)),
         Meta::List(ref meta_list) => {
             // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
             if meta_list.nested.len() == 1 {
-                if let NestedMeta::Literal(Lit::Bool(LitBool { value, .. })) = meta_list.nested[0] {
+                if let NestedMeta::Lit(Lit::Bool(LitBool { value, .. })) = meta_list.nested[0] {
                     return Ok(Some(value));
                 }
             }
@@ -302,23 +302,23 @@ fn bool_attr(key: &str, attr: &Meta) -> Result<Option<bool>, Error> {
 
 /// Checks if an attribute matches a word.
 fn word_attr(key: &str, attr: &Meta) -> bool {
-    if let Meta::Word(ref ident) = *attr {
-        ident == key
+    if let Meta::Path(ref path) = *attr {
+        path.is_ident(key)
     } else {
         false
     }
 }
 
 pub(super) fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
-    if attr.name() != "tag" {
+    if !attr.path().is_ident("tag") {
         return Ok(None);
     }
     match *attr {
         Meta::List(ref meta_list) => {
             // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
             if meta_list.nested.len() == 1 {
-                if let NestedMeta::Literal(Lit::Int(ref lit)) = meta_list.nested[0] {
-                    return Ok(Some(lit.value() as u32));
+                if let NestedMeta::Lit(Lit::Int(ref lit)) = meta_list.nested[0] {
+                    return Ok(Some(lit.base10_parse()?));
                 }
             }
             bail!("invalid tag attribute: {:?}", attr);
@@ -329,7 +329,7 @@ pub(super) fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
                 .parse::<u32>()
                 .map_err(Error::from)
                 .map(Option::Some),
-            Lit::Int(ref lit) => Ok(Some(lit.value() as u32)),
+            Lit::Int(ref lit) => Ok(Some(lit.base10_parse()?)),
             _ => bail!("invalid tag attribute: {:?}", attr),
         },
         _ => bail!("invalid tag attribute: {:?}", attr),
@@ -337,15 +337,15 @@ pub(super) fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
 }
 
 fn tags_attr(attr: &Meta) -> Result<Option<Vec<u32>>, Error> {
-    if attr.name() != "tags" {
+    if !attr.path().is_ident("tags") {
         return Ok(None);
     }
     match *attr {
         Meta::List(ref meta_list) => {
             let mut tags = Vec::with_capacity(meta_list.nested.len());
             for item in &meta_list.nested {
-                if let NestedMeta::Literal(Lit::Int(ref lit)) = *item {
-                    tags.push(lit.value() as u32);
+                if let NestedMeta::Lit(Lit::Int(ref lit)) = *item {
+                    tags.push(lit.base10_parse()?);
                 } else {
                     bail!("invalid tag attribute: {:?}", attr);
                 }

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -18,7 +18,7 @@ impl Field {
         let mut unknown_attrs = Vec::new();
 
         for attr in attrs {
-            if attr.name() == "oneof" {
+            if attr.path().is_ident("oneof") {
                 let t = match *attr {
                     Meta::NameValue(MetaNameValue {
                         lit: Lit::Str(ref lit),
@@ -26,8 +26,12 @@ impl Field {
                     }) => parse_str::<Path>(&lit.value())?,
                     Meta::List(ref list) if list.nested.len() == 1 => {
                         // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
-                        if let NestedMeta::Meta(Meta::Word(ref ident)) = list.nested[0] {
-                            Path::from(ident.clone())
+                        if let NestedMeta::Meta(Meta::Path(ref path)) = list.nested[0] {
+                            if let Some(ident) = path.get_ident() {
+                                Path::from(ident.clone())
+                            } else {
+                                bail!("invalid oneof attribute: item must be an identifier");
+                            }
                         } else {
                             bail!("invalid oneof attribute: item must be an identifier");
                         }

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -4,8 +4,7 @@ use failure::{bail, format_err, Error};
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
-    self, parse_str, FloatSuffix, Ident, IntSuffix, Lit, LitByteStr, Meta, MetaList, MetaNameValue,
-    NestedMeta, Path,
+    self, parse_str, Ident, Lit, LitByteStr, Meta, MetaList, MetaNameValue, NestedMeta, Path,
 };
 
 use crate::field::{bool_attr, set_option, tag_attr, Label};
@@ -394,35 +393,35 @@ pub enum Ty {
 impl Ty {
     pub fn from_attr(attr: &Meta) -> Result<Option<Ty>, Error> {
         let ty = match *attr {
-            Meta::Word(ref name) if name == "float" => Ty::Float,
-            Meta::Word(ref name) if name == "double" => Ty::Double,
-            Meta::Word(ref name) if name == "int32" => Ty::Int32,
-            Meta::Word(ref name) if name == "int64" => Ty::Int64,
-            Meta::Word(ref name) if name == "uint32" => Ty::Uint32,
-            Meta::Word(ref name) if name == "uint64" => Ty::Uint64,
-            Meta::Word(ref name) if name == "sint32" => Ty::Sint32,
-            Meta::Word(ref name) if name == "sint64" => Ty::Sint64,
-            Meta::Word(ref name) if name == "fixed32" => Ty::Fixed32,
-            Meta::Word(ref name) if name == "fixed64" => Ty::Fixed64,
-            Meta::Word(ref name) if name == "sfixed32" => Ty::Sfixed32,
-            Meta::Word(ref name) if name == "sfixed64" => Ty::Sfixed64,
-            Meta::Word(ref name) if name == "bool" => Ty::Bool,
-            Meta::Word(ref name) if name == "string" => Ty::String,
-            Meta::Word(ref name) if name == "bytes" => Ty::Bytes,
+            Meta::Path(ref name) if name.is_ident("float") => Ty::Float,
+            Meta::Path(ref name) if name.is_ident("double") => Ty::Double,
+            Meta::Path(ref name) if name.is_ident("int32") => Ty::Int32,
+            Meta::Path(ref name) if name.is_ident("int64") => Ty::Int64,
+            Meta::Path(ref name) if name.is_ident("uint32") => Ty::Uint32,
+            Meta::Path(ref name) if name.is_ident("uint64") => Ty::Uint64,
+            Meta::Path(ref name) if name.is_ident("sint32") => Ty::Sint32,
+            Meta::Path(ref name) if name.is_ident("sint64") => Ty::Sint64,
+            Meta::Path(ref name) if name.is_ident("fixed32") => Ty::Fixed32,
+            Meta::Path(ref name) if name.is_ident("fixed64") => Ty::Fixed64,
+            Meta::Path(ref name) if name.is_ident("sfixed32") => Ty::Sfixed32,
+            Meta::Path(ref name) if name.is_ident("sfixed64") => Ty::Sfixed64,
+            Meta::Path(ref name) if name.is_ident("bool") => Ty::Bool,
+            Meta::Path(ref name) if name.is_ident("string") => Ty::String,
+            Meta::Path(ref name) if name.is_ident("bytes") => Ty::Bytes,
             Meta::NameValue(MetaNameValue {
-                ref ident,
+                ref path,
                 lit: Lit::Str(ref l),
                 ..
-            }) if ident == "enumeration" => Ty::Enumeration(parse_str::<Path>(&l.value())?),
+            }) if path.is_ident("enumeration") => Ty::Enumeration(parse_str::<Path>(&l.value())?),
             Meta::List(MetaList {
-                ref ident,
+                ref path,
                 ref nested,
                 ..
-            }) if ident == "enumeration" => {
+            }) if path.is_ident("enumeration") => {
                 // TODO(rustlang/rust#23121): slice pattern matching would make this much nicer.
                 if nested.len() == 1 {
-                    if let NestedMeta::Meta(Meta::Word(ref ident)) = nested[0] {
-                        Ty::Enumeration(Path::from(ident.clone()))
+                    if let NestedMeta::Meta(Meta::Path(ref path)) = nested[0] {
+                        Ty::Enumeration(path.clone())
                     } else {
                         bail!("invalid enumeration attribute: item must be an identifier");
                     }
@@ -583,7 +582,7 @@ pub enum DefaultValue {
 
 impl DefaultValue {
     pub fn from_attr(attr: &Meta) -> Result<Option<Lit>, Error> {
-        if attr.name() != "default" {
+        if !attr.path().is_ident("default") {
             return Ok(None);
         } else if let Meta::NameValue(ref name_value) = *attr {
             Ok(Some(name_value.lit.clone()))
@@ -599,51 +598,35 @@ impl DefaultValue {
         let is_u32 = *ty == Ty::Uint32 || *ty == Ty::Fixed32;
         let is_u64 = *ty == Ty::Uint64 || *ty == Ty::Fixed64;
 
+        let empty_or_is = |expected, actual: &str| expected == actual || actual.is_empty();
+
         let default = match lit {
-            Lit::Int(ref lit)
-                if is_i32
-                    && (lit.suffix() == IntSuffix::I32 || lit.suffix() == IntSuffix::None) =>
-            {
-                DefaultValue::I32(lit.value() as _)
+            Lit::Int(ref lit) if is_i32 && empty_or_is("i32", lit.suffix()) => {
+                DefaultValue::I32(lit.base10_parse()?)
             }
-            Lit::Int(ref lit)
-                if is_i64
-                    && (lit.suffix() == IntSuffix::I64 || lit.suffix() == IntSuffix::None) =>
-            {
-                DefaultValue::I64(lit.value() as _)
+            Lit::Int(ref lit) if is_i64 && empty_or_is("i64", lit.suffix()) => {
+                DefaultValue::I64(lit.base10_parse()?)
             }
-            Lit::Int(ref lit)
-                if is_u32
-                    && (lit.suffix() == IntSuffix::U32 || lit.suffix() == IntSuffix::None) =>
-            {
-                DefaultValue::U32(lit.value() as _)
+            Lit::Int(ref lit) if is_u32 && empty_or_is("u32", lit.suffix()) => {
+                DefaultValue::U32(lit.base10_parse()?)
             }
-            Lit::Int(ref lit)
-                if is_u64
-                    && (lit.suffix() == IntSuffix::U64 || lit.suffix() == IntSuffix::None) =>
-            {
-                DefaultValue::U64(lit.value())
+            Lit::Int(ref lit) if is_u64 && empty_or_is("u64", lit.suffix()) => {
+                DefaultValue::U64(lit.base10_parse()?)
             }
 
-            Lit::Float(ref lit)
-                if *ty == Ty::Float
-                    && (lit.suffix() == FloatSuffix::F32 || lit.suffix() == FloatSuffix::None) =>
-            {
-                DefaultValue::F32(lit.value() as _)
+            Lit::Float(ref lit) if *ty == Ty::Float && empty_or_is("f32", lit.suffix()) => {
+                DefaultValue::F32(lit.base10_parse()?)
             }
-            Lit::Int(ref lit) if *ty == Ty::Float => DefaultValue::F32(lit.value() as _),
+            Lit::Int(ref lit) if *ty == Ty::Float => DefaultValue::F32(lit.base10_parse()?),
 
-            Lit::Float(ref lit)
-                if *ty == Ty::Double
-                    && (lit.suffix() == FloatSuffix::F64 || lit.suffix() == FloatSuffix::None) =>
-            {
-                DefaultValue::F64(lit.value())
+            Lit::Float(ref lit) if *ty == Ty::Double && empty_or_is("f64", lit.suffix()) => {
+                DefaultValue::F64(lit.base10_parse()?)
             }
-            Lit::Int(ref lit) if *ty == Ty::Double => DefaultValue::F64(lit.value() as _),
+            Lit::Int(ref lit) if *ty == Ty::Double => DefaultValue::F64(lit.base10_parse()?),
 
             Lit::Bool(ref lit) if *ty == Ty::Bool => DefaultValue::Bool(lit.value),
-            Lit::Str(ref lit) if *ty == Ty::String => DefaultValue::String(lit.value().clone()),
-            Lit::ByteStr(ref lit) if *ty == Ty::Bytes => DefaultValue::Bytes(lit.value().clone()),
+            Lit::Str(ref lit) if *ty == Ty::String => DefaultValue::String(lit.value()),
+            Lit::ByteStr(ref lit) if *ty == Ty::Bytes => DefaultValue::Bytes(lit.value()),
 
             Lit::Str(ref lit) => {
                 let value = lit.value();
@@ -697,47 +680,43 @@ impl DefaultValue {
                     if let Ok(lit) = syn::parse_str::<Lit>(&value[1..]) {
                         match lit {
                             Lit::Int(ref lit)
-                                if is_i32
-                                    && (lit.suffix() == IntSuffix::I32
-                                        || lit.suffix() == IntSuffix::None) =>
+                                if is_i32 && empty_or_is("i32", lit.suffix()) =>
                             {
-                                return Ok(DefaultValue::I32((!lit.value() + 1) as i32));
+                                // XXX: Technically we lose span information by doing this, is
+                                // there a better way?
+                                return Ok(DefaultValue::I32(
+                                    format!("-{}", lit.base10_digits()).parse()?,
+                                ));
                             }
 
                             Lit::Int(ref lit)
-                                if is_i64
-                                    && (lit.suffix() == IntSuffix::I64
-                                        || lit.suffix() == IntSuffix::None) =>
+                                if is_i64 && empty_or_is("i64", lit.suffix()) =>
                             {
-                                return Ok(DefaultValue::I64((!lit.value() + 1) as i64));
+                                // XXX: Technically we lose span information by doing this, is
+                                // there a better way?
+                                return Ok(DefaultValue::I64(
+                                    format!("-{}", lit.base10_digits()).parse()?,
+                                ));
                             }
 
                             Lit::Float(ref lit)
-                                if *ty == Ty::Float
-                                    && (lit.suffix() == FloatSuffix::F32
-                                        || lit.suffix() == FloatSuffix::None) =>
+                                if *ty == Ty::Float && empty_or_is("f32", lit.suffix()) =>
                             {
-                                return Ok(DefaultValue::F32(-lit.value() as f32));
+                                return Ok(DefaultValue::F32(-lit.base10_parse()?));
                             }
 
                             Lit::Float(ref lit)
-                                if *ty == Ty::Double
-                                    && (lit.suffix() == FloatSuffix::F64
-                                        || lit.suffix() == FloatSuffix::None) =>
+                                if *ty == Ty::Double && empty_or_is("f64", lit.suffix()) =>
                             {
-                                return Ok(DefaultValue::F64(-lit.value()));
+                                return Ok(DefaultValue::F64(-lit.base10_parse()?));
                             }
 
-                            Lit::Int(ref lit)
-                                if *ty == Ty::Float && lit.suffix() == IntSuffix::None =>
-                            {
-                                return Ok(DefaultValue::F32(-(lit.value() as f32)));
+                            Lit::Int(ref lit) if *ty == Ty::Float && lit.suffix().is_empty() => {
+                                return Ok(DefaultValue::F32(-lit.base10_parse()?));
                             }
 
-                            Lit::Int(ref lit)
-                                if *ty == Ty::Double && lit.suffix() == IntSuffix::None =>
-                            {
-                                return Ok(DefaultValue::F64(-(lit.value() as f64)));
+                            Lit::Int(ref lit) if *ty == Ty::Double && lit.suffix().is_empty() => {
+                                return Ok(DefaultValue::F64(-lit.base10_parse()?));
                             }
 
                             _ => (),


### PR DESCRIPTION
Where possible, I've tried to preserve the semantics of the existing code. It's possible that I misunderstood some intent -- feel free to tell me what I've borked! :)

Supersedes #219, resolves #218. I created this PR by myself, and then reviewed it against #219 to minimize differences and hopefully improve the implementation. Vivint uses this in its stack, so we're interested in keeping this PR up-to-date!

The only non-mechanical change I think made here I didn't expect was needing to modify the parsing of integer literals in the case of signed types and negative values. Since `syn` no longer provides the parsed values of integer and float literals, we need to provide the minus again ourselves when going to use the existing `FromStr` implementation for the related primitives. 