### PR TITLE
fix proto2 enumeration field default case transform

### DIFF
--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -1,4 +1,3 @@
-use prost_types;
 use prost_types::source_code_info::Location;
 
 /// Comments on a Protobuf item.

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -349,11 +349,12 @@ impl<'a> CodeGenerator<'a> {
                         .as_ref()
                         .and_then(|ty| ty.split('.').last())
                         .unwrap();
-                    strip_enum_prefix(enum_type, &enum_value)
+
+                    strip_enum_prefix(&to_upper_camel(&enum_type), &enum_value)
                 } else {
-                    default
+                    &enum_value
                 };
-                self.buf.push_str(&to_upper_camel(stripped_prefix));
+                self.buf.push_str(stripped_prefix);
             } else {
                 // TODO: this is only correct if the Protobuf escaping matches Rust escaping. To be
                 // safer, we should unescape the Protobuf string and re-escape it with the Rust

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -692,7 +692,6 @@ pub fn protoc_include() -> &'static Path {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use env_logger;
     use std::cell::RefCell;
     use std::rc::Rc;
 

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -1,7 +1,3 @@
-use prost_build;
-
-use tempfile;
-
 use std::env;
 use std::fs;
 use std::io::Cursor;

--- a/tests/src/default_enum_value.proto
+++ b/tests/src/default_enum_value.proto
@@ -16,3 +16,11 @@ message Test {
   optional PrivacyLevel privacy_level_3 = 2 [default = PRIVACY_LEVEL_PRIVACY_LEVEL_THREE];
   optional PrivacyLevel privacy_level_4 = 3 [default = PRIVACY_LEVELPRIVACY_LEVEL_FOUR];
 }
+
+// danburkert/prost#310
+enum ERemoteClientBroadcastMsg {
+    k_ERemoteClientBroadcastMsgDiscovery = 0;
+}
+message CMsgRemoteClientBroadcastHeader {
+    optional ERemoteClientBroadcastMsg msg_type = 2 [default = k_ERemoteClientBroadcastMsgDiscovery];
+}

--- a/tests/src/unittest.rs
+++ b/tests/src/unittest.rs
@@ -1,3 +1,4 @@
+#![cfg(test)]
 #![allow(clippy::float_cmp)]
 
 use core::{f32, f64};


### PR DESCRIPTION
Fixes #310

Fixes an instances where setting a default field value to an enum variant with an 'untraditional' casing would cause a miscompile.

This is technically a breaking change, but it's unlikely that any affected programs would succeed to compile previously, so low impact.