### PR TITLE
CI: update to checkout@v2

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -24,7 +24,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: install toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
It appears PR retries were failing due to (presumably)
https://github.com/actions/checkout/issues/23.