### PR TITLE
prost-build: fix compilation error when using --no-default-features

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -99,3 +99,13 @@ jobs:
         with:
           command: no-std-check
           args: --manifest-path prost-types/Cargo.toml --no-default-features
+      # prost-build depends on prost with --no-default-features, but when
+      # prost-build is built through the workspace, prost typically has default
+      # features enabled due to vagaries in Cargo workspace feature resolution.
+      # This additional check ensures that prost-build does not rely on any of
+      # prost's default features to compile.
+      - name: prost-build check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path prost-build/Cargo.toml

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -551,7 +551,12 @@ impl Config {
         }
 
         let buf = fs::read(descriptor_set)?;
-        let descriptor_set = FileDescriptorSet::decode(&*buf)?;
+        let descriptor_set = FileDescriptorSet::decode(&*buf).map_err(|error| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                format!("invalid FileDescriptorSet: {}", error.to_string()),
+            )
+        })?;
 
         let modules = self.generate(descriptor_set.file)?;
         for (module, content) in modules {


### PR DESCRIPTION
Fixes a prost-build compile failure when its built in isolation.