### PR TITLE
Remove the check for existing protoc at build time (#283)

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -680,13 +680,19 @@ where
 }
 
 /// Returns the path to the `protoc` binary.
-pub fn protoc() -> &'static Path {
-    Path::new(env!("PROTOC"))
+pub fn protoc() -> PathBuf {
+    match env::var_os("PROTOC") {
+        Some(protoc) => PathBuf::from(protoc),
+        None => PathBuf::from(env!("PROTOC")),
+    }
 }
 
 /// Returns the path to the Protobuf include directory.
-pub fn protoc_include() -> &'static Path {
-    Path::new(env!("PROTOC_INCLUDE"))
+pub fn protoc_include() -> PathBuf {
+    match env::var_os("PROTOC_INCLUDE") {
+        Some(include) => PathBuf::from(include),
+        None => PathBuf::from(env!("PROTOC_INCLUDE")),
+    }
 }
 
 #[cfg(test)]

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -14,7 +14,7 @@ use tempfile;
 /// repo. Ensures that the checked-in compiled versions are up-to-date.
 #[test]
 fn bootstrap() {
-    let protobuf = Path::new(prost_build::protoc_include())
+    let protobuf = prost_build::protoc_include()
         .join("google")
         .join("protobuf");
 


### PR DESCRIPTION
This to allow setting `PROTOC=protoc`, which in turn allows for using a `protoc` found in `PATH`.

This is a breaking change.