### PR TITLE
prost-build: Support generating single include file

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -114,7 +114,7 @@ use std::collections::HashMap;
 use std::default;
 use std::env;
 use std::fs;
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, ErrorKind, Result, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -187,6 +187,7 @@ pub struct Config {
     strip_enum_prefix: bool,
     out_dir: Option<PathBuf>,
     extern_paths: Vec<(String, String)>,
+    include_file: Option<PathBuf>,
 }
 
 impl Config {
@@ -482,6 +483,36 @@ impl Config {
         self
     }
 
+    /// Configures the optional module filename for easy inclusion of all generated Rust files
+    ///
+    /// If set, generates a file (inside the `OUT_DIR` or `out_dir()` as appropriate) which contains
+    /// a set of `pub mod XXX` statements combining to load all Rust files generated.  This can allow
+    /// for a shortcut where multiple related proto files have been compiled together resulting in
+    /// a semi-complex set of includes.
+    ///
+    /// Turning a need for:
+    ///
+    /// ```rust,no_run,ignore
+    /// pub mod Foo {
+    ///     pub mod Bar {
+    ///         include!(concat!(env!("OUT_DIR"), "/foo.bar.rs"));
+    ///     }
+    ///     pub mod Baz {
+    ///         include!(concat!(env!("OUT_DIR"), "/foo.baz.rs"));
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Into the simpler:
+    ///
+    /// ```rust,no_run,ignore
+    /// include!(concat!(env!("OUT_DIR"), "/_includes.rs"));
+    /// ```
+    pub fn include_file<P>(&mut self, path: P) -> &mut Self where P: Into<PathBuf> {
+        self.include_file = Some(path.into());
+        self
+    }
+
     /// Compile `.proto` files into Rust files during a Cargo build with additional code generator
     /// configuration options.
     ///
@@ -503,12 +534,12 @@ impl Config {
     where
         P: AsRef<Path>,
     {
+        let mut target_is_env = false;
         let target: PathBuf = self.out_dir.clone().map(Ok).unwrap_or_else(|| {
             env::var_os("OUT_DIR")
-                .ok_or_else(|| {
-                    Error::new(ErrorKind::Other, "OUT_DIR environment variable is not set")
-                })
-                .map(Into::into)
+                .ok_or_else(|| Error::new(ErrorKind::Other,
+                                          "OUT_DIR environment variable is not set"))
+                .map(|val| { target_is_env = true; Into::into(val) })
         })?;
 
         // TODO: This should probably emit 'rerun-if-changed=PATH' directives for cargo, however
@@ -550,7 +581,7 @@ impl Config {
         let descriptor_set = FileDescriptorSet::decode(&*buf)?;
 
         let modules = self.generate(descriptor_set.file)?;
-        for (module, content) in modules {
+        for (module, content) in &modules {
             let mut filename = module.join(".");
             filename.push_str(".rs");
 
@@ -569,7 +600,47 @@ impl Config {
             }
         }
 
+        if let Some(ref include_file) = self.include_file {
+            trace!("Writing include file: {:?}", target.join(include_file));
+            let mut file = fs::File::create(target.join(include_file))?;
+            self.write_includes(modules.keys().collect(), &mut file, 0, if target_is_env { None } else { Some(&target) })?;
+            file.flush()?;
+        }
+
         Ok(())
+    }
+
+    fn write_includes(&self, mut entries: Vec<&Module>, outfile: &mut fs::File, depth: usize, basepath: Option<&PathBuf>) -> Result<usize> {
+        let mut written = 0;
+        while entries.len() > 0 {
+            let modident = &entries[0][depth];
+            let matching: Vec<&Module> = entries.iter().filter(|&v| &v[depth] == modident).map(|v| *v).collect();
+            {
+                // Will NLL sort this mess out?
+                let _temp = entries.drain(..).filter(|&v| &v[depth] != modident).collect();
+                entries = _temp;
+            }
+            self.write_line(outfile, depth, &format!("pub mod {} {{", modident))?;
+            let subwritten = self.write_includes(matching.iter().filter(|v| v.len() > depth + 1).map(|v| *v).collect(),
+                                                 outfile, depth + 1, basepath)?;
+            written += subwritten;
+            if subwritten != matching.len() {
+                let modname = matching[0][..=depth].join(".");
+                if let Some(buf) = basepath {
+                    self.write_line(outfile, depth + 1, &format!("include!(\"{:?}/{}.rs\");", buf, modname))?;
+                } else {
+                    self.write_line(outfile, depth + 1, &format!("include!(concat!(env!(\"OUT_DIR\"), \"/{}.rs\"));", modname))?;
+                }
+                written += 1;
+            }
+
+            self.write_line(outfile, depth, "}")?;
+        }
+        Ok(written)
+    }
+
+    fn write_line(&self, outfile: &mut fs::File, depth: usize, line: &str) -> Result<()> {
+        outfile.write_all(format!("{}{}\n", ("    ").to_owned().repeat(depth), line).as_bytes())
     }
 
     fn generate(&mut self, files: Vec<FileDescriptorProto>) -> Result<HashMap<Module, String>> {
@@ -623,6 +694,7 @@ impl default::Default for Config {
             strip_enum_prefix: true,
             out_dir: None,
             extern_paths: Vec::new(),
+            include_file: None,
         }
     }
 }
@@ -772,8 +844,9 @@ mod tests {
         let gen = MockServiceGenerator::new(Rc::clone(&state));
 
         Config::new()
-            .service_generator(Box::new(gen))
-            .compile_protos(&["src/hello.proto", "src/goodbye.proto"], &["src"])
+            .service_generator(Box::new(ServiceTraitGenerator))
+            .include_file("_protos.rs")
+            .compile_protos(&["src/smoke_test.proto"], &["src"])
             .unwrap();
 
         let state = state.borrow();

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -844,9 +844,9 @@ mod tests {
         let gen = MockServiceGenerator::new(Rc::clone(&state));
 
         Config::new()
-            .service_generator(Box::new(ServiceTraitGenerator))
+            .service_generator(Box::new(gen))
             .include_file("_protos.rs")
-            .compile_protos(&["src/smoke_test.proto"], &["src"])
+            .compile_protos(&["src/hello.proto", "src/goodbye.proto"], &["src"])
             .unwrap();
 
         let state = state.borrow();


### PR DESCRIPTION
In order to support use-cases where many protocol buffer
packages are parsed and generated, support the configuration
containing an optional `include_file()` which allows the build
script to name a file to be created to automatically `include!()`
all the generated content with the right module structure.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>