### PR TITLE
Add `file_descriptor` option to `prost-build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Compared to other Protocol Buffers implementations, `prost`
 * Respects the Protobuf `package` specifier when organizing generated code
   into Rust modules.
 * Preserves unknown enum values during deserialization.
-* Does not include support for runtime reflection or message descriptors.
+* Includes support for including message descriptors in generated code in order
+  that runtime reflection can be implemented by consumers.
 
 ## Using `prost` in a Cargo Project
 
@@ -58,6 +59,10 @@ package foo.bar;
 ```
 
 All Rust types generated from the file will be in the `foo::bar` module.
+
+If the `file_descriptor` option is set on the `prost_build::Config` used to
+generate the Rust module, an encoded constant byte slice containing the
+corresponding `FileDescriptorProto` will be included.
 
 ### Messages
 

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -181,6 +181,7 @@ pub trait ServiceGenerator {
 ///
 /// This configuration builder can be used to set non-default code generation options.
 pub struct Config {
+    include_file_descriptor: bool,
     service_generator: Option<Box<dyn ServiceGenerator>>,
     btree_map: Vec<String>,
     type_attributes: Vec<(String, String)>,
@@ -251,6 +252,14 @@ impl Config {
         S: AsRef<str>,
     {
         self.btree_map = paths.into_iter().map(|s| s.as_ref().to_string()).collect();
+        self
+    }
+
+    /// Include a constant byte array containing the encoded `FileDescriptorProto` named
+    /// `FILE_DESCRIPTOR` in each generated module file. This can be used in conjunction with
+    /// the types in the `prost-types` crate to help implement server reflection.
+    pub fn include_file_descriptor(&mut self) -> &mut Self {
+        self.include_file_descriptor = true;
         self
     }
 
@@ -618,6 +627,7 @@ impl Config {
 impl default::Default for Config {
     fn default() -> Config {
         Config {
+            include_file_descriptor: false,
             service_generator: None,
             btree_map: Vec::new(),
             type_attributes: Vec::new(),

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -582,20 +582,20 @@ varint!(i64, int64);
 varint!(u32, uint32);
 varint!(u64, uint64);
 varint!(i32, sint32,
-        to_uint64(value) {
-            ((value << 1) ^ (value >> 31)) as u32 as u64
-        },
-        from_uint64(value) {
-            let value = value as u32;
-            ((value >> 1) as i32) ^ (-((value & 1) as i32))
-        });
+to_uint64(value) {
+    ((value << 1) ^ (value >> 31)) as u32 as u64
+},
+from_uint64(value) {
+    let value = value as u32;
+    ((value >> 1) as i32) ^ (-((value & 1) as i32))
+});
 varint!(i64, sint64,
-        to_uint64(value) {
-            ((value << 1) ^ (value >> 63)) as u64
-        },
-        from_uint64(value) {
-            ((value >> 1) as i64) ^ (-((value & 1) as i64))
-        });
+to_uint64(value) {
+    ((value << 1) ^ (value >> 63)) as u64
+},
+from_uint64(value) {
+    ((value >> 1) as i64) ^ (-((value & 1) as i64))
+});
 
 /// Macro which emits a module containing a set of encoding functions for a
 /// fixed width numeric type.
@@ -1626,34 +1626,34 @@ mod test {
     }
 
     map_tests!(keys: [
-                   (i32, int32),
-                   (i64, int64),
-                   (u32, uint32),
-                   (u64, uint64),
-                   (i32, sint32),
-                   (i64, sint64),
-                   (u32, fixed32),
-                   (u64, fixed64),
-                   (i32, sfixed32),
-                   (i64, sfixed64),
-                   (bool, bool),
-                   (String, string)
-               ],
-               vals: [
-                   (f32, float),
-                   (f64, double),
-                   (i32, int32),
-                   (i64, int64),
-                   (u32, uint32),
-                   (u64, uint64),
-                   (i32, sint32),
-                   (i64, sint64),
-                   (u32, fixed32),
-                   (u64, fixed64),
-                   (i32, sfixed32),
-                   (i64, sfixed64),
-                   (bool, bool),
-                   (String, string),
-                   (Vec<u8>, bytes)
-               ]);
+        (i32, int32),
+        (i64, int64),
+        (u32, uint32),
+        (u64, uint64),
+        (i32, sint32),
+        (i64, sint64),
+        (u32, fixed32),
+        (u64, fixed64),
+        (i32, sfixed32),
+        (i64, sfixed64),
+        (bool, bool),
+        (String, string)
+    ],
+    vals: [
+        (f32, float),
+        (f64, double),
+        (i32, int32),
+        (i64, int64),
+        (u32, uint32),
+        (u64, uint64),
+        (i32, sint32),
+        (i64, sint64),
+        (u32, fixed32),
+        (u64, fixed64),
+        (i32, sfixed32),
+        (i64, sfixed64),
+        (bool, bool),
+        (String, string),
+        (Vec<u8>, bytes)
+    ]);
 }


### PR DESCRIPTION
This pull request adds support for including an encoded version of the appropriate `FileDescriptorProto` in each generated Rust module in the form of a `&'static [u8]` named `FILE_DESCRIPTOR`. This is disabled by default, and is enabled by setting `file_descriptor(true)` in a `Config` builder.

The rationale for this pull request is to support the [gRPC Server Reflection Protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md), which operates in terms of `FileDescriptorProto`, in [Tonic](https://github.com/hyperium/tonic/issues/165).