### PR TITLE
Move from `failure` to `anyhow` in `prost-derive`

### DIFF
--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 proc_macro = true
 
 [dependencies]
-failure = { version = "0.1", default-features = false, features = ["std"] }
+anyhow = "1"
 itertools = "0.8"
 proc-macro2 = "1"
 quote = "1"

--- a/prost-derive/src/field/group.rs
+++ b/prost-derive/src/field/group.rs
@@ -1,4 +1,4 @@
-use failure::{bail, Error};
+use anyhow::{bail, Error};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::Meta;

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -1,4 +1,4 @@
-use failure::{bail, Error};
+use anyhow::{bail, Error};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{Ident, Lit, Meta, MetaNameValue, NestedMeta};

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -1,4 +1,4 @@
-use failure::{bail, Error};
+use anyhow::{bail, Error};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::Meta;

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -7,7 +7,7 @@ mod scalar;
 use std::fmt;
 use std::slice;
 
-use failure::{bail, Error};
+use anyhow::{bail, Error};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, Ident, Lit, LitBool, Meta, MetaList, MetaNameValue, NestedMeta};

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -1,4 +1,4 @@
-use failure::{bail, Error};
+use anyhow::{bail, Error};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse_str, Lit, Meta, MetaNameValue, NestedMeta, Path};

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::fmt;
 
-use failure::{bail, format_err, Error};
+use anyhow::{anyhow, bail, Error};
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
@@ -437,7 +437,7 @@ impl Ty {
 
     pub fn from_str(s: &str) -> Result<Ty, Error> {
         let enumeration_len = "enumeration".len();
-        let error = Err(format_err!("invalid type: {}", s));
+        let error = Err(anyhow!("invalid type: {}", s));
         let ty = match s.trim() {
             "float" => Ty::Float,
             "double" => Ty::Double,

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -4,10 +4,10 @@
 
 extern crate proc_macro;
 
-use failure::bail;
+use anyhow::bail;
 use quote::quote;
 
-use failure::Error;
+use anyhow::Error;
 use itertools::Itertools;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
@@ -71,7 +71,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                 )),
             }
         })
-        .collect::<Result<Vec<(Ident, Field)>, failure::Context<String>>>()?;
+        .collect::<Result<Vec<_>, _>>()?;
 
     // We want Debug to be in declaration order
     let unsorted_fields = fields.clone();


### PR DESCRIPTION
This PR removes the `failure` dependency in `prost-derive` and replaces it with `anyhow`.  
The change is trivial, it is pretty much just a namespace change (eg. `s/failure::/anyhow::/g`).

**Closes #258.**
