### PR TITLE
Add feature to prost-build to allow runtime specification of protoc

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -9,6 +9,11 @@ readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2018"
 
+[features]
+# Modify prost-build to be built and run as an executable outside of the normal
+# build.rs environment.  Requires explicitly setting the protoc path at runtime.
+runtime-protoc = []
+
 [dependencies]
 bytes = { version = "0.5", default-features = false }
 heck = "0.3"


### PR DESCRIPTION
Opening this as a way of opening the discussion about an issue that I
was running into.  If you would prefer a different approach, I'm happy
to discuss that.

Within multi-language environments, such as bazel, cargo isn't always
able to drive the build process.  However, prost and prost-build
provides an amazing foundation of which to build off.  The general idea
of this commit was to open up prost-build to having tools built off of
it, while still preserving previous behavior.

Currently, if PROTOC or PROTO_INCLUDE are not set at build-time, then
the build fails.  This commit introduces feature, runtime-protoc. This
hides env! invocations when enabled, allowing compilation, under the
assumption that the protoc location will be provided at runtime.  This
wouldn't be my first preference, but I was prioritizing the build-break
if the environment flags were not specified.  I would generally have
preferred grabbing those with option_env! macros and then trying to
gracefully handle the error at runtime protoc has not been provided at
build time or runtime similar, since this is already covered by tests.
That would allow removal of the feature flag.  It would also make the
code a little cleaner, since there's not a great way to do conditionals
with cfg (see rust-lang/rust#71679).