### PR TITLE
Add protoc plugin handling to the prost-build Config and basic plugin

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -25,3 +25,9 @@ which = { version = "3", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }
+
+[[bin]]
+name = "protoc-gen-rust"
+path = "src/bin/protoc-gen-rust.rs"
+test = false
+bench = false

--- a/prost-build/src/bin/protoc-gen-rust.rs
+++ b/prost-build/src/bin/protoc-gen-rust.rs
@@ -1,0 +1,32 @@
+extern crate prost;
+extern crate prost_types;
+
+use crate::prost::Message;
+use prost_types::compiler::{CodeGeneratorRequest, CodeGeneratorResponse};
+use std::io::{Error, ErrorKind, Result};
+use std::io::{Read, Write};
+
+fn main() -> Result<()> {
+    let mut buf = Vec::new();
+    std::io::stdin().read_to_end(&mut buf)?;
+
+    let request = CodeGeneratorRequest::decode(&*buf).map_err(|error| {
+        Error::new(
+            ErrorKind::InvalidInput,
+            format!("invalid FileDescriptorSet: {}", error.to_string()),
+        )
+    })?;
+
+    let response: CodeGeneratorResponse = prost_build::Config::new().run_plugin(request);
+
+    let mut out = Vec::new();
+    response.encode(&mut out).map_err(|error| {
+        Error::new(
+            ErrorKind::InvalidInput,
+            format!("invalid FileDescriptorSet: {}", error.to_string()),
+        )
+    })?;
+    std::io::stdout().write_all(&out)?;
+
+    Ok(())
+}


### PR DESCRIPTION
This refactors some of the private logic within prost-build's lib.rs so
that it is compatible with generating the logic necessary to run a
plugin for protoc or a build.rs file.  In both cases, the output can be
changed based on how the Config is built.  This adds the capability for
paramters passed in via protoc to a plugin to allow adjust this
configuration, but the mechanics of that are left as a TODO until the
design is solidified.

This based on #312 to take care of rustfmt issues and #313 for some CI issues.