### PR TITLE
Add support for `deprecated` attributes on fields.

### DIFF
--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -333,6 +333,7 @@ pub struct FileOptions {
     #[prost(bool, optional, tag="10", default="false")]
     pub java_multiple_files: ::std::option::Option<bool>,
     /// This option does nothing.
+    #[deprecated]
     #[prost(bool, optional, tag="20")]
     pub java_generate_equals_and_hash: ::std::option::Option<bool>,
     /// If set true, then the Java2 code generator will generate code that

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -78,6 +78,10 @@ fn main() {
         .unwrap();
 
     config
+        .compile_protos(&[src.join("deprecated_field.proto")], includes)
+        .unwrap();
+
+    config
         .compile_protos(&[src.join("well_known_types.proto")], includes)
         .unwrap();
 

--- a/tests/src/deprecated_field.proto
+++ b/tests/src/deprecated_field.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package deprecated_field;
+
+message Test {
+  string not_outdated = 1;
+  string outdated = 2 [deprecated = true];
+}

--- a/tests/src/deprecated_field.rs
+++ b/tests/src/deprecated_field.rs
@@ -1,0 +1,28 @@
+mod deprecated_field {
+    // #![deny(unused_results)]
+    include!(concat!(env!("OUT_DIR"), "/deprecated_field.rs"));
+}
+
+#[test]
+fn test_warns_when_using_fields_with_deprecated_field() {
+    #[allow(deprecated)]
+    deprecated_field::Test {
+        not_outdated: ".ogg".to_string(),
+        outdated: ".wav".to_string(),
+    };
+    // This test relies on the `#[allow(deprecated)]` attribute to ignore the warning that should
+    // be raised by the compiler.
+    // This test has a shortcoming since it doesn't explicitly check for the presence of the
+    // `deprecated` attribute since it doesn't exist at runtime. If complied without the `allow`
+    // attribute the following warning would be raised:
+    //
+    //    warning: use of deprecated item 'deprecated_field::deprecated_field::Test::outdated'
+    //      --> tests/src/deprecated_field.rs:11:9
+    //       |
+    //    11 |         outdated: ".wav".to_string(),
+    //       |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    //       |
+    //       = note: `#[warn(deprecated)]` on by default
+
+    assert!(true);
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -23,6 +23,8 @@ mod bootstrap;
 #[cfg(test)]
 mod debug;
 #[cfg(test)]
+mod deprecated_field;
+#[cfg(test)]
 mod message_encoding;
 #[cfg(test)]
 mod no_unused_results;


### PR DESCRIPTION
Protobufs support `deprecated` field options. These field options allow
the field to continue to be supported, but allow for language specific
code generators to include that the field has been deprecated in the
generated code. As discussed in https://github.com/danburkert/prost/issues/221 we should considersupporting this in `prost`.

This commit adds support for this feature in `prost-build` by checking
the field options, and if present emitting a `#[deprecated]` attribute.

One short coming of this change is that it is difficult to test that the
`deprecated` attribute is correctly added with an assertion since the
attribute is not accessible at runtime.