### PR TITLE
Update to `bytes` 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ os:
   - osx
 
 rust:
-  - 1.32.0
+  - 1.39.0
   - nightly
 
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default = ["prost-derive"]
 no-recursion-limit = []
 
 [dependencies]
-bytes = "0.4.7"
+bytes1 = { version = "0.5.2", package = "bytes" }
 prost-derive = { version = "0.5.0", path = "prost-derive", optional = true }
 
 [dev-dependencies]

--- a/benches/varint.rs
+++ b/benches/varint.rs
@@ -1,8 +1,5 @@
-#![feature(test)]
-
 extern crate test;
 
-use bytes::IntoBuf;
 use prost::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
 macro_rules! varint_bench {
@@ -26,7 +23,6 @@ macro_rules! varint_bench {
             let mut values = [0u64; 100];
 
             b.iter(|| {
-                let mut buf = buf.into_buf();
                 for i in 0..100 {
                     values[i] = decode_varint(&mut buf).unwrap();
                 }
@@ -40,9 +36,8 @@ macro_rules! varint_bench {
             {
                 let mut buf = Vec::with_capacity(100 * 10);
                 $encode(&mut buf);
-                let mut buf = (&buf[..]).into_buf();
                 for i in 0..100 {
-                    values[i] = decode_varint(&mut buf).unwrap();
+                    values[i] = decode_varint(&mut buf[..]).unwrap();
                 }
             }
 

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5.2"
 env_logger = { version = "0.6", default-features = false }
 log = "0.3"
 prost = { path = ".." }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -11,7 +11,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2018"
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5.2"
 heck = "0.3"
 itertools = "0.8"
 log = "0.4"

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -538,7 +538,7 @@ impl Config {
 
         let mut buf = Vec::new();
         fs::File::open(descriptor_set)?.read_to_end(&mut buf)?;
-        let descriptor_set = FileDescriptorSet::decode(&buf)?;
+        let descriptor_set = FileDescriptorSet::decode(&buf[..])?;
 
         let modules = self.generate(descriptor_set.file)?;
         for (module, content) in modules {

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -15,5 +15,5 @@ doctest = false
 test = false
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5.2"
 prost = { version = "0.5.0", path = ".." }

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }
 

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -21,9 +21,6 @@ where
 {
     // Safety notes:
     //
-    // - bytes_mut is unsafe because it may return an uninitialized slice.
-    //   The use here is safe because the slice is only written to, never read from.
-    //
     // - advance_mut is unsafe because it could cause uninitialized memory to be
     //   advanced over. The use here is safe since each byte which is advanced over
     //   has been written to in the previous loop iteration.

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -7,7 +7,7 @@ use std::mem;
 use std::u32;
 use std::usize;
 
-use ::bytes::{Buf, BufMut};
+use bytes1::{buf::ext::BufExt, Buf, BufMut};
 
 use crate::DecodeError;
 use crate::Message;
@@ -31,13 +31,13 @@ where
     'outer: loop {
         i = 0;
 
-        for byte in unsafe { buf.bytes_mut() } {
+        for byte in buf.bytes_mut() {
             i += 1;
             if value < 0x80 {
-                *byte = value as u8;
+                *byte = mem::MaybeUninit::new(value as u8);
                 break 'outer;
             } else {
-                *byte = ((value & 0x7F) | 0x80) as u8;
+                *byte = mem::MaybeUninit::new(((value & 0x7F) | 0x80) as u8);
                 value >>= 7;
             }
         }
@@ -1240,7 +1240,7 @@ mod test {
     use std::io::Cursor;
     use std::u64;
 
-    use ::bytes::{Bytes, BytesMut, IntoBuf};
+    use bytes1::{Bytes, BytesMut};
     use quickcheck::TestResult;
 
     use crate::encoding::*;
@@ -1250,7 +1250,7 @@ mod test {
         tag: u32,
         wire_type: WireType,
         encode: fn(u32, &B, &mut BytesMut),
-        merge: fn(WireType, &mut T, &mut Cursor<Bytes>, DecodeContext) -> Result<(), DecodeError>,
+        merge: fn(WireType, &mut T, &mut Bytes, DecodeContext) -> Result<(), DecodeError>,
         encoded_len: fn(u32, &B) -> usize,
     ) -> TestResult
     where
@@ -1266,7 +1266,7 @@ mod test {
         let mut buf = BytesMut::with_capacity(expected_len);
         encode(tag, value.borrow(), &mut buf);
 
-        let mut buf = buf.freeze().into_buf();
+        let mut buf = buf.freeze();
 
         if buf.remaining() != expected_len {
             return TestResult::error(format!(
@@ -1354,7 +1354,7 @@ mod test {
         T: Debug + Default + PartialEq + Borrow<B>,
         B: ?Sized,
         E: FnOnce(u32, &B, &mut BytesMut),
-        M: FnMut(WireType, &mut T, &mut Cursor<Bytes>, DecodeContext) -> Result<(), DecodeError>,
+        M: FnMut(WireType, &mut T, &mut Bytes, DecodeContext) -> Result<(), DecodeError>,
         L: FnOnce(u32, &B) -> usize,
     {
         if tag > MAX_TAG || tag < MIN_TAG {
@@ -1366,7 +1366,7 @@ mod test {
         let mut buf = BytesMut::with_capacity(expected_len);
         encode(tag, value.borrow(), &mut buf);
 
-        let mut buf = buf.freeze().into_buf();
+        let mut buf = buf.freeze();
 
         if buf.remaining() != expected_len {
             return TestResult::error(format!(
@@ -1430,7 +1430,7 @@ mod test {
 
     #[test]
     fn varint() {
-        fn check(value: u64, encoded: &[u8]) {
+        fn check(value: u64, mut encoded: &[u8]) {
             // Small buffer.
             let mut buf = Vec::with_capacity(1);
             encode_varint(value, &mut buf);
@@ -1443,11 +1443,11 @@ mod test {
 
             assert_eq!(encoded_len_varint(value), encoded.len());
 
-            let roundtrip_value = decode_varint(&mut encoded.into_buf()).expect("decoding failed");
+            let roundtrip_value = decode_varint(&mut encoded.clone()).expect("decoding failed");
             assert_eq!(value, roundtrip_value);
 
-            let roundtrip_value =
-                decode_varint_slow(&mut encoded.into_buf()).expect("slow decoding failed");
+            println!("encoding {:?}", encoded);
+            let roundtrip_value = decode_varint_slow(&mut encoded).expect("slow decoding failed");
             assert_eq!(value, roundtrip_value);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod encoding;
 pub use crate::error::{DecodeError, EncodeError};
 pub use crate::message::Message;
 
-use bytes::{BufMut, IntoBuf};
+use bytes1::{Buf, BufMut};
 
 use crate::encoding::{decode_varint, encode_varint, encoded_len_varint};
 
@@ -58,11 +58,10 @@ pub fn length_delimiter_len(length: usize) -> usize {
 ///    input is required to decode the full delimiter.
 ///  * If the supplied buffer contains more than 10 bytes, then the buffer contains an invalid
 ///    delimiter, and typically the buffer should be considered corrupt.
-pub fn decode_length_delimiter<B>(buf: B) -> Result<usize, DecodeError>
+pub fn decode_length_delimiter<B>(mut buf: B) -> Result<usize, DecodeError>
 where
-    B: IntoBuf,
+    B: Buf,
 {
-    let mut buf = buf.into_buf();
     let length = decode_varint(&mut buf)?;
     if length > usize::max_value() as u64 {
         return Err(DecodeError::new(

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::usize;
 
-use ::bytes::{Buf, BufMut, IntoBuf};
+use bytes1::{Buf, BufMut};
 
 use crate::encoding::*;
 use crate::DecodeError;
@@ -78,19 +78,19 @@ pub trait Message: Debug + Send + Sync {
     /// Decodes an instance of the message from a buffer.
     ///
     /// The entire buffer will be consumed.
-    fn decode<B>(buf: B) -> Result<Self, DecodeError>
+    fn decode<B>(mut buf: B) -> Result<Self, DecodeError>
     where
-        B: IntoBuf,
+        B: Buf,
         Self: Default,
     {
         let mut message = Self::default();
-        Self::merge(&mut message, &mut buf.into_buf()).map(|_| message)
+        Self::merge(&mut message, &mut buf).map(|_| message)
     }
 
     /// Decodes a length-delimited instance of the message from the buffer.
     fn decode_length_delimited<B>(buf: B) -> Result<Self, DecodeError>
     where
-        B: IntoBuf,
+        B: Buf,
         Self: Default,
     {
         let mut message = Self::default();
@@ -101,12 +101,11 @@ pub trait Message: Debug + Send + Sync {
     /// Decodes an instance of the message from a buffer, and merges it into `self`.
     ///
     /// The entire buffer will be consumed.
-    fn merge<B>(&mut self, buf: B) -> Result<(), DecodeError>
+    fn merge<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
     where
-        B: IntoBuf,
+        B: Buf,
         Self: Sized,
     {
-        let mut buf = buf.into_buf();
         let ctx = DecodeContext::default();
         while buf.has_remaining() {
             let (tag, wire_type) = decode_key(&mut buf)?;
@@ -117,15 +116,15 @@ pub trait Message: Debug + Send + Sync {
 
     /// Decodes a length-delimited instance of the message from buffer, and
     /// merges it into `self`.
-    fn merge_length_delimited<B>(&mut self, buf: B) -> Result<(), DecodeError>
+    fn merge_length_delimited<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
     where
-        B: IntoBuf,
+        B: Buf,
         Self: Sized,
     {
         message::merge(
             WireType::LengthDelimited,
             self,
-            &mut buf.into_buf(),
+            &mut buf,
             DecodeContext::default(),
         )
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@
 //! the `prost-types` crate in order to avoid a cyclic dependency between `prost` and
 //! `prost-build`.
 
-use ::bytes::{Buf, BufMut};
+use bytes1::{Buf, BufMut};
 
 use crate::encoding::*;
 use crate::DecodeError;

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -16,7 +16,7 @@ default = ["edition-2015"]
 edition-2015 = []
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5.2"
 cfg-if = "0.1"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,7 +11,7 @@ build = "src/build.rs"
 doctest = false
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.5.2"
 cfg-if = "0.1"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }


### PR DESCRIPTION
This PR updates bytes to `0.5`. This also bumps the MSRV to `1.39` since that is the MSRV of `bytes` 0.5. Mainly, this update is required for https://github.com/hyperium/tonic to update to `tokio` 0.2 and `hyper` 0.13.

Some notes:

-  `bytes` is renamed to `bytes1` in the main crate to allow the use of the the `pub mod bytes` within `src/encoding.rs`.
- Some unsafe code has been removed with the usage of `MaybeUninit`.

All tests pass but I am having some trouble compiling some of the benchmarks and conformance tests but I want to make sure we see no regressions.