### PR TITLE
Add `no_std` support to `prost`, `prost-types` & make codegen `no_std` compatible

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -12,7 +12,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
             toolchain: stable
-            override: true
+            default: true
+            profile: minimal
             components: rustfmt
       - name: rustfmt
         uses: actions-rs/cargo@v1
@@ -28,7 +29,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
             toolchain: stable
-            override: true
+            default: true
+            profile: minimal
             components: clippy
       - name: install ninja
         uses: seanmiddleditch/gha-setup-ninja@v1
@@ -45,7 +47,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-targets
+          args: --workspace --all-features --all-targets
 
   test:
     runs-on: ${{ matrix.os }}
@@ -65,8 +67,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
             toolchain: ${{ matrix.toolchain }}
-            override: true
-            components: rustfmt
+            default: true
+            profile: minimal
       - name: install ninja
         uses: seanmiddleditch/gha-setup-ninja@v1
       - name: cache target directory
@@ -82,3 +84,35 @@ jobs:
         with:
           command: test
           args: --workspace --all-targets
+      - name: test no-default-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
+
+  no-std:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            default: true
+            profile: minimal
+      - name: install cargo-no-std-check
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-no-std-check
+      - name: prost cargo-no-std-check
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-std-check
+          args: --manifest-path Cargo.toml --no-default-features
+      - name: prost-types cargo-no-std-check
+        uses: actions-rs/cargo@v1
+        with:
+          command: no-std-check
+          args: --manifest-path prost-types/Cargo.toml --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "protobuf",
   "tests",
   "tests-2015",
+  "tests-no-std",
 ]
 exclude = [
   # The fuzz crate can't be compiled or tested without the 'cargo fuzz' command,
@@ -36,11 +37,12 @@ exclude = [
 bench = false
 
 [features]
-default = ["prost-derive"]
+default = ["prost-derive", "std"]
 no-recursion-limit = []
+std = []
 
 [dependencies]
-bytes = "0.5"
+bytes = { version = "0.5", default-features = false }
 prost-derive = { version = "0.6.1", path = "prost-derive", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -251,6 +251,29 @@ pub struct AddressBook {
 }
 ```
 
+## Using `prost` in a `no_std` Crate
+
+`prost` is compatible with `no_std` crates. To enable `no_std` support, disable
+the `std` features in `prost` and `prost-types`:
+
+```
+[dependencies]
+prost = { version = "0.6", default-features = false, features = ["prost-derive"] }
+# Only necessary if using Protobuf well-known types:
+prost-types = { version = "0.6", default-features = false }
+```
+
+Additionally, configure `prost-buid` to output `BTreeMap`s instead of `HashMap`s
+for all Protobuf `map` fields in your `build.rs`:
+
+```rust
+let mut config = prost_build::Config::new();
+config.btree_map(&["."]);
+```
+
+When using edition 2015, it may be necessary to add an `extern crate core;`
+directive to the crate which includes `prost`-generated code.
+
 ## Serializing Existing Types
 
 `prost` uses a custom derive macro to handle encoding and decoding types, which

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -10,14 +10,14 @@ description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2018"
 
 [dependencies]
-bytes = "0.5"
+bytes = { version = "0.5", default-features = false }
 heck = "0.3"
 itertools = "0.8"
 log = "0.4"
 multimap = { version = "0.8", default-features = false }
 petgraph = { version = "0.5", default-features = false }
-prost = { version = "0.6.1", path = ".." }
-prost-types = { version = "0.6.1", path = "../prost-types" }
+prost = { version = "0.6.1", path = "..", default-features = false }
+prost-types = { version = "0.6.1", path = "../prost-types", default-features = false }
 tempfile = "3"
 
 [build-dependencies]

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -369,12 +369,12 @@ impl<'a> CodeGenerator<'a> {
         self.buf.push_str(&to_snake(field.name()));
         self.buf.push_str(": ");
         if repeated {
-            self.buf.push_str("::std::vec::Vec<");
+            self.buf.push_str("::prost::alloc::vec::Vec<");
         } else if optional {
-            self.buf.push_str("::std::option::Option<");
+            self.buf.push_str("::core::option::Option<");
         }
         if boxed {
-            self.buf.push_str("::std::boxed::Box<");
+            self.buf.push_str("::prost::alloc::boxed::Box<");
         }
         self.buf.push_str(&ty);
         if boxed {
@@ -411,10 +411,10 @@ impl<'a> CodeGenerator<'a> {
             .btree_map
             .iter()
             .any(|matcher| match_ident(matcher, msg_name, Some(field.name())));
-        let (annotation_ty, rust_ty) = if btree_map {
-            ("btree_map", "BTreeMap")
+        let (annotation_ty, lib_name, rust_ty) = if btree_map {
+            ("btree_map", "::prost::alloc::collections", "BTreeMap")
         } else {
-            ("map", "HashMap")
+            ("map", "::std::collections", "HashMap")
         };
 
         let key_tag = self.field_type_tag(key);
@@ -429,8 +429,9 @@ impl<'a> CodeGenerator<'a> {
         self.append_field_attributes(msg_name, field.name());
         self.push_indent();
         self.buf.push_str(&format!(
-            "pub {}: ::std::collections::{}<{}, {}>,\n",
+            "pub {}: {}::{}<{}, {}>,\n",
             to_snake(field.name()),
+            lib_name,
             rust_ty,
             key_ty,
             value_ty
@@ -462,7 +463,7 @@ impl<'a> CodeGenerator<'a> {
         self.append_field_attributes(fq_message_name, oneof.name());
         self.push_indent();
         self.buf.push_str(&format!(
-            "pub {}: ::std::option::Option<{}>,\n",
+            "pub {}: ::core::option::Option<{}>,\n",
             to_snake(oneof.name()),
             name
         ));
@@ -523,8 +524,11 @@ impl<'a> CodeGenerator<'a> {
             );
 
             if boxed {
-                self.buf
-                    .push_str(&format!("{}(Box<{}>),\n", to_upper_camel(field.name()), ty));
+                self.buf.push_str(&format!(
+                    "{}(::prost::alloc::boxed::Box<{}>),\n",
+                    to_upper_camel(field.name()),
+                    ty
+                ));
             } else {
                 self.buf
                     .push_str(&format!("{}({}),\n", to_upper_camel(field.name()), ty));
@@ -714,8 +718,8 @@ impl<'a> CodeGenerator<'a> {
             Type::Int32 | Type::Sfixed32 | Type::Sint32 | Type::Enum => String::from("i32"),
             Type::Int64 | Type::Sfixed64 | Type::Sint64 => String::from("i64"),
             Type::Bool => String::from("bool"),
-            Type::String => String::from("std::string::String"),
-            Type::Bytes => String::from("std::vec::Vec<u8>"),
+            Type::String => String::from("::prost::alloc::string::String"),
+            Type::Bytes => String::from("::prost::alloc::vec::Vec<u8>"),
             Type::Group | Type::Message => self.resolve_ident(field.type_name()),
         }
     }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -225,7 +225,7 @@ impl Config {
     /// // Match all map fields in a package.
     /// config.btree_map(&[".my_messages"]);
     ///
-    /// // Match all map fields.
+    /// // Match all map fields. Expecially useful in `no_std` contexts.
     /// config.btree_map(&["."]);
     ///
     /// // Match all map fields in a nested message.

--- a/prost-derive/src/field/group.rs
+++ b/prost-derive/src/field/group.rs
@@ -126,7 +126,7 @@ impl Field {
 
     pub fn clear(&self, ident: TokenStream) -> TokenStream {
         match self.label {
-            Label::Optional => quote!(#ident = ::std::option::Option::None),
+            Label::Optional => quote!(#ident = ::core::option::Option::None),
             Label::Required => quote!(#ident.clear()),
             Label::Repeated => quote!(#ident.clear()),
         }

--- a/prost-derive/src/field/message.rs
+++ b/prost-derive/src/field/message.rs
@@ -126,7 +126,7 @@ impl Field {
 
     pub fn clear(&self, ident: TokenStream) -> TokenStream {
         match self.label {
-            Label::Optional => quote!(#ident = ::std::option::Option::None),
+            Label::Optional => quote!(#ident = ::core::option::Option::None),
             Label::Required => quote!(#ident.clear()),
             Label::Repeated => quote!(#ident.clear()),
         }

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -135,7 +135,7 @@ impl Field {
     pub fn default(&self) -> TokenStream {
         match *self {
             Field::Scalar(ref scalar) => scalar.default(),
-            _ => quote!(::std::default::Default::default()),
+            _ => quote!(::core::default::Default::default()),
         }
     }
 

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -94,6 +94,6 @@ impl Field {
     }
 
     pub fn clear(&self, ident: TokenStream) -> TokenStream {
-        quote!(#ident = ::std::option::Option::None)
+        quote!(#ident = ::core::option::Option::None)
     }
 }

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -4,9 +4,7 @@ use std::fmt;
 use anyhow::{anyhow, bail, Error};
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
-use syn::{
-    self, parse_str, Ident, Lit, LitByteStr, Meta, MetaList, MetaNameValue, NestedMeta, Path,
-};
+use syn::{parse_str, Ident, Lit, LitByteStr, Meta, MetaList, MetaNameValue, NestedMeta, Path};
 
 use crate::field::{bool_attr, set_option, tag_attr, Label};
 
@@ -127,7 +125,7 @@ impl Field {
                 }
             }
             Kind::Optional(..) => quote! {
-                if let ::std::option::Option::Some(ref value) = #ident {
+                if let ::core::option::Option::Some(ref value) = #ident {
                     #encode_fn(#tag, value, buf);
                 }
             },
@@ -200,7 +198,7 @@ impl Field {
                     _ => quote!(#ident = #default),
                 }
             }
-            Kind::Optional(_) => quote!(#ident = ::std::option::Option::None),
+            Kind::Optional(_) => quote!(#ident = ::core::option::Option::None),
             Kind::Repeated | Kind::Packed => quote!(#ident.clear()),
         }
     }
@@ -209,8 +207,8 @@ impl Field {
     pub fn default(&self) -> TokenStream {
         match self.kind {
             Kind::Plain(ref value) | Kind::Required(ref value) => value.owned(),
-            Kind::Optional(_) => quote!(::std::option::Option::None),
-            Kind::Repeated | Kind::Packed => quote!(::std::vec::Vec::new()),
+            Kind::Optional(_) => quote!(::core::option::Option::None),
+            Kind::Repeated | Kind::Packed => quote!(::prost::alloc::vec::Vec::new()),
         }
     }
 
@@ -219,11 +217,11 @@ impl Field {
         if let Ty::Enumeration(ref ty) = self.ty {
             quote! {
                 struct #wrap_name<'a>(&'a i32);
-                impl<'a> ::std::fmt::Debug for #wrap_name<'a> {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                impl<'a> ::core::fmt::Debug for #wrap_name<'a> {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                         match #ty::from_i32(*self.0) {
-                            None => ::std::fmt::Debug::fmt(&self.0, f),
-                            Some(en) => ::std::fmt::Debug::fmt(&en, f),
+                            None => ::core::fmt::Debug::fmt(&self.0, f),
+                            Some(en) => ::core::fmt::Debug::fmt(&en, f),
                         }
                     }
                 }
@@ -242,19 +240,19 @@ impl Field {
         match self.kind {
             Kind::Plain(_) | Kind::Required(_) => self.debug_inner(wrapper_name),
             Kind::Optional(_) => quote! {
-                struct #wrapper_name<'a>(&'a ::std::option::Option<#inner_ty>);
-                impl<'a> ::std::fmt::Debug for #wrapper_name<'a> {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                struct #wrapper_name<'a>(&'a ::core::option::Option<#inner_ty>);
+                impl<'a> ::core::fmt::Debug for #wrapper_name<'a> {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                         #wrapper
-                        ::std::fmt::Debug::fmt(&self.0.as_ref().map(Inner), f)
+                        ::core::fmt::Debug::fmt(&self.0.as_ref().map(Inner), f)
                     }
                 }
             },
             Kind::Repeated | Kind::Packed => {
                 quote! {
-                    struct #wrapper_name<'a>(&'a ::std::vec::Vec<#inner_ty>);
-                    impl<'a> ::std::fmt::Debug for #wrapper_name<'a> {
-                        fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    struct #wrapper_name<'a>(&'a ::prost::alloc::vec::Vec<#inner_ty>);
+                    impl<'a> ::core::fmt::Debug for #wrapper_name<'a> {
+                        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                             let mut vec_builder = f.debug_list();
                             for v in self.0 {
                                 #wrapper
@@ -311,7 +309,7 @@ impl Field {
 
                         #[doc=#set_doc]
                         pub fn #set(&mut self, value: #ty) {
-                            self.#ident = ::std::option::Option::Some(value as i32);
+                            self.#ident = ::core::option::Option::Some(value as i32);
                         }
                     }
                 }
@@ -324,9 +322,9 @@ impl Field {
                     let push_doc = format!("Appends the provided enum value to `{}`.", ident_str);
                     quote! {
                         #[doc=#iter_doc]
-                        pub fn #ident(&self) -> ::std::iter::FilterMap<
-                            ::std::iter::Cloned<::std::slice::Iter<i32>>,
-                            fn(i32) -> ::std::option::Option<#ty>,
+                        pub fn #ident(&self) -> ::core::iter::FilterMap<
+                            ::core::iter::Cloned<::core::slice::Iter<i32>>,
+                            fn(i32) -> ::core::option::Option<#ty>,
                         > {
                             self.#ident.iter().cloned().filter_map(#ty::from_i32)
                         }
@@ -341,9 +339,9 @@ impl Field {
             let ty = self.ty.rust_ref_type();
 
             let match_some = if self.ty.is_numeric() {
-                quote!(::std::option::Option::Some(val) => val,)
+                quote!(::core::option::Option::Some(val) => val,)
             } else {
-                quote!(::std::option::Option::Some(ref val) => &val[..],)
+                quote!(::core::option::Option::Some(ref val) => &val[..],)
             };
 
             let get_doc = format!(
@@ -356,7 +354,7 @@ impl Field {
                 pub fn #ident(&self) -> #ty {
                     match self.#ident {
                         #match_some
-                        ::std::option::Option::None => #default,
+                        ::core::option::Option::None => #default,
                     }
                 }
             })
@@ -493,8 +491,8 @@ impl Ty {
     // TODO: rename to 'owned_type'.
     pub fn rust_type(&self) -> TokenStream {
         match *self {
-            Ty::String => quote!(::std::string::String),
-            Ty::Bytes => quote!(::std::vec::Vec<u8>),
+            Ty::String => quote!(::prost::alloc::string::String),
+            Ty::Bytes => quote!(::prost::alloc::vec::Vec<u8>),
             _ => self.rust_ref_type(),
         }
     }
@@ -639,16 +637,16 @@ impl DefaultValue {
                     match value {
                         "inf" => {
                             return Ok(DefaultValue::Path(parse_str::<Path>(
-                                "::std::f32::INFINITY",
+                                "::core::f32::INFINITY",
                             )?));
                         }
                         "-inf" => {
                             return Ok(DefaultValue::Path(parse_str::<Path>(
-                                "::std::f32::NEG_INFINITY",
+                                "::core::f32::NEG_INFINITY",
                             )?));
                         }
                         "nan" => {
-                            return Ok(DefaultValue::Path(parse_str::<Path>("::std::f32::NAN")?));
+                            return Ok(DefaultValue::Path(parse_str::<Path>("::core::f32::NAN")?));
                         }
                         _ => (),
                     }
@@ -657,16 +655,16 @@ impl DefaultValue {
                     match value {
                         "inf" => {
                             return Ok(DefaultValue::Path(parse_str::<Path>(
-                                "::std::f64::INFINITY",
+                                "::core::f64::INFINITY",
                             )?));
                         }
                         "-inf" => {
                             return Ok(DefaultValue::Path(parse_str::<Path>(
-                                "::std::f64::NEG_INFINITY",
+                                "::core::f64::NEG_INFINITY",
                             )?));
                         }
                         "nan" => {
-                            return Ok(DefaultValue::Path(parse_str::<Path>("::std::f64::NAN")?));
+                            return Ok(DefaultValue::Path(parse_str::<Path>("::core::f64::NAN")?));
                         }
                         _ => (),
                     }
@@ -744,10 +742,12 @@ impl DefaultValue {
     pub fn owned(&self) -> TokenStream {
         match *self {
             DefaultValue::String(ref value) if value.is_empty() => {
-                quote!(::std::string::String::new())
+                quote!(::prost::alloc::string::String::new())
             }
             DefaultValue::String(ref value) => quote!(#value.to_owned()),
-            DefaultValue::Bytes(ref value) if value.is_empty() => quote!(::std::vec::Vec::new()),
+            DefaultValue::Bytes(ref value) if value.is_empty() => {
+                quote!(::prost::alloc::vec::Vec::new())
+            }
             DefaultValue::Bytes(ref value) => {
                 let lit = LitByteStr::new(value, Span::call_site());
                 quote!(#lit.to_owned())

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -2,15 +2,14 @@
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 
+extern crate alloc;
 extern crate proc_macro;
 
-use anyhow::bail;
-use quote::quote;
-
-use anyhow::Error;
+use anyhow::{bail, Error};
 use itertools::Itertools;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
+use quote::quote;
 use syn::{
     punctuated::Punctuated, Data, DataEnum, DataStruct, DeriveInput, Expr, Fields, FieldsNamed,
     FieldsUnnamed, Ident, Variant,
@@ -189,7 +188,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                 wire_type: ::prost::encoding::WireType,
                 buf: &mut B,
                 ctx: ::prost::encoding::DecodeContext,
-            ) -> ::std::result::Result<(), ::prost::DecodeError>
+            ) -> ::core::result::Result<(), ::prost::DecodeError>
             where B: ::prost::bytes::Buf {
                 #struct_name
                 match tag {
@@ -216,8 +215,8 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
             }
         }
 
-        impl ::std::fmt::Debug for #ident {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl ::core::fmt::Debug for #ident {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 let mut builder = #debug_builder;
                 #(#debugs;)*
                 builder.finish()
@@ -281,7 +280,7 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
         .iter()
         .map(|&(_, ref value)| quote!(#value => true));
     let from = variants.iter().map(
-        |&(ref variant, ref value)| quote!(#value => ::std::option::Option::Some(#ident::#variant)),
+        |&(ref variant, ref value)| quote!(#value => ::core::option::Option::Some(#ident::#variant)),
     );
 
     let is_valid_doc = format!("Returns `true` if `value` is a variant of `{}`.", ident);
@@ -301,21 +300,21 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
             }
 
             #[doc=#from_i32_doc]
-            pub fn from_i32(value: i32) -> ::std::option::Option<#ident> {
+            pub fn from_i32(value: i32) -> ::core::option::Option<#ident> {
                 match value {
                     #(#from,)*
-                    _ => ::std::option::Option::None,
+                    _ => ::core::option::Option::None,
                 }
             }
         }
 
-        impl ::std::default::Default for #ident {
+        impl ::core::default::Default for #ident {
             fn default() -> #ident {
                 #ident::#default
             }
         }
 
-        impl ::std::convert::From<#ident> for i32 {
+        impl ::core::convert::From<#ident> for i32 {
             fn from(value: #ident) -> i32 {
                 value as i32
             }
@@ -400,13 +399,13 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         quote! {
             #tag => {
                 match field {
-                    ::std::option::Option::Some(#ident::#variant_ident(ref mut value)) => {
+                    ::core::option::Option::Some(#ident::#variant_ident(ref mut value)) => {
                         #merge
                     },
                     _ => {
-                        let mut owned_value = ::std::default::Default::default();
+                        let mut owned_value = ::core::default::Default::default();
                         let value = &mut owned_value;
-                        #merge.map(|_| *field = ::std::option::Option::Some(#ident::#variant_ident(owned_value)))
+                        #merge.map(|_| *field = ::core::option::Option::Some(#ident::#variant_ident(owned_value)))
                     },
                 }
             }
@@ -437,12 +436,12 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
             }
 
             pub fn merge<B>(
-                field: &mut ::std::option::Option<#ident>,
+                field: &mut ::core::option::Option<#ident>,
                 tag: u32,
                 wire_type: ::prost::encoding::WireType,
                 buf: &mut B,
                 ctx: ::prost::encoding::DecodeContext,
-            ) -> ::std::result::Result<(), ::prost::DecodeError>
+            ) -> ::core::result::Result<(), ::prost::DecodeError>
             where B: ::prost::bytes::Buf {
                 match tag {
                     #(#merge,)*
@@ -458,8 +457,8 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
             }
         }
 
-        impl ::std::fmt::Debug for #ident {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        impl ::core::fmt::Debug for #ident {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 match *self {
                     #(#debug,)*
                 }

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -13,6 +13,10 @@ edition = "2018"
 doctest = false
 test = false
 
+[features]
+default = ["std"]
+std = ["prost/std"]
+
 [dependencies]
-bytes = "0.5"
-prost = { version = "0.6.1", path = ".." }
+bytes = { version = "0.5", default-features = false }
+prost = { version = "0.6.1", path = "..", default-features = false, features = ["prost-derive"] }

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -2,15 +2,15 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Version {
     #[prost(int32, optional, tag="1")]
-    pub major: ::std::option::Option<i32>,
+    pub major: ::core::option::Option<i32>,
     #[prost(int32, optional, tag="2")]
-    pub minor: ::std::option::Option<i32>,
+    pub minor: ::core::option::Option<i32>,
     #[prost(int32, optional, tag="3")]
-    pub patch: ::std::option::Option<i32>,
+    pub patch: ::core::option::Option<i32>,
     /// A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
     /// be empty for mainline stable releases.
     #[prost(string, optional, tag="4")]
-    pub suffix: ::std::option::Option<std::string::String>,
+    pub suffix: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -19,10 +19,10 @@ pub struct CodeGeneratorRequest {
     /// code generator should generate code only for these files.  Each file's
     /// descriptor will be included in proto_file, below.
     #[prost(string, repeated, tag="1")]
-    pub file_to_generate: ::std::vec::Vec<std::string::String>,
+    pub file_to_generate: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// The generator parameter passed on the command-line.
     #[prost(string, optional, tag="2")]
-    pub parameter: ::std::option::Option<std::string::String>,
+    pub parameter: ::core::option::Option<::prost::alloc::string::String>,
     /// FileDescriptorProtos for all files in files_to_generate and everything
     /// they import.  The files will appear in topological order, so each file
     /// appears before any file that imports it.
@@ -38,10 +38,10 @@ pub struct CodeGeneratorRequest {
     /// Type names of fields and extensions in the FileDescriptorProto are always
     /// fully qualified.
     #[prost(message, repeated, tag="15")]
-    pub proto_file: ::std::vec::Vec<super::FileDescriptorProto>,
+    pub proto_file: ::prost::alloc::vec::Vec<super::FileDescriptorProto>,
     /// The version number of protocol compiler.
     #[prost(message, optional, tag="3")]
-    pub compiler_version: ::std::option::Option<Version>,
+    pub compiler_version: ::core::option::Option<Version>,
 }
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -55,9 +55,9 @@ pub struct CodeGeneratorResponse {
     /// unparseable -- should be reported by writing a message to stderr and
     /// exiting with a non-zero status code.
     #[prost(string, optional, tag="1")]
-    pub error: ::std::option::Option<std::string::String>,
+    pub error: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag="15")]
-    pub file: ::std::vec::Vec<code_generator_response::File>,
+    pub file: ::prost::alloc::vec::Vec<code_generator_response::File>,
 }
 pub mod code_generator_response {
     /// Represents a single generated file.
@@ -75,7 +75,7 @@ pub mod code_generator_response {
         /// this writing protoc does not optimize for this -- it will read the entire
         /// CodeGeneratorResponse before writing files to disk.
         #[prost(string, optional, tag="1")]
-        pub name: ::std::option::Option<std::string::String>,
+        pub name: ::core::option::Option<::prost::alloc::string::String>,
         /// If non-empty, indicates that the named file should already exist, and the
         /// content here is to be inserted into that file at a defined insertion
         /// point.  This feature allows a code generator to extend the output
@@ -114,9 +114,9 @@ pub mod code_generator_response {
         ///
         /// If |insertion_point| is present, |name| must also be present.
         #[prost(string, optional, tag="2")]
-        pub insertion_point: ::std::option::Option<std::string::String>,
+        pub insertion_point: ::core::option::Option<::prost::alloc::string::String>,
         /// The file contents.
         #[prost(string, optional, tag="15")]
-        pub content: ::std::option::Option<std::string::String>,
+        pub content: ::core::option::Option<::prost::alloc::string::String>,
     }
 }

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -3,86 +3,86 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag="1")]
-    pub file: ::std::vec::Vec<FileDescriptorProto>,
+    pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     /// e.g. "foo", "foo.bar", etc.
     #[prost(string, optional, tag="2")]
-    pub package: ::std::option::Option<std::string::String>,
+    pub package: ::core::option::Option<::prost::alloc::string::String>,
     /// Names of files imported by this file.
     #[prost(string, repeated, tag="3")]
-    pub dependency: ::std::vec::Vec<std::string::String>,
+    pub dependency: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Indexes of the public imported files in the dependency list above.
     #[prost(int32, repeated, packed="false", tag="10")]
-    pub public_dependency: ::std::vec::Vec<i32>,
+    pub public_dependency: ::prost::alloc::vec::Vec<i32>,
     /// Indexes of the weak imported files in the dependency list.
     /// For Google-internal migration only. Do not use.
     #[prost(int32, repeated, packed="false", tag="11")]
-    pub weak_dependency: ::std::vec::Vec<i32>,
+    pub weak_dependency: ::prost::alloc::vec::Vec<i32>,
     /// All top-level definitions in this file.
     #[prost(message, repeated, tag="4")]
-    pub message_type: ::std::vec::Vec<DescriptorProto>,
+    pub message_type: ::prost::alloc::vec::Vec<DescriptorProto>,
     #[prost(message, repeated, tag="5")]
-    pub enum_type: ::std::vec::Vec<EnumDescriptorProto>,
+    pub enum_type: ::prost::alloc::vec::Vec<EnumDescriptorProto>,
     #[prost(message, repeated, tag="6")]
-    pub service: ::std::vec::Vec<ServiceDescriptorProto>,
+    pub service: ::prost::alloc::vec::Vec<ServiceDescriptorProto>,
     #[prost(message, repeated, tag="7")]
-    pub extension: ::std::vec::Vec<FieldDescriptorProto>,
+    pub extension: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
     #[prost(message, optional, tag="8")]
-    pub options: ::std::option::Option<FileOptions>,
+    pub options: ::core::option::Option<FileOptions>,
     /// This field contains optional information about the original source code.
     /// You may safely remove this entire field without harming runtime
     /// functionality of the descriptors -- the information is needed only by
     /// development tools.
     #[prost(message, optional, tag="9")]
-    pub source_code_info: ::std::option::Option<SourceCodeInfo>,
+    pub source_code_info: ::core::option::Option<SourceCodeInfo>,
     /// The syntax of the proto file.
     /// The supported values are "proto2" and "proto3".
     #[prost(string, optional, tag="12")]
-    pub syntax: ::std::option::Option<std::string::String>,
+    pub syntax: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Describes a message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag="2")]
-    pub field: ::std::vec::Vec<FieldDescriptorProto>,
+    pub field: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
     #[prost(message, repeated, tag="6")]
-    pub extension: ::std::vec::Vec<FieldDescriptorProto>,
+    pub extension: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
     #[prost(message, repeated, tag="3")]
-    pub nested_type: ::std::vec::Vec<DescriptorProto>,
+    pub nested_type: ::prost::alloc::vec::Vec<DescriptorProto>,
     #[prost(message, repeated, tag="4")]
-    pub enum_type: ::std::vec::Vec<EnumDescriptorProto>,
+    pub enum_type: ::prost::alloc::vec::Vec<EnumDescriptorProto>,
     #[prost(message, repeated, tag="5")]
-    pub extension_range: ::std::vec::Vec<descriptor_proto::ExtensionRange>,
+    pub extension_range: ::prost::alloc::vec::Vec<descriptor_proto::ExtensionRange>,
     #[prost(message, repeated, tag="8")]
-    pub oneof_decl: ::std::vec::Vec<OneofDescriptorProto>,
+    pub oneof_decl: ::prost::alloc::vec::Vec<OneofDescriptorProto>,
     #[prost(message, optional, tag="7")]
-    pub options: ::std::option::Option<MessageOptions>,
+    pub options: ::core::option::Option<MessageOptions>,
     #[prost(message, repeated, tag="9")]
-    pub reserved_range: ::std::vec::Vec<descriptor_proto::ReservedRange>,
+    pub reserved_range: ::prost::alloc::vec::Vec<descriptor_proto::ReservedRange>,
     /// Reserved field names, which may not be used by fields in the same message.
     /// A given name may only be reserved once.
     #[prost(string, repeated, tag="10")]
-    pub reserved_name: ::std::vec::Vec<std::string::String>,
+    pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 pub mod descriptor_proto {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct ExtensionRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
-        pub start: ::std::option::Option<i32>,
+        pub start: ::core::option::Option<i32>,
         /// Exclusive.
         #[prost(int32, optional, tag="2")]
-        pub end: ::std::option::Option<i32>,
+        pub end: ::core::option::Option<i32>,
         #[prost(message, optional, tag="3")]
-        pub options: ::std::option::Option<super::ExtensionRangeOptions>,
+        pub options: ::core::option::Option<super::ExtensionRangeOptions>,
     }
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
@@ -91,61 +91,61 @@ pub mod descriptor_proto {
     pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
-        pub start: ::std::option::Option<i32>,
+        pub start: ::core::option::Option<i32>,
         /// Exclusive.
         #[prost(int32, optional, tag="2")]
-        pub end: ::std::option::Option<i32>,
+        pub end: ::core::option::Option<i32>,
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 /// Describes a field within a message.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(int32, optional, tag="3")]
-    pub number: ::std::option::Option<i32>,
+    pub number: ::core::option::Option<i32>,
     #[prost(enumeration="field_descriptor_proto::Label", optional, tag="4")]
-    pub label: ::std::option::Option<i32>,
+    pub label: ::core::option::Option<i32>,
     /// If type_name is set, this need not be set.  If both this and type_name
     /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     #[prost(enumeration="field_descriptor_proto::Type", optional, tag="5")]
-    pub r#type: ::std::option::Option<i32>,
+    pub r#type: ::core::option::Option<i32>,
     /// For message and enum types, this is the name of the type.  If the name
     /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
     /// rules are used to find the type (i.e. first the nested types within this
     /// message are searched, then within the parent, on up to the root
     /// namespace).
     #[prost(string, optional, tag="6")]
-    pub type_name: ::std::option::Option<std::string::String>,
+    pub type_name: ::core::option::Option<::prost::alloc::string::String>,
     /// For extensions, this is the name of the type being extended.  It is
     /// resolved in the same manner as type_name.
     #[prost(string, optional, tag="2")]
-    pub extendee: ::std::option::Option<std::string::String>,
+    pub extendee: ::core::option::Option<::prost::alloc::string::String>,
     /// For numeric types, contains the original text representation of the value.
     /// For booleans, "true" or "false".
     /// For strings, contains the default text contents (not escaped in any way).
     /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
     /// TODO(kenton):  Base-64 encode?
     #[prost(string, optional, tag="7")]
-    pub default_value: ::std::option::Option<std::string::String>,
+    pub default_value: ::core::option::Option<::prost::alloc::string::String>,
     /// If set, gives the index of a oneof in the containing type's oneof_decl
     /// list.  This field is a member of that oneof.
     #[prost(int32, optional, tag="9")]
-    pub oneof_index: ::std::option::Option<i32>,
+    pub oneof_index: ::core::option::Option<i32>,
     /// JSON name of this field. The value is set by protocol compiler. If the
     /// user has set a "json_name" option on this field, that option's value
     /// will be used. Otherwise, it's deduced from the field's name by converting
     /// it to camelCase.
     #[prost(string, optional, tag="10")]
-    pub json_name: ::std::option::Option<std::string::String>,
+    pub json_name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag="8")]
-    pub options: ::std::option::Option<FieldOptions>,
+    pub options: ::core::option::Option<FieldOptions>,
 }
 pub mod field_descriptor_proto {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -197,28 +197,28 @@ pub mod field_descriptor_proto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag="2")]
-    pub options: ::std::option::Option<OneofOptions>,
+    pub options: ::core::option::Option<OneofOptions>,
 }
 /// Describes an enum type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag="2")]
-    pub value: ::std::vec::Vec<EnumValueDescriptorProto>,
+    pub value: ::prost::alloc::vec::Vec<EnumValueDescriptorProto>,
     #[prost(message, optional, tag="3")]
-    pub options: ::std::option::Option<EnumOptions>,
+    pub options: ::core::option::Option<EnumOptions>,
     /// Range of reserved numeric values. Reserved numeric values may not be used
     /// by enum values in the same enum declaration. Reserved ranges may not
     /// overlap.
     #[prost(message, repeated, tag="4")]
-    pub reserved_range: ::std::vec::Vec<enum_descriptor_proto::EnumReservedRange>,
+    pub reserved_range: ::prost::alloc::vec::Vec<enum_descriptor_proto::EnumReservedRange>,
     /// Reserved enum value names, which may not be reused. A given name may only
     /// be reserved once.
     #[prost(string, repeated, tag="5")]
-    pub reserved_name: ::std::vec::Vec<std::string::String>,
+    pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 pub mod enum_descriptor_proto {
     /// Range of reserved numeric values. Reserved values may not be used by
@@ -231,51 +231,51 @@ pub mod enum_descriptor_proto {
     pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
-        pub start: ::std::option::Option<i32>,
+        pub start: ::core::option::Option<i32>,
         /// Inclusive.
         #[prost(int32, optional, tag="2")]
-        pub end: ::std::option::Option<i32>,
+        pub end: ::core::option::Option<i32>,
     }
 }
 /// Describes a value within an enum.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(int32, optional, tag="2")]
-    pub number: ::std::option::Option<i32>,
+    pub number: ::core::option::Option<i32>,
     #[prost(message, optional, tag="3")]
-    pub options: ::std::option::Option<EnumValueOptions>,
+    pub options: ::core::option::Option<EnumValueOptions>,
 }
 /// Describes a service.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag="2")]
-    pub method: ::std::vec::Vec<MethodDescriptorProto>,
+    pub method: ::prost::alloc::vec::Vec<MethodDescriptorProto>,
     #[prost(message, optional, tag="3")]
-    pub options: ::std::option::Option<ServiceOptions>,
+    pub options: ::core::option::Option<ServiceOptions>,
 }
 /// Describes a method of a service.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag="1")]
-    pub name: ::std::option::Option<std::string::String>,
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
     /// Input and output type names.  These are resolved in the same way as
     /// FieldDescriptorProto.type_name, but must refer to a message type.
     #[prost(string, optional, tag="2")]
-    pub input_type: ::std::option::Option<std::string::String>,
+    pub input_type: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag="3")]
-    pub output_type: ::std::option::Option<std::string::String>,
+    pub output_type: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag="4")]
-    pub options: ::std::option::Option<MethodOptions>,
+    pub options: ::core::option::Option<MethodOptions>,
     /// Identifies if client streams multiple client messages
     #[prost(bool, optional, tag="5", default="false")]
-    pub client_streaming: ::std::option::Option<bool>,
+    pub client_streaming: ::core::option::Option<bool>,
     /// Identifies if server streams multiple server messages
     #[prost(bool, optional, tag="6", default="false")]
-    pub server_streaming: ::std::option::Option<bool>,
+    pub server_streaming: ::core::option::Option<bool>,
 }
 // ===================================================================
 // Options
@@ -316,14 +316,14 @@ pub struct FileOptions {
     /// inappropriate because proto packages do not normally start with backwards
     /// domain names.
     #[prost(string, optional, tag="1")]
-    pub java_package: ::std::option::Option<std::string::String>,
+    pub java_package: ::core::option::Option<::prost::alloc::string::String>,
     /// If set, all the classes from the .proto file are wrapped in a single
     /// outer class with the given name.  This applies to both Proto1
     /// (equivalent to the old "--one_java_file" option) and Proto2 (where
     /// a .proto always translates to a single class, but you may want to
     /// explicitly choose the class name).
     #[prost(string, optional, tag="8")]
-    pub java_outer_classname: ::std::option::Option<std::string::String>,
+    pub java_outer_classname: ::core::option::Option<::prost::alloc::string::String>,
     /// If set true, then the Java code generator will generate a separate .java
     /// file for each top-level message, enum, and service defined in the .proto
     /// file.  Thus, these types will *not* be nested inside the outer class
@@ -331,11 +331,11 @@ pub struct FileOptions {
     /// generated to contain the file's getDescriptor() method as well as any
     /// top-level extensions defined in the file.
     #[prost(bool, optional, tag="10", default="false")]
-    pub java_multiple_files: ::std::option::Option<bool>,
+    pub java_multiple_files: ::core::option::Option<bool>,
     /// This option does nothing.
     #[deprecated]
     #[prost(bool, optional, tag="20")]
-    pub java_generate_equals_and_hash: ::std::option::Option<bool>,
+    pub java_generate_equals_and_hash: ::core::option::Option<bool>,
     /// If set true, then the Java2 code generator will generate code that
     /// throws an exception whenever an attempt is made to assign a non-UTF-8
     /// byte sequence to a string field.
@@ -343,16 +343,16 @@ pub struct FileOptions {
     /// However, an extension field still accepts non-UTF-8 byte sequences.
     /// This option has no effect on when used with the lite runtime.
     #[prost(bool, optional, tag="27", default="false")]
-    pub java_string_check_utf8: ::std::option::Option<bool>,
+    pub java_string_check_utf8: ::core::option::Option<bool>,
     #[prost(enumeration="file_options::OptimizeMode", optional, tag="9", default="Speed")]
-    pub optimize_for: ::std::option::Option<i32>,
+    pub optimize_for: ::core::option::Option<i32>,
     /// Sets the Go package where structs generated from this .proto will be
     /// placed. If omitted, the Go package will be derived from the following:
     ///   - The basename of the package import path, if provided.
     ///   - Otherwise, the package statement in the .proto file, if present.
     ///   - Otherwise, the basename of the .proto file, without extension.
     #[prost(string, optional, tag="11")]
-    pub go_package: ::std::option::Option<std::string::String>,
+    pub go_package: ::core::option::Option<::prost::alloc::string::String>,
     /// Should generic services be generated in each language?  "Generic" services
     /// are not specific to any particular RPC system.  They are generated by the
     /// main code generators in each language (without additional plugins).
@@ -364,59 +364,59 @@ pub struct FileOptions {
     /// these default to false.  Old code which depends on generic services should
     /// explicitly set them to true.
     #[prost(bool, optional, tag="16", default="false")]
-    pub cc_generic_services: ::std::option::Option<bool>,
+    pub cc_generic_services: ::core::option::Option<bool>,
     #[prost(bool, optional, tag="17", default="false")]
-    pub java_generic_services: ::std::option::Option<bool>,
+    pub java_generic_services: ::core::option::Option<bool>,
     #[prost(bool, optional, tag="18", default="false")]
-    pub py_generic_services: ::std::option::Option<bool>,
+    pub py_generic_services: ::core::option::Option<bool>,
     #[prost(bool, optional, tag="42", default="false")]
-    pub php_generic_services: ::std::option::Option<bool>,
+    pub php_generic_services: ::core::option::Option<bool>,
     /// Is this file deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for everything in the file, or it will be completely ignored; in the very
     /// least, this is a formalization for deprecating files.
     #[prost(bool, optional, tag="23", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// Enables the use of arenas for the proto messages in this file. This applies
     /// only to generated classes for C++.
     #[prost(bool, optional, tag="31", default="false")]
-    pub cc_enable_arenas: ::std::option::Option<bool>,
+    pub cc_enable_arenas: ::core::option::Option<bool>,
     /// Sets the objective c class prefix which is prepended to all objective c
     /// generated classes from this .proto. There is no default.
     #[prost(string, optional, tag="36")]
-    pub objc_class_prefix: ::std::option::Option<std::string::String>,
+    pub objc_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Namespace for generated classes; defaults to the package.
     #[prost(string, optional, tag="37")]
-    pub csharp_namespace: ::std::option::Option<std::string::String>,
+    pub csharp_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// By default Swift generators will take the proto package and CamelCase it
     /// replacing '.' with underscore and use that to prefix the types/symbols
     /// defined. When this options is provided, they will use this value instead
     /// to prefix the types/symbols defined.
     #[prost(string, optional, tag="39")]
-    pub swift_prefix: ::std::option::Option<std::string::String>,
+    pub swift_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Sets the php class prefix which is prepended to all php generated classes
     /// from this .proto. Default is empty.
     #[prost(string, optional, tag="40")]
-    pub php_class_prefix: ::std::option::Option<std::string::String>,
+    pub php_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the namespace of php generated classes. Default
     /// is empty. When this option is empty, the package name will be used for
     /// determining the namespace.
     #[prost(string, optional, tag="41")]
-    pub php_namespace: ::std::option::Option<std::string::String>,
+    pub php_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the namespace of php generated metadata classes.
     /// Default is empty. When this option is empty, the proto file name will be
     /// used for determining the namespace.
     #[prost(string, optional, tag="44")]
-    pub php_metadata_namespace: ::std::option::Option<std::string::String>,
+    pub php_metadata_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the package of ruby generated classes. Default
     /// is empty. When this option is not set, the package name will be used for
     /// determining the ruby package.
     #[prost(string, optional, tag="45")]
-    pub ruby_package: ::std::option::Option<std::string::String>,
+    pub ruby_package: ::core::option::Option<::prost::alloc::string::String>,
     /// The parser stores options it doesn't recognize here.
     /// See the documentation for the "Options" section above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 pub mod file_options {
     /// Generated classes can be optimized for speed or code size.
@@ -454,18 +454,18 @@ pub struct MessageOptions {
     /// Because this is an option, the above two restrictions are not enforced by
     /// the protocol compiler.
     #[prost(bool, optional, tag="1", default="false")]
-    pub message_set_wire_format: ::std::option::Option<bool>,
+    pub message_set_wire_format: ::core::option::Option<bool>,
     /// Disables the generation of the standard "descriptor()" accessor, which can
     /// conflict with a field of the same name.  This is meant to make migration
     /// from proto1 easier; new code should avoid fields named "descriptor".
     #[prost(bool, optional, tag="2", default="false")]
-    pub no_standard_descriptor_accessor: ::std::option::Option<bool>,
+    pub no_standard_descriptor_accessor: ::core::option::Option<bool>,
     /// Is this message deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the message, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating messages.
     #[prost(bool, optional, tag="3", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// Whether the message is an automatically generated map entry type for the
     /// maps field.
     ///
@@ -488,10 +488,10 @@ pub struct MessageOptions {
     /// instead. The option should only be implicitly set by the proto compiler
     /// parser.
     #[prost(bool, optional, tag="7")]
-    pub map_entry: ::std::option::Option<bool>,
+    pub map_entry: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldOptions {
@@ -500,14 +500,14 @@ pub struct FieldOptions {
     /// options below.  This option is not yet implemented in the open source
     /// release -- sorry, we'll try to include it in a future version!
     #[prost(enumeration="field_options::CType", optional, tag="1", default="String")]
-    pub ctype: ::std::option::Option<i32>,
+    pub ctype: ::core::option::Option<i32>,
     /// The packed option can be enabled for repeated primitive fields to enable
     /// a more efficient representation on the wire. Rather than repeatedly
     /// writing the tag and type for each element, the entire array is encoded as
     /// a single length-delimited blob. In proto3, only explicit setting it to
     /// false will avoid using packed encoding.
     #[prost(bool, optional, tag="2")]
-    pub packed: ::std::option::Option<bool>,
+    pub packed: ::core::option::Option<bool>,
     /// The jstype option determines the JavaScript type used for values of the
     /// field.  The option is permitted only for 64 bit integral and fixed types
     /// (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
@@ -520,7 +520,7 @@ pub struct FieldOptions {
     /// This option is an enum to permit additional types to be added, e.g.
     /// goog.math.Integer.
     #[prost(enumeration="field_options::JsType", optional, tag="6", default="JsNormal")]
-    pub jstype: ::std::option::Option<i32>,
+    pub jstype: ::core::option::Option<i32>,
     /// Should this field be parsed lazily?  Lazy applies only to message-type
     /// fields.  It means that when the outer message is initially parsed, the
     /// inner message's contents will not be parsed but instead stored in encoded
@@ -550,19 +550,19 @@ pub struct FieldOptions {
     /// check its required fields, regardless of whether or not the message has
     /// been parsed.
     #[prost(bool, optional, tag="5", default="false")]
-    pub lazy: ::std::option::Option<bool>,
+    pub lazy: ::core::option::Option<bool>,
     /// Is this field deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for accessors, or it will be completely ignored; in the very least, this
     /// is a formalization for deprecating fields.
     #[prost(bool, optional, tag="3", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// For Google-internal migration only. Do not use.
     #[prost(bool, optional, tag="10", default="false")]
-    pub weak: ::std::option::Option<bool>,
+    pub weak: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 pub mod field_options {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -588,23 +588,23 @@ pub mod field_options {
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
     #[prost(bool, optional, tag="2")]
-    pub allow_alias: ::std::option::Option<bool>,
+    pub allow_alias: ::core::option::Option<bool>,
     /// Is this enum deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
     /// for the enum, or it will be completely ignored; in the very least, this
     /// is a formalization for deprecating enums.
     #[prost(bool, optional, tag="3", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueOptions {
@@ -613,10 +613,10 @@ pub struct EnumValueOptions {
     /// for the enum value, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating enum values.
     #[prost(bool, optional, tag="1", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceOptions {
@@ -630,10 +630,10 @@ pub struct ServiceOptions {
     /// for the service, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating services.
     #[prost(bool, optional, tag="33", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodOptions {
@@ -647,12 +647,12 @@ pub struct MethodOptions {
     /// for the method, or it will be completely ignored; in the very least,
     /// this is a formalization for deprecating methods.
     #[prost(bool, optional, tag="33", default="false")]
-    pub deprecated: ::std::option::Option<bool>,
+    pub deprecated: ::core::option::Option<bool>,
     #[prost(enumeration="method_options::IdempotencyLevel", optional, tag="34", default="IdempotencyUnknown")]
-    pub idempotency_level: ::std::option::Option<i32>,
+    pub idempotency_level: ::core::option::Option<i32>,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
-    pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
@@ -677,21 +677,21 @@ pub mod method_options {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag="2")]
-    pub name: ::std::vec::Vec<uninterpreted_option::NamePart>,
+    pub name: ::prost::alloc::vec::Vec<uninterpreted_option::NamePart>,
     /// The value of the uninterpreted option, in whatever type the tokenizer
     /// identified it as during parsing. Exactly one of these should be set.
     #[prost(string, optional, tag="3")]
-    pub identifier_value: ::std::option::Option<std::string::String>,
+    pub identifier_value: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(uint64, optional, tag="4")]
-    pub positive_int_value: ::std::option::Option<u64>,
+    pub positive_int_value: ::core::option::Option<u64>,
     #[prost(int64, optional, tag="5")]
-    pub negative_int_value: ::std::option::Option<i64>,
+    pub negative_int_value: ::core::option::Option<i64>,
     #[prost(double, optional, tag="6")]
-    pub double_value: ::std::option::Option<f64>,
+    pub double_value: ::core::option::Option<f64>,
     #[prost(bytes, optional, tag="7")]
-    pub string_value: ::std::option::Option<std::vec::Vec<u8>>,
+    pub string_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     #[prost(string, optional, tag="8")]
-    pub aggregate_value: ::std::option::Option<std::string::String>,
+    pub aggregate_value: ::core::option::Option<::prost::alloc::string::String>,
 }
 pub mod uninterpreted_option {
     /// The name of the uninterpreted option.  Each string represents a segment in
@@ -702,7 +702,7 @@ pub mod uninterpreted_option {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NamePart {
         #[prost(string, required, tag="1")]
-        pub name_part: std::string::String,
+        pub name_part: ::prost::alloc::string::String,
         #[prost(bool, required, tag="2")]
         pub is_extension: bool,
     }
@@ -758,7 +758,7 @@ pub struct SourceCodeInfo {
     ///   ignore those that it doesn't understand, as more types of locations could
     ///   be recorded in the future.
     #[prost(message, repeated, tag="1")]
-    pub location: ::std::vec::Vec<source_code_info::Location>,
+    pub location: ::prost::alloc::vec::Vec<source_code_info::Location>,
 }
 pub mod source_code_info {
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -787,14 +787,14 @@ pub mod source_code_info {
         /// this path refers to the whole field declaration (from the beginning
         /// of the label to the terminating semicolon).
         #[prost(int32, repeated, tag="1")]
-        pub path: ::std::vec::Vec<i32>,
+        pub path: ::prost::alloc::vec::Vec<i32>,
         /// Always has exactly three or four elements: start line, start column,
         /// end line (optional, otherwise assumed same as start line), end column.
         /// These are packed into a single field for efficiency.  Note that line
         /// and column numbers are zero-based -- typically you will want to add
         /// 1 to each before displaying to a user.
         #[prost(int32, repeated, tag="2")]
-        pub span: ::std::vec::Vec<i32>,
+        pub span: ::prost::alloc::vec::Vec<i32>,
         /// If this SourceCodeInfo represents a complete declaration, these are any
         /// comments appearing before and after the declaration which appear to be
         /// attached to the declaration.
@@ -843,11 +843,11 @@ pub mod source_code_info {
         ///
         ///   // ignored detached comments.
         #[prost(string, optional, tag="3")]
-        pub leading_comments: ::std::option::Option<std::string::String>,
+        pub leading_comments: ::core::option::Option<::prost::alloc::string::String>,
         #[prost(string, optional, tag="4")]
-        pub trailing_comments: ::std::option::Option<std::string::String>,
+        pub trailing_comments: ::core::option::Option<::prost::alloc::string::String>,
         #[prost(string, repeated, tag="6")]
-        pub leading_detached_comments: ::std::vec::Vec<std::string::String>,
+        pub leading_detached_comments: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     }
 }
 /// Describes the relationship between generated code and its original source
@@ -858,7 +858,7 @@ pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
     #[prost(message, repeated, tag="1")]
-    pub annotation: ::std::vec::Vec<generated_code_info::Annotation>,
+    pub annotation: ::prost::alloc::vec::Vec<generated_code_info::Annotation>,
 }
 pub mod generated_code_info {
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -866,19 +866,19 @@ pub mod generated_code_info {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
         #[prost(int32, repeated, tag="1")]
-        pub path: ::std::vec::Vec<i32>,
+        pub path: ::prost::alloc::vec::Vec<i32>,
         /// Identifies the filesystem path to the original source .proto.
         #[prost(string, optional, tag="2")]
-        pub source_file: ::std::option::Option<std::string::String>,
+        pub source_file: ::core::option::Option<::prost::alloc::string::String>,
         /// Identifies the starting offset in bytes in the generated code
         /// that relates to the identified object.
         #[prost(int32, optional, tag="3")]
-        pub begin: ::std::option::Option<i32>,
+        pub begin: ::core::option::Option<i32>,
         /// Identifies the ending offset in bytes in the generated code that
         /// relates to the identified offset. The end offset should be one past
         /// the last relevant byte (so the length of the text = end - begin).
         #[prost(int32, optional, tag="4")]
-        pub end: ::std::option::Option<i32>,
+        pub end: ::core::option::Option<i32>,
     }
 }
 /// `Any` contains an arbitrary serialized protocol buffer message along with a
@@ -992,10 +992,10 @@ pub struct Any {
     /// used with implementation specific semantics.
     ///
     #[prost(string, tag="1")]
-    pub type_url: std::string::String,
+    pub type_url: ::prost::alloc::string::String,
     /// Must be a valid serialized protocol buffer of the above specified type.
     #[prost(bytes, tag="2")]
-    pub value: std::vec::Vec<u8>,
+    pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// `SourceContext` represents information about the source of a
 /// protobuf element, like the file in which it is defined.
@@ -1004,26 +1004,26 @@ pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
     #[prost(string, tag="1")]
-    pub file_name: std::string::String,
+    pub file_name: ::prost::alloc::string::String,
 }
 /// A protocol buffer message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Type {
     /// The fully qualified message name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     /// The list of fields.
     #[prost(message, repeated, tag="2")]
-    pub fields: ::std::vec::Vec<Field>,
+    pub fields: ::prost::alloc::vec::Vec<Field>,
     /// The list of types appearing in `oneof` definitions in this type.
     #[prost(string, repeated, tag="3")]
-    pub oneofs: ::std::vec::Vec<std::string::String>,
+    pub oneofs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// The protocol buffer options.
     #[prost(message, repeated, tag="4")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: ::prost::alloc::vec::Vec<Option>,
     /// The source context.
     #[prost(message, optional, tag="5")]
-    pub source_context: ::std::option::Option<SourceContext>,
+    pub source_context: ::core::option::Option<SourceContext>,
     /// The source syntax.
     #[prost(enumeration="Syntax", tag="6")]
     pub syntax: i32,
@@ -1042,11 +1042,11 @@ pub struct Field {
     pub number: i32,
     /// The field name.
     #[prost(string, tag="4")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     /// The field type URL, without the scheme, for message or enumeration
     /// types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
     #[prost(string, tag="6")]
-    pub type_url: std::string::String,
+    pub type_url: ::prost::alloc::string::String,
     /// The index of the field type in `Type.oneofs`, for message or enumeration
     /// types. The first type has index 1; zero means the type is not in the list.
     #[prost(int32, tag="7")]
@@ -1056,13 +1056,13 @@ pub struct Field {
     pub packed: bool,
     /// The protocol buffer options.
     #[prost(message, repeated, tag="9")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: ::prost::alloc::vec::Vec<Option>,
     /// The field JSON name.
     #[prost(string, tag="10")]
-    pub json_name: std::string::String,
+    pub json_name: ::prost::alloc::string::String,
     /// The string value of the default value of this field. Proto2 syntax only.
     #[prost(string, tag="11")]
-    pub default_value: std::string::String,
+    pub default_value: ::prost::alloc::string::String,
 }
 pub mod field {
     /// Basic field types.
@@ -1127,16 +1127,16 @@ pub mod field {
 pub struct Enum {
     /// Enum type name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     /// Enum value definitions.
     #[prost(message, repeated, tag="2")]
-    pub enumvalue: ::std::vec::Vec<EnumValue>,
+    pub enumvalue: ::prost::alloc::vec::Vec<EnumValue>,
     /// Protocol buffer options.
     #[prost(message, repeated, tag="3")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: ::prost::alloc::vec::Vec<Option>,
     /// The source context.
     #[prost(message, optional, tag="4")]
-    pub source_context: ::std::option::Option<SourceContext>,
+    pub source_context: ::core::option::Option<SourceContext>,
     /// The source syntax.
     #[prost(enumeration="Syntax", tag="5")]
     pub syntax: i32,
@@ -1146,13 +1146,13 @@ pub struct Enum {
 pub struct EnumValue {
     /// Enum value name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     /// Enum value number.
     #[prost(int32, tag="2")]
     pub number: i32,
     /// Protocol buffer options.
     #[prost(message, repeated, tag="3")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: ::prost::alloc::vec::Vec<Option>,
 }
 /// A protocol buffer option, which can be attached to a message, field,
 /// enumeration, etc.
@@ -1163,13 +1163,13 @@ pub struct Option {
     /// For custom options, it should be the fully-qualified name. For example,
     /// `"google.api.http"`.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     /// The option's value packed in an Any message. If the value is a primitive,
     /// the corresponding wrapper type defined in google/protobuf/wrappers.proto
     /// should be used. If the value is an enum, it should be stored as an int32
     /// value using the google.protobuf.Int32Value type.
     #[prost(message, optional, tag="2")]
-    pub value: ::std::option::Option<Any>,
+    pub value: ::core::option::Option<Any>,
 }
 /// The syntax in which a protocol buffer element is defined.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -1194,13 +1194,13 @@ pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     /// The methods of this interface, in unspecified order.
     #[prost(message, repeated, tag="2")]
-    pub methods: ::std::vec::Vec<Method>,
+    pub methods: ::prost::alloc::vec::Vec<Method>,
     /// Any metadata attached to the interface.
     #[prost(message, repeated, tag="3")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: ::prost::alloc::vec::Vec<Option>,
     /// A version string for this interface. If specified, must have the form
     /// `major-version.minor-version`, as in `1.10`. If the minor version is
     /// omitted, it defaults to zero. If the entire version field is empty, the
@@ -1223,14 +1223,14 @@ pub struct Api {
     ///
     ///
     #[prost(string, tag="4")]
-    pub version: std::string::String,
+    pub version: ::prost::alloc::string::String,
     /// Source context for the protocol buffer service represented by this
     /// message.
     #[prost(message, optional, tag="5")]
-    pub source_context: ::std::option::Option<SourceContext>,
+    pub source_context: ::core::option::Option<SourceContext>,
     /// Included interfaces. See [Mixin][].
     #[prost(message, repeated, tag="6")]
-    pub mixins: ::std::vec::Vec<Mixin>,
+    pub mixins: ::prost::alloc::vec::Vec<Mixin>,
     /// The source syntax of the service.
     #[prost(enumeration="Syntax", tag="7")]
     pub syntax: i32,
@@ -1240,22 +1240,22 @@ pub struct Api {
 pub struct Method {
     /// The simple name of this method.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     /// A URL of the input message type.
     #[prost(string, tag="2")]
-    pub request_type_url: std::string::String,
+    pub request_type_url: ::prost::alloc::string::String,
     /// If true, the request is streamed.
     #[prost(bool, tag="3")]
     pub request_streaming: bool,
     /// The URL of the output message type.
     #[prost(string, tag="4")]
-    pub response_type_url: std::string::String,
+    pub response_type_url: ::prost::alloc::string::String,
     /// If true, the response is streamed.
     #[prost(bool, tag="5")]
     pub response_streaming: bool,
     /// Any metadata attached to the method.
     #[prost(message, repeated, tag="6")]
-    pub options: ::std::vec::Vec<Option>,
+    pub options: ::prost::alloc::vec::Vec<Option>,
     /// The source syntax of this method.
     #[prost(enumeration="Syntax", tag="7")]
     pub syntax: i32,
@@ -1342,11 +1342,11 @@ pub struct Method {
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
     #[prost(string, tag="1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     /// If non-empty specifies a path under which inherited HTTP paths
     /// are rooted.
     #[prost(string, tag="2")]
-    pub root: std::string::String,
+    pub root: ::prost::alloc::string::String,
 }
 /// A Duration represents a signed, fixed-length span of time represented
 /// as a count of seconds and fractions of seconds at nanosecond
@@ -1627,7 +1627,7 @@ pub struct Duration {
 pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag="1")]
-    pub paths: ::std::vec::Vec<std::string::String>,
+    pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// `Struct` represents a structured data value, consisting of fields
 /// which map to dynamically typed values. In some languages, `Struct`
@@ -1641,7 +1641,7 @@ pub struct FieldMask {
 pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map="string, message", tag="1")]
-    pub fields: ::std::collections::BTreeMap<std::string::String, Value>,
+    pub fields: ::prost::alloc::collections::BTreeMap<::prost::alloc::string::String, Value>,
 }
 /// `Value` represents a dynamically typed value which can be either
 /// null, a number, a string, a boolean, a recursive struct value, or a
@@ -1653,7 +1653,7 @@ pub struct Struct {
 pub struct Value {
     /// The kind of value.
     #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
-    pub kind: ::std::option::Option<value::Kind>,
+    pub kind: ::core::option::Option<value::Kind>,
 }
 pub mod value {
     /// The kind of value.
@@ -1667,7 +1667,7 @@ pub mod value {
         NumberValue(f64),
         /// Represents a string value.
         #[prost(string, tag="3")]
-        StringValue(std::string::String),
+        StringValue(::prost::alloc::string::String),
         /// Represents a boolean value.
         #[prost(bool, tag="4")]
         BoolValue(bool),
@@ -1686,7 +1686,7 @@ pub mod value {
 pub struct ListValue {
     /// Repeated field of dynamically typed values.
     #[prost(message, repeated, tag="1")]
-    pub values: ::std::vec::Vec<Value>,
+    pub values: ::prost::alloc::vec::Vec<Value>,
 }
 /// `NullValue` is a singleton enumeration to represent the null value for the
 /// `Value` type union.

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "0.5"
+bytes = { version = "0.5", default-features = false }
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
 //! Protobuf encoding and decoding errors.
 
-use std::borrow::Cow;
-use std::error;
-use std::fmt;
-use std::io;
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+
+use core::fmt;
 
 /// A Protobuf message decoding error.
 ///
@@ -54,11 +54,13 @@ impl fmt::Display for DecodeError {
     }
 }
 
-impl error::Error for DecodeError {}
+#[cfg(feature = "std")]
+impl std::error::Error for DecodeError {}
 
-impl From<DecodeError> for io::Error {
-    fn from(error: DecodeError) -> io::Error {
-        io::Error::new(io::ErrorKind::InvalidData, error)
+#[cfg(feature = "std")]
+impl From<DecodeError> for std::io::Error {
+    fn from(error: DecodeError) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, error)
     }
 }
 
@@ -103,10 +105,12 @@ impl fmt::Display for EncodeError {
     }
 }
 
-impl error::Error for EncodeError {}
+#[cfg(feature = "std")]
+impl std::error::Error for EncodeError {}
 
-impl From<EncodeError> for io::Error {
-    fn from(error: EncodeError) -> io::Error {
-        io::Error::new(io::ErrorKind::InvalidInput, error)
+#[cfg(feature = "std")]
+impl From<EncodeError> for std::io::Error {
+    fn from(error: EncodeError) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, error)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,13 @@
 #![doc(html_root_url = "https://docs.rs/prost/0.6.1")]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+// Re-export the alloc crate for use within derived code.
+#[doc(hidden)]
+pub extern crate alloc;
+
+// Re-export the bytes crate for use within derived code.
+#[doc(hidden)]
+pub use bytes;
 
 mod error;
 mod message;
@@ -79,9 +88,6 @@ where
 #[allow(unused_imports)]
 #[macro_use]
 extern crate prost_derive;
-#[cfg(feature = "prost-derive")]
-#[doc(hidden)]
-pub use bytes;
 #[cfg(feature = "prost-derive")]
 #[doc(hidden)]
 pub use prost_derive::*;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,5 +1,6 @@
-use std::fmt::Debug;
-use std::usize;
+use alloc::boxed::Box;
+use core::fmt::Debug;
+use core::usize;
 
 use bytes::{Buf, BufMut};
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,9 @@
 //! the `prost-types` crate in order to avoid a cyclic dependency between `prost` and
 //! `prost-build`.
 
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use ::bytes::{Buf, BufMut};
 
 use crate::{

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -12,10 +12,12 @@ doctest = false
 path = "../tests/src/lib.rs"
 
 [features]
-default = ["edition-2015"]
+default = ["edition-2015", "std"]
 edition-2015 = []
+std = []
 
 [dependencies]
+anyhow = "1"
 bytes = "0.5"
 cfg-if = "0.1"
 prost = { path = ".." }

--- a/tests-no-std/Cargo.toml
+++ b/tests-no-std/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "tests-no-std"
+version = "0.0.0"
+authors = ["Dan Burkert <dan@danburkert.com>"]
+publish = false
+edition = "2018"
+
+build = "../tests/src/build.rs"
+
+[lib]
+doctest = false
+path = "../tests/src/lib.rs"
+
+# Compile the `tests` crate *without* the std feature, which is implicitly
+# omitted from the default crate features. It would be easier to do something
+# like `cargo test -p tests --no-default-features`, but that currently does not
+# do the right thing (see [1] for more context).
+# [1]: https://github.com/rust-lang/cargo/pull/8074
+
+[dependencies]
+anyhow = { version = "1", default-features = false }
+bytes = { version = "0.5", default-features = false }
+cfg-if = "0.1"
+prost = { path = "..", default-features = false, features = ["prost-derive"] }
+prost-types = { path = "../prost-types", default-features = false }
+protobuf = { path = "../protobuf" }
+
+[dev-dependencies]
+diff = "0.1"
+prost-build = { path = "../prost-build" }
+tempfile = "3"
+
+[build-dependencies]
+cfg-if = "0.1"
+env_logger = { version = "0.7", default-features = false }
+prost-build = { path = "../prost-build" }
+protobuf = { path = "../protobuf" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,7 +10,12 @@ build = "src/build.rs"
 [lib]
 doctest = false
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
+anyhow = "1"
 bytes = "0.5"
 cfg-if = "0.1"
 prost = { path = ".." }

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -1,5 +1,6 @@
 // protoc on Windows outputs \r\n line endings.
 #![cfg(not(target_os = "windows"))]
+#![cfg(feature = "std")]
 
 use std::fs;
 use std::io::Read;

--- a/tests/src/debug.rs
+++ b/tests/src/debug.rs
@@ -3,11 +3,16 @@
 //! The tests check against expected output. This may be a bit fragile, but it is likely OK for
 //! actual use.
 
+use prost::alloc::{format, string::String};
+
 // Borrow some types from other places.
-use crate::message_encoding::{Basic, BasicEnumeration};
+#[cfg(feature = "std")]
+use crate::message_encoding::Basic;
+use crate::message_encoding::BasicEnumeration;
 
 /// Some real-life message
 #[test]
+#[cfg(feature = "std")]
 fn basic() {
     let mut basic = Basic::default();
     assert_eq!(

--- a/tests/src/deprecated_field.rs
+++ b/tests/src/deprecated_field.rs
@@ -1,3 +1,5 @@
+use alloc::string::ToString;
+
 mod deprecated_field {
     // #![deny(unused_results)]
     include!(concat!(env!("OUT_DIR"), "/deprecated_field.rs"));

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -1,3 +1,4 @@
+use prost::alloc::{borrow::ToOwned, string::String, vec, vec::Vec};
 use prost::{Enumeration, Message, Oneof};
 
 use crate::check_message;
@@ -200,7 +201,7 @@ fn check_tags_inferred() {
         three: vec![0.0, 1.0, 1.0],
         skip_to_nine: "nine".to_owned(),
         ten: 0,
-        eleven: ::std::collections::HashMap::new(),
+        eleven: ::alloc::collections::BTreeMap::new(),
         back_to_five: vec![1, 0, 1],
         six: Basic::default(),
     };
@@ -214,7 +215,7 @@ fn check_tags_inferred() {
         six: Basic::default(),
         nine: "nine".to_owned(),
         ten: 0,
-        eleven: ::std::collections::HashMap::new(),
+        eleven: ::alloc::collections::BTreeMap::new(),
     };
     check_serialize_equivalent(&tags_inferred, &tags_qualified);
 }
@@ -232,8 +233,8 @@ pub struct TagsInferred {
     pub skip_to_nine: String,
     #[prost(enumeration = "BasicEnumeration", default = "ONE")]
     pub ten: i32,
-    #[prost(map = "string, string")]
-    pub eleven: ::std::collections::HashMap<String, String>,
+    #[prost(btree_map = "string, string")]
+    pub eleven: ::alloc::collections::BTreeMap<String, String>,
 
     #[prost(tag = "5", bytes)]
     pub back_to_five: Vec<u8>,
@@ -259,8 +260,8 @@ pub struct TagsQualified {
     pub nine: String,
     #[prost(tag = "10", enumeration = "BasicEnumeration", default = "ONE")]
     pub ten: i32,
-    #[prost(tag = "11", map = "string, string")]
-    pub eleven: ::std::collections::HashMap<String, String>,
+    #[prost(tag = "11", btree_map = "string, string")]
+    pub eleven: ::alloc::collections::BTreeMap<String, String>,
 }
 
 /// A prost message with default value.
@@ -324,16 +325,18 @@ pub struct Basic {
     pub enumeration: i32,
 
     #[prost(map = "int32, enumeration(BasicEnumeration)", tag = "6")]
+    #[cfg(feature = "std")]
     pub enumeration_map: ::std::collections::HashMap<i32, i32>,
 
     #[prost(hash_map = "string, string", tag = "7")]
+    #[cfg(feature = "std")]
     pub string_map: ::std::collections::HashMap<String, String>,
 
     #[prost(btree_map = "int32, enumeration(BasicEnumeration)", tag = "10")]
-    pub enumeration_btree_map: ::std::collections::BTreeMap<i32, i32>,
+    pub enumeration_btree_map: prost::alloc::collections::BTreeMap<i32, i32>,
 
     #[prost(btree_map = "string, string", tag = "11")]
-    pub string_btree_map: ::std::collections::BTreeMap<String, String>,
+    pub string_btree_map: prost::alloc::collections::BTreeMap<String, String>,
 
     #[prost(oneof = "BasicOneof", tags = "8, 9")]
     pub oneof: Option<BasicOneof>,
@@ -351,10 +354,11 @@ pub struct Compound {
     pub repeated_message: Vec<Basic>,
 
     #[prost(map = "sint32, message", tag = "4")]
+    #[cfg(feature = "std")]
     pub message_map: ::std::collections::HashMap<i32, Basic>,
 
     #[prost(btree_map = "sint32, message", tag = "5")]
-    pub message_btree_map: ::std::collections::BTreeMap<i32, Basic>,
+    pub message_btree_map: prost::alloc::collections::BTreeMap<i32, Basic>,
 }
 
 #[derive(Clone, PartialEq, Oneof)]

--- a/tests/src/unittest.rs
+++ b/tests/src/unittest.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::float_cmp)]
 
+use core::{f32, f64};
+
+use protobuf::test_messages::protobuf_unittest;
+
 #[test]
 fn extreme_default_values() {
-    use protobuf::test_messages::protobuf_unittest;
-    use std::{f32, f64};
-
     let pb = protobuf_unittest::TestExtremeDefaultValues::default();
 
     assert_eq!(


### PR DESCRIPTION
This PR adds a new `std` feature to the `prost` and `prost-types`
crates, which is enabled by default. Additionally, the `prost-build` and
`prost-derive` crates have been updated to emit no-std compatible code.

This is a breaking change for edition-2015 crates, which are likely to
now require an `extern crate core;` directive when including
`prost`-generated code.

Co-authored-by: Chris Beck <beck.ct@gmail.com>
Co-authored-by: Dan Burkert <dan@danburkert.com>
Co-authored-by: David Flemström <david.flemstrom@gmail.com>