### PR TITLE
fix Timestamp <-> SystemTime conversions

### DIFF
--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [lib]
 doctest = false
-test = false
 
 [features]
 default = ["std"]
@@ -20,3 +19,6 @@ std = ["prost/std"]
 [dependencies]
 bytes = { version = "0.5", default-features = false }
 prost = { version = "0.6.1", path = "..", default-features = false, features = ["prost-derive"] }
+
+[dev-dependencies]
+proptest = "0.9"

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -32,7 +32,7 @@ impl Duration {
     ///
     /// Based on [`google::protobuf::util::CreateNormalized`][1].
     /// [1]: https://github.com/google/protobuf/blob/v3.3.2/src/google/protobuf/util/time_util.cc#L79-L100
-    fn normalize(&mut self) {
+    pub fn normalize(&mut self) {
         // Make sure nanos is in the range.
         if self.nanos <= -NANOS_PER_SECOND || self.nanos >= NANOS_PER_SECOND {
             self.seconds += (self.nanos / NANOS_PER_SECOND) as i64;
@@ -101,7 +101,7 @@ impl Timestamp {
     /// Based on [`google::protobuf::util::CreateNormalized`][1].
     /// [1]: https://github.com/google/protobuf/blob/v3.3.2/src/google/protobuf/util/time_util.cc#L59-L77
     #[cfg(feature = "std")]
-    fn normalize(&mut self) {
+    pub fn normalize(&mut self) {
         // Make sure nanos is in the range.
         if self.nanos <= -NANOS_PER_SECOND || self.nanos >= NANOS_PER_SECOND {
             self.seconds += (self.nanos / NANOS_PER_SECOND) as i64;
@@ -120,39 +120,58 @@ impl Timestamp {
     }
 }
 
-/// Converts a `std::time::SystemTime` to a `Timestamp`.
 #[cfg(feature = "std")]
 impl From<std::time::SystemTime> for Timestamp {
-    fn from(time: std::time::SystemTime) -> Timestamp {
-        let duration = Duration::from(time.duration_since(std::time::UNIX_EPOCH).unwrap());
-        Timestamp {
-            seconds: duration.seconds,
-            nanos: duration.nanos,
-        }
+    fn from(system_time: std::time::SystemTime) -> Timestamp {
+        let (seconds, nanos) = match system_time.duration_since(std::time::UNIX_EPOCH) {
+            Ok(duration) => {
+                let seconds = i64::try_from(duration.as_secs()).unwrap();
+                (seconds, duration.subsec_nanos() as i32)
+            }
+            Err(error) => {
+                let duration = error.duration();
+                let seconds = i64::try_from(duration.as_secs()).unwrap();
+                let nanos = duration.subsec_nanos() as i32;
+                if nanos == 0 {
+                    (-seconds, 0)
+                } else {
+                    (-seconds - 1, 1_000_000_000 - nanos)
+                }
+            }
+        };
+        Timestamp { seconds, nanos }
     }
 }
 
 #[cfg(feature = "std")]
-impl TryFrom<Timestamp> for std::time::SystemTime {
-    type Error = time::Duration;
-
-    /// Converts a `Timestamp` to a `SystemTime`, or if the timestamp falls before the Unix epoch,
-    /// a duration containing the difference.
-    fn try_from(mut timestamp: Timestamp) -> Result<std::time::SystemTime, time::Duration> {
+impl From<Timestamp> for std::time::SystemTime {
+    fn from(mut timestamp: Timestamp) -> std::time::SystemTime {
         timestamp.normalize();
-        if timestamp.seconds >= 0 {
-            Ok(std::time::UNIX_EPOCH
-                + time::Duration::new(timestamp.seconds as u64, timestamp.nanos as u32))
+        let system_time = if timestamp.seconds >= 0 {
+            std::time::UNIX_EPOCH + time::Duration::from_secs(timestamp.seconds as u64)
         } else {
-            let mut duration = Duration {
-                seconds: -timestamp.seconds,
-                nanos: timestamp.nanos,
-            };
-            duration.normalize();
-            Err(time::Duration::new(
-                duration.seconds as u64,
-                duration.nanos as u32,
-            ))
+            std::time::UNIX_EPOCH - time::Duration::from_secs((-timestamp.seconds) as u64)
+        };
+
+        system_time + time::Duration::from_nanos(timestamp.nanos as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use proptest::prelude::*;
+
+    use super::*;
+
+    #[cfg(feature = "std")]
+    proptest! {
+        #[test]
+        fn check_system_time_roundtrip(
+            system_time in SystemTime::arbitrary(),
+        ) {
+            prop_assert_eq!(SystemTime::from(Timestamp::from(system_time)), system_time);
         }
     }
 }


### PR DESCRIPTION
I must have been under the impression that SystemTime couldn't handle
datetimes before the Unix epoch back when I wrote the conversion code in
2017. That is wrong, and so was the code.

BREAKING CHANGE: this is a breaking change to prost-types, because the
Timestamp TryFrom<SystemTime> impl is now the default impl, with a
different error type.