### PR TITLE
prost-derive: remove unnecessary dummy consts

### DIFF
--- a/prost-derive/src/field/group.rs
+++ b/prost-derive/src/field/group.rs
@@ -72,15 +72,15 @@ impl Field {
         match self.label {
             Label::Optional => quote! {
                 if let Some(ref msg) = #ident {
-                    _prost::encoding::group::encode(#tag, msg, buf);
+                    ::prost::encoding::group::encode(#tag, msg, buf);
                 }
             },
             Label::Required => quote! {
-                _prost::encoding::group::encode(#tag, &#ident, buf);
+                ::prost::encoding::group::encode(#tag, &#ident, buf);
             },
             Label::Repeated => quote! {
                 for msg in &#ident {
-                    _prost::encoding::group::encode(#tag, msg, buf);
+                    ::prost::encoding::group::encode(#tag, msg, buf);
                 }
             },
         }
@@ -89,16 +89,19 @@ impl Field {
     pub fn merge(&self, ident: TokenStream) -> TokenStream {
         match self.label {
             Label::Optional => quote! {
-                _prost::encoding::group::merge(tag, wire_type,
-                                                 #ident.get_or_insert_with(Default::default),
-                                                 buf,
-                                                 ctx)
+                ::prost::encoding::group::merge(
+                    tag,
+                    wire_type,
+                    #ident.get_or_insert_with(Default::default),
+                    buf,
+                    ctx,
+                )
             },
             Label::Required => quote! {
-                _prost::encoding::group::merge(tag, wire_type, &mut #ident, buf, ctx)
+                ::prost::encoding::group::merge(tag, wire_type, &mut #ident, buf, ctx)
             },
             Label::Repeated => quote! {
-                _prost::encoding::group::merge_repeated(tag, wire_type, &mut #ident, buf, ctx)
+                ::prost::encoding::group::merge_repeated(tag, wire_type, &mut #ident, buf, ctx)
             },
         }
     }
@@ -107,13 +110,13 @@ impl Field {
         let tag = self.tag;
         match self.label {
             Label::Optional => quote! {
-                #ident.as_ref().map_or(0, |msg| _prost::encoding::group::encoded_len(#tag, msg))
+                #ident.as_ref().map_or(0, |msg| ::prost::encoding::group::encoded_len(#tag, msg))
             },
             Label::Required => quote! {
-                _prost::encoding::group::encoded_len(#tag, &#ident)
+                ::prost::encoding::group::encoded_len(#tag, &#ident)
             },
             Label::Repeated => quote! {
-                _prost::encoding::group::encoded_len_repeated(#tag, &#ident)
+                ::prost::encoding::group::encoded_len_repeated(#tag, &#ident)
             },
         }
     }

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -117,36 +117,51 @@ impl Field {
     pub fn encode(&self, ident: TokenStream) -> TokenStream {
         let tag = self.tag;
         let key_mod = self.key_ty.module();
-        let ke = quote!(_prost::encoding::#key_mod::encode);
-        let kl = quote!(_prost::encoding::#key_mod::encoded_len);
+        let ke = quote!(::prost::encoding::#key_mod::encode);
+        let kl = quote!(::prost::encoding::#key_mod::encoded_len);
         let module = self.map_ty.module();
         match self.value_ty {
             ValueTy::Scalar(scalar::Ty::Enumeration(ref ty)) => {
                 let default = quote!(#ty::default() as i32);
                 quote! {
-                    _prost::encoding::#module::encode_with_default(#ke, #kl,
-                                                                   _prost::encoding::int32::encode,
-                                                                   _prost::encoding::int32::encoded_len,
-                                                                   &(#default),
-                                                                   #tag, &#ident, buf);
+                    ::prost::encoding::#module::encode_with_default(
+                        #ke,
+                        #kl,
+                        ::prost::encoding::int32::encode,
+                        ::prost::encoding::int32::encoded_len,
+                        &(#default),
+                        #tag,
+                        &#ident,
+                        buf,
+                    );
                 }
             }
             ValueTy::Scalar(ref value_ty) => {
                 let val_mod = value_ty.module();
-                let ve = quote!(_prost::encoding::#val_mod::encode);
-                let vl = quote!(_prost::encoding::#val_mod::encoded_len);
+                let ve = quote!(::prost::encoding::#val_mod::encode);
+                let vl = quote!(::prost::encoding::#val_mod::encoded_len);
                 quote! {
-                    _prost::encoding::#module::encode(#ke, #kl, #ve, #vl,
-                                                      #tag, &#ident, buf);
+                    ::prost::encoding::#module::encode(
+                        #ke,
+                        #kl,
+                        #ve,
+                        #vl,
+                        #tag,
+                        &#ident,
+                        buf,
+                    );
                 }
             }
-            ValueTy::Message => {
-                quote! {
-                    _prost::encoding::#module::encode(#ke, #kl,
-                                                      _prost::encoding::message::encode,
-                                                      _prost::encoding::message::encoded_len,
-                                                      #tag, &#ident, buf);
-                }
+            ValueTy::Message => quote! {
+                ::prost::encoding::#module::encode(
+                    #ke,
+                    #kl,
+                    ::prost::encoding::message::encode,
+                    ::prost::encoding::message::encoded_len,
+                    #tag,
+                    &#ident,
+                    buf,
+                );
             }
         }
     }
@@ -155,24 +170,35 @@ impl Field {
     /// into the map.
     pub fn merge(&self, ident: TokenStream) -> TokenStream {
         let key_mod = self.key_ty.module();
-        let km = quote!(_prost::encoding::#key_mod::merge);
+        let km = quote!(::prost::encoding::#key_mod::merge);
         let module = self.map_ty.module();
         match self.value_ty {
             ValueTy::Scalar(scalar::Ty::Enumeration(ref ty)) => {
                 let default = quote!(#ty::default() as i32);
                 quote! {
-                    _prost::encoding::#module::merge_with_default(#km, _prost::encoding::int32::merge,
-                                                                  #default, &mut #ident, buf, ctx)
+                    ::prost::encoding::#module::merge_with_default(
+                        #km,
+                        ::prost::encoding::int32::merge,
+                        #default,
+                        &mut #ident,
+                        buf,
+                        ctx,
+                    )
                 }
             }
             ValueTy::Scalar(ref value_ty) => {
                 let val_mod = value_ty.module();
-                let vm = quote!(_prost::encoding::#val_mod::merge);
-                quote!(_prost::encoding::#module::merge(#km, #vm, &mut #ident, buf, ctx))
+                let vm = quote!(::prost::encoding::#val_mod::merge);
+                quote!(::prost::encoding::#module::merge(#km, #vm, &mut #ident, buf, ctx))
             }
-            ValueTy::Message => {
-                quote!(_prost::encoding::#module::merge(#km, _prost::encoding::message::merge,
-                                                        &mut #ident, buf, ctx))
+            ValueTy::Message => quote! {
+                ::prost::encoding::#module::merge(
+                    #km,
+                    ::prost::encoding::message::merge,
+                    &mut #ident,
+                    buf,
+                    ctx,
+                )
             }
         }
     }
@@ -181,25 +207,33 @@ impl Field {
     pub fn encoded_len(&self, ident: TokenStream) -> TokenStream {
         let tag = self.tag;
         let key_mod = self.key_ty.module();
-        let kl = quote!(_prost::encoding::#key_mod::encoded_len);
+        let kl = quote!(::prost::encoding::#key_mod::encoded_len);
         let module = self.map_ty.module();
         match self.value_ty {
             ValueTy::Scalar(scalar::Ty::Enumeration(ref ty)) => {
                 let default = quote!(#ty::default() as i32);
                 quote! {
-                    _prost::encoding::#module::encoded_len_with_default(
-                        #kl, _prost::encoding::int32::encoded_len,
-                        &(#default), #tag, &#ident)
+                    ::prost::encoding::#module::encoded_len_with_default(
+                        #kl,
+                        ::prost::encoding::int32::encoded_len,
+                        &(#default),
+                        #tag,
+                        &#ident,
+                    )
                 }
             }
             ValueTy::Scalar(ref value_ty) => {
                 let val_mod = value_ty.module();
-                let vl = quote!(_prost::encoding::#val_mod::encoded_len);
-                quote!(_prost::encoding::#module::encoded_len(#kl, #vl, #tag, &#ident))
+                let vl = quote!(::prost::encoding::#val_mod::encoded_len);
+                quote!(::prost::encoding::#module::encoded_len(#kl, #vl, #tag, &#ident))
             }
-            ValueTy::Message => {
-                quote!(_prost::encoding::#module::encoded_len(#kl, _prost::encoding::message::encoded_len,
-                                                              #tag, &#ident))
+            ValueTy::Message => quote! {
+                ::prost::encoding::#module::encoded_len(
+                    #kl,
+                    ::prost::encoding::message::encoded_len,
+                    #tag,
+                    &#ident,
+                )
             }
         }
     }

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -75,15 +75,15 @@ impl Field {
         match self.label {
             Label::Optional => quote! {
                 if let Some(ref msg) = #ident {
-                    _prost::encoding::message::encode(#tag, msg, buf);
+                    ::prost::encoding::message::encode(#tag, msg, buf);
                 }
             },
             Label::Required => quote! {
-                _prost::encoding::message::encode(#tag, &#ident, buf);
+                ::prost::encoding::message::encode(#tag, &#ident, buf);
             },
             Label::Repeated => quote! {
                 for msg in &#ident {
-                    _prost::encoding::message::encode(#tag, msg, buf);
+                    ::prost::encoding::message::encode(#tag, msg, buf);
                 }
             },
         }
@@ -92,16 +92,16 @@ impl Field {
     pub fn merge(&self, ident: TokenStream) -> TokenStream {
         match self.label {
             Label::Optional => quote! {
-                _prost::encoding::message::merge(wire_type,
+                ::prost::encoding::message::merge(wire_type,
                                                  #ident.get_or_insert_with(Default::default),
                                                  buf,
                                                  ctx)
             },
             Label::Required => quote! {
-                _prost::encoding::message::merge(wire_type, &mut #ident, buf, ctx)
+                ::prost::encoding::message::merge(wire_type, &mut #ident, buf, ctx)
             },
             Label::Repeated => quote! {
-                _prost::encoding::message::merge_repeated(wire_type, &mut #ident, buf, ctx)
+                ::prost::encoding::message::merge_repeated(wire_type, &mut #ident, buf, ctx)
             },
         }
     }
@@ -110,13 +110,13 @@ impl Field {
         let tag = self.tag;
         match self.label {
             Label::Optional => quote! {
-                #ident.as_ref().map_or(0, |msg| _prost::encoding::message::encoded_len(#tag, msg))
+                #ident.as_ref().map_or(0, |msg| ::prost::encoding::message::encoded_len(#tag, msg))
             },
             Label::Required => quote! {
-                _prost::encoding::message::encoded_len(#tag, &#ident)
+                ::prost::encoding::message::encoded_len(#tag, &#ident)
             },
             Label::Repeated => quote! {
-                _prost::encoding::message::encoded_len_repeated(#tag, &#ident)
+                ::prost::encoding::message::encoded_len_repeated(#tag, &#ident)
             },
         }
     }

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -118,7 +118,7 @@ impl Field {
             Kind::Repeated => quote!(encode_repeated),
             Kind::Packed => quote!(encode_packed),
         };
-        let encode_fn = quote!(_prost::encoding::#module::#encode_fn);
+        let encode_fn = quote!(::prost::encoding::#module::#encode_fn);
         let tag = self.tag;
 
         match self.kind {
@@ -149,7 +149,7 @@ impl Field {
             Kind::Plain(..) | Kind::Optional(..) | Kind::Required(..) => quote!(merge),
             Kind::Repeated | Kind::Packed => quote!(merge_repeated),
         };
-        let merge_fn = quote!(_prost::encoding::#module::#merge_fn);
+        let merge_fn = quote!(::prost::encoding::#module::#merge_fn);
 
         match self.kind {
             Kind::Plain(..) | Kind::Required(..) | Kind::Repeated | Kind::Packed => quote! {
@@ -172,7 +172,7 @@ impl Field {
             Kind::Repeated => quote!(encoded_len_repeated),
             Kind::Packed => quote!(encoded_len_packed),
         };
-        let encoded_len_fn = quote!(_prost::encoding::#module::#encoded_len_fn);
+        let encoded_len_fn = quote!(::prost::encoding::#module::#encoded_len_fn);
         let tag = self.tag;
 
         match self.kind {

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -94,9 +94,6 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         bail!("message {} has fields with duplicate tags", ident);
     }
 
-    // Put impls in a const, so that 'extern crate' can be used.
-    let dummy_const = Ident::new(&format!("{}_MESSAGE", ident), Span::call_site());
-
     let encoded_len = fields
         .iter()
         .map(|&(ref field_ident, ref field)| field.encoded_len(quote!(self.#field_ident)));
@@ -174,60 +171,55 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     };
 
     let expanded = quote! {
-        #[allow(non_snake_case, unused_attributes)]
-        const #dummy_const: () = {
-            extern crate prost as _prost;
-            extern crate bytes as _bytes;
+        impl ::prost::Message for #ident {
+            #[allow(unused_variables)]
+            fn encode_raw<B>(&self, buf: &mut B) where B: ::bytes::BufMut {
+                #(#encode)*
+            }
 
-            impl _prost::Message for #ident {
-                #[allow(unused_variables)]
-                fn encode_raw<B>(&self, buf: &mut B) where B: _bytes::BufMut {
-                    #(#encode)*
-                }
-
-                #[allow(unused_variables)]
-                fn merge_field<B>(&mut self,
-                                  tag: u32,
-                                  wire_type: _prost::encoding::WireType,
-                                  buf: &mut B,
-                                  ctx: _prost::encoding::DecodeContext,
-                ) -> ::std::result::Result<(), _prost::DecodeError>
-                where B: _bytes::Buf {
-                    #struct_name
-                    match tag {
-                        #(#merge)*
-                        _ => _prost::encoding::skip_field(wire_type, tag, buf),
-                    }
-                }
-
-                #[inline]
-                fn encoded_len(&self) -> usize {
-                    0 #(+ #encoded_len)*
-                }
-
-                fn clear(&mut self) {
-                    #(#clear;)*
+            #[allow(unused_variables)]
+            fn merge_field<B>(
+                &mut self,
+                tag: u32,
+                wire_type: ::prost::encoding::WireType,
+                buf: &mut B,
+                ctx: ::prost::encoding::DecodeContext,
+            ) -> ::std::result::Result<(), ::prost::DecodeError>
+            where B: ::bytes::Buf {
+                #struct_name
+                match tag {
+                    #(#merge)*
+                    _ => ::prost::encoding::skip_field(wire_type, tag, buf),
                 }
             }
 
-            impl Default for #ident {
-                fn default() -> #ident {
-                    #ident {
-                        #(#default)*
-                    }
-                }
+            #[inline]
+            fn encoded_len(&self) -> usize {
+                0 #(+ #encoded_len)*
             }
 
-            impl ::std::fmt::Debug for #ident {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                    let mut builder = #debug_builder;
-                    #(#debugs;)*
-                    builder.finish()
+            fn clear(&mut self) {
+                #(#clear;)*
+            }
+        }
+
+        impl Default for #ident {
+            fn default() -> #ident {
+                #ident {
+                    #(#default)*
                 }
             }
+        }
 
-            #methods
-        };
+        impl ::std::fmt::Debug for #ident {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                let mut builder = #debug_builder;
+                #(#debugs;)*
+                builder.finish()
+            }
+        }
+
+        #methods
     };
 
     Ok(expanded.into())
@@ -280,8 +272,6 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
 
     let default = variants[0].0.clone();
 
-    // Put impls in a const, so that 'extern crate' can be used.
-    let dummy_const = Ident::new(&format!("{}_ENUMERATION", ident), Span::call_site());
     let is_valid = variants
         .iter()
         .map(|&(_, ref value)| quote!(#value => true));
@@ -296,39 +286,35 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
     );
 
     let expanded = quote! {
-        #[allow(non_snake_case, unused_attributes)]
-        const #dummy_const: () = {
-            impl #ident {
-
-                #[doc=#is_valid_doc]
-                pub fn is_valid(value: i32) -> bool {
-                    match value {
-                        #(#is_valid,)*
-                        _ => false,
-                    }
-                }
-
-                #[doc=#from_i32_doc]
-                pub fn from_i32(value: i32) -> ::std::option::Option<#ident> {
-                    match value {
-                        #(#from,)*
-                        _ => ::std::option::Option::None,
-                    }
+        impl #ident {
+            #[doc=#is_valid_doc]
+            pub fn is_valid(value: i32) -> bool {
+                match value {
+                    #(#is_valid,)*
+                    _ => false,
                 }
             }
 
-            impl ::std::default::Default for #ident {
-                fn default() -> #ident {
-                    #ident::#default
+            #[doc=#from_i32_doc]
+            pub fn from_i32(value: i32) -> ::std::option::Option<#ident> {
+                match value {
+                    #(#from,)*
+                    _ => ::std::option::Option::None,
                 }
             }
+        }
 
-            impl ::std::convert::From<#ident> for i32 {
-                fn from(value: #ident) -> i32 {
-                    value as i32
-                }
+        impl ::std::default::Default for #ident {
+            fn default() -> #ident {
+                #ident::#default
             }
-        };
+        }
+
+        impl ::std::convert::From<#ident> for i32 {
+            fn from(value: #ident) -> i32 {
+                value as i32
+            }
+        }
     };
 
     Ok(expanded.into())
@@ -398,9 +384,6 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         panic!("invalid oneof {}: variants have duplicate tags", ident);
     }
 
-    // Put impls in a const, so that 'extern crate' can be used.
-    let dummy_const = Ident::new(&format!("{}_ONEOF", ident), Span::call_site());
-
     let encode = fields.iter().map(|&(ref variant_ident, ref field)| {
         let encode = field.encode(quote!(*value));
         quote!(#ident::#variant_ident(ref value) => { #encode })
@@ -433,47 +416,42 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
     });
 
     let expanded = quote! {
-        #[allow(non_snake_case, unused_attributes)]
-        const #dummy_const: () = {
-            extern crate bytes as _bytes;
-            extern crate prost as _prost;
-
-            impl #ident {
-                pub fn encode<B>(&self, buf: &mut B) where B: _bytes::BufMut {
-                    match *self {
-                        #(#encode,)*
-                    }
-                }
-
-                pub fn merge<B>(field: &mut ::std::option::Option<#ident>,
-                                tag: u32,
-                                wire_type: _prost::encoding::WireType,
-                                buf: &mut B,
-                                ctx: _prost::encoding::DecodeContext,
-                ) -> ::std::result::Result<(), _prost::DecodeError>
-                where B: _bytes::Buf {
-                    match tag {
-                        #(#merge,)*
-                        _ => unreachable!(concat!("invalid ", stringify!(#ident), " tag: {}"), tag),
-                    }
-                }
-
-                #[inline]
-                pub fn encoded_len(&self) -> usize {
-                    match *self {
-                        #(#encoded_len,)*
-                    }
+        impl #ident {
+            pub fn encode<B>(&self, buf: &mut B) where B: ::bytes::BufMut {
+                match *self {
+                    #(#encode,)*
                 }
             }
 
-            impl ::std::fmt::Debug for #ident {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                    match *self {
-                        #(#debug,)*
-                    }
+            pub fn merge<B>(
+                field: &mut ::std::option::Option<#ident>,
+                tag: u32,
+                wire_type: ::prost::encoding::WireType,
+                buf: &mut B,
+                ctx: ::prost::encoding::DecodeContext,
+            ) -> ::std::result::Result<(), ::prost::DecodeError>
+            where B: ::bytes::Buf {
+                match tag {
+                    #(#merge,)*
+                    _ => unreachable!(concat!("invalid ", stringify!(#ident), " tag: {}"), tag),
                 }
             }
-        };
+
+            #[inline]
+            pub fn encoded_len(&self) -> usize {
+                match *self {
+                    #(#encoded_len,)*
+                }
+            }
+        }
+
+        impl ::std::fmt::Debug for #ident {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                match *self {
+                    #(#debug,)*
+                }
+            }
+        }
     };
 
     Ok(expanded.into())


### PR DESCRIPTION
They were inhibiting rustdoc from generating code for nested impl
blocks, and are no longer necessary since the new 2018 edition fully
qualified imports.