### PR TITLE
Re-export `bytes` and update derive

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ First, add `prost` and its public dependencies to your `Cargo.toml` (see
 ```
 [dependencies]
 prost = <prost-version>
-bytes = <bytes-version>
 # Only necessary if using Protobuf well-known types:
 prost-types = <prost-version>
 ```

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -173,7 +173,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let expanded = quote! {
         impl ::prost::Message for #ident {
             #[allow(unused_variables)]
-            fn encode_raw<B>(&self, buf: &mut B) where B: ::bytes::BufMut {
+            fn encode_raw<B>(&self, buf: &mut B) where B: ::prost::bytes::BufMut {
                 #(#encode)*
             }
 
@@ -185,7 +185,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                 buf: &mut B,
                 ctx: ::prost::encoding::DecodeContext,
             ) -> ::std::result::Result<(), ::prost::DecodeError>
-            where B: ::bytes::Buf {
+            where B: ::prost::bytes::Buf {
                 #struct_name
                 match tag {
                     #(#merge)*
@@ -417,7 +417,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
 
     let expanded = quote! {
         impl #ident {
-            pub fn encode<B>(&self, buf: &mut B) where B: ::bytes::BufMut {
+            pub fn encode<B>(&self, buf: &mut B) where B: ::prost::bytes::BufMut {
                 match *self {
                     #(#encode,)*
                 }
@@ -430,7 +430,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
                 buf: &mut B,
                 ctx: ::prost::encoding::DecodeContext,
             ) -> ::std::result::Result<(), ::prost::DecodeError>
-            where B: ::bytes::Buf {
+            where B: ::prost::bytes::Buf {
                 match tag {
                     #(#merge,)*
                     _ => unreachable!(concat!("invalid ", stringify!(#ident), " tag: {}"), tag),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,3 +82,5 @@ extern crate prost_derive;
 #[cfg(feature = "prost-derive")]
 #[doc(hidden)]
 pub use prost_derive::*;
+
+pub use bytes;

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -16,7 +16,6 @@ default = ["edition-2015"]
 edition-2015 = []
 
 [dependencies]
-bytes = "0.5"
 cfg-if = "0.1"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,7 +11,6 @@ build = "src/build.rs"
 doctest = false
 
 [dependencies]
-bytes = "0.5"
 cfg-if = "0.1"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -3,7 +3,6 @@ extern crate cfg_if;
 
 cfg_if! {
     if #[cfg(feature = "edition-2015")] {
-        extern crate bytes;
         extern crate prost;
         extern crate prost_types;
         extern crate protobuf;
@@ -76,7 +75,7 @@ pub mod groups {
 
 use std::error::Error;
 
-use bytes::Buf;
+use prost::bytes::Buf;
 
 use prost::Message;
 


### PR DESCRIPTION
This change removes the need to include `bytes` in your `Cargo.toml` when using the `prost-derive` macros.

Here is a preview of the docs.

![image](https://user-images.githubusercontent.com/5758045/71100132-72942d00-2182-11ea-9c10-fe6779bc2173.png)

Fixes #127 

cc @danburkert 