### PR TITLE
Include Message Proto information

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -117,6 +117,7 @@ impl<'a> CodeGenerator<'a> {
         debug!("  message: {:?}", message.name());
 
         let message_name = message.name().to_string();
+        let package_name = self.package.clone();
         let fq_message_name = format!(".{}.{}", self.package, message.name());
 
         // Skip external types.
@@ -175,6 +176,8 @@ impl<'a> CodeGenerator<'a> {
         self.push_indent();
         self.buf
             .push_str("#[derive(Clone, PartialEq, ::prost::Message)]\n");
+        self.push_indent();
+        self.buf.push_str(format!("#[prost(package=\"{}\")]\n", package_name).as_str());
         self.push_indent();
         self.buf.push_str("pub struct ");
         self.buf.push_str(&to_upper_camel(&message_name));

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -1,5 +1,6 @@
 /// The version number of protocol compiler.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf.compiler")]
 pub struct Version {
     #[prost(int32, optional, tag="1")]
     pub major: ::core::option::Option<i32>,
@@ -14,6 +15,7 @@ pub struct Version {
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf.compiler")]
 pub struct CodeGeneratorRequest {
     /// The .proto files that were explicitly listed on the command-line.  The
     /// code generator should generate code only for these files.  Each file's
@@ -45,6 +47,7 @@ pub struct CodeGeneratorRequest {
 }
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf.compiler")]
 pub struct CodeGeneratorResponse {
     /// Error message.  If non-empty, code generation failed.  The plugin process
     /// should exit with status code zero even if it reports an error in this way.
@@ -63,6 +66,7 @@ pub struct CodeGeneratorResponse {
 pub mod code_generator_response {
     /// Represents a single generated file.
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.compiler.CodeGeneratorResponse")]
     pub struct File {
         /// The file name, relative to the output directory.  The name must not
         /// contain "." or ".." components and must be relative, not be absolute (so,

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1,12 +1,14 @@
 /// The protocol compiler can output a FileDescriptorSet containing the .proto
 /// files it parses.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag="1")]
     pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag="1")]
@@ -48,6 +50,7 @@ pub struct FileDescriptorProto {
 }
 /// Describes a message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct DescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -75,6 +78,7 @@ pub struct DescriptorProto {
 /// Nested message and enum types in `DescriptorProto`.
 pub mod descriptor_proto {
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.DescriptorProto")]
     pub struct ExtensionRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -89,6 +93,7 @@ pub mod descriptor_proto {
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.DescriptorProto")]
     pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -99,6 +104,7 @@ pub mod descriptor_proto {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
@@ -106,6 +112,7 @@ pub struct ExtensionRangeOptions {
 }
 /// Describes a field within a message.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -197,6 +204,7 @@ pub mod field_descriptor_proto {
 }
 /// Describes a oneof.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -205,6 +213,7 @@ pub struct OneofDescriptorProto {
 }
 /// Describes an enum type.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -231,6 +240,7 @@ pub mod enum_descriptor_proto {
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.EnumDescriptorProto")]
     pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -242,6 +252,7 @@ pub mod enum_descriptor_proto {
 }
 /// Describes a value within an enum.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -252,6 +263,7 @@ pub struct EnumValueDescriptorProto {
 }
 /// Describes a service.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -262,6 +274,7 @@ pub struct ServiceDescriptorProto {
 }
 /// Describes a method of a service.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -313,6 +326,7 @@ pub struct MethodDescriptorProto {
 //   to automatically assign option numbers.
 
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FileOptions {
     /// Sets the Java package where classes generated from this .proto will be
     /// placed.  By default, the proto package is used, but this is often
@@ -438,6 +452,7 @@ pub mod file_options {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct MessageOptions {
     /// Set true to use the old proto1 MessageSet wire format for extensions.
     /// This is provided for backwards-compatibility with the MessageSet wire
@@ -498,6 +513,7 @@ pub struct MessageOptions {
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FieldOptions {
     /// The ctype option instructs the C++ code generator to use a different
     /// representation of the field than it normally would.  See the specific
@@ -590,12 +606,14 @@ pub mod field_options {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
@@ -612,6 +630,7 @@ pub struct EnumOptions {
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct EnumValueOptions {
     /// Is this enum value deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -624,6 +643,7 @@ pub struct EnumValueOptions {
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct ServiceOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -641,6 +661,7 @@ pub struct ServiceOptions {
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct MethodOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -681,6 +702,7 @@ pub mod method_options {
 /// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 /// in them.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag="2")]
     pub name: ::prost::alloc::vec::Vec<uninterpreted_option::NamePart>,
@@ -707,6 +729,7 @@ pub mod uninterpreted_option {
     /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
     /// "foo.(bar.baz).qux".
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.UninterpretedOption")]
     pub struct NamePart {
         #[prost(string, required, tag="1")]
         pub name_part: ::prost::alloc::string::String,
@@ -720,6 +743,7 @@ pub mod uninterpreted_option {
 /// Encapsulates information about the original source file from which a
 /// FileDescriptorProto was generated.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct SourceCodeInfo {
     /// A Location identifies a piece of source code in a .proto file which
     /// corresponds to a particular definition.  This information is intended
@@ -770,6 +794,7 @@ pub struct SourceCodeInfo {
 /// Nested message and enum types in `SourceCodeInfo`.
 pub mod source_code_info {
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.SourceCodeInfo")]
     pub struct Location {
         /// Identifies which part of the FileDescriptorProto was defined at this
         /// location.
@@ -862,6 +887,7 @@ pub mod source_code_info {
 /// file. A GeneratedCodeInfo message is associated with only one generated
 /// source file, but may contain references to different source .proto files.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
@@ -871,6 +897,7 @@ pub struct GeneratedCodeInfo {
 /// Nested message and enum types in `GeneratedCodeInfo`.
 pub mod generated_code_info {
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.GeneratedCodeInfo")]
     pub struct Annotation {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
@@ -971,6 +998,7 @@ pub mod generated_code_info {
 ///     }
 ///
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Any {
     /// A URL/resource name that uniquely identifies the type of the serialized
     /// protocol buffer message. This string must contain at least
@@ -1009,6 +1037,7 @@ pub struct Any {
 /// `SourceContext` represents information about the source of a
 /// protobuf element, like the file in which it is defined.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
@@ -1017,6 +1046,7 @@ pub struct SourceContext {
 }
 /// A protocol buffer message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Type {
     /// The fully qualified message name.
     #[prost(string, tag="1")]
@@ -1039,6 +1069,7 @@ pub struct Type {
 }
 /// A single field of a message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Field {
     /// The field type.
     #[prost(enumeration="field::Kind", tag="1")]
@@ -1134,6 +1165,7 @@ pub mod field {
 }
 /// Enum type definition.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Enum {
     /// Enum type name.
     #[prost(string, tag="1")]
@@ -1153,6 +1185,7 @@ pub struct Enum {
 }
 /// Enum value definition.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct EnumValue {
     /// Enum value name.
     #[prost(string, tag="1")]
@@ -1167,6 +1200,7 @@ pub struct EnumValue {
 /// A protocol buffer option, which can be attached to a message, field,
 /// enumeration, etc.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Option {
     /// The option's name. For protobuf built-in options (options defined in
     /// descriptor.proto), this is the short name. For example, `"map_entry"`.
@@ -1200,6 +1234,7 @@ pub enum Syntax {
 /// this message itself. See https://cloud.google.com/apis/design/glossary for
 /// detailed terminology.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
@@ -1247,6 +1282,7 @@ pub struct Api {
 }
 /// Method represents a method of an API interface.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Method {
     /// The simple name of this method.
     #[prost(string, tag="1")]
@@ -1349,6 +1385,7 @@ pub struct Method {
 ///       ...
 ///     }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
     #[prost(string, tag="1")]
@@ -1419,6 +1456,7 @@ pub struct Mixin {
 ///
 ///
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
@@ -1634,6 +1672,7 @@ pub struct Duration {
 /// request should verify the included field paths, and return an
 /// `INVALID_ARGUMENT` error if any path is unmappable.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag="1")]
@@ -1648,6 +1687,7 @@ pub struct FieldMask {
 ///
 /// The JSON representation for `Struct` is JSON object.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map="string, message", tag="1")]
@@ -1660,6 +1700,7 @@ pub struct Struct {
 ///
 /// The JSON representation for `Value` is JSON value.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Value {
     /// The kind of value.
     #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
@@ -1694,6 +1735,7 @@ pub mod value {
 ///
 /// The JSON representation for `ListValue` is JSON array.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct ListValue {
     /// Repeated field of dynamically typed values.
     #[prost(message, repeated, tag="1")]
@@ -1794,6 +1836,7 @@ pub enum NullValue {
 ///
 ///
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod encoding;
 
 pub use crate::error::{DecodeError, EncodeError};
 pub use crate::message::Message;
+pub use crate::message::MessageProto;
 
 use bytes::{Buf, BufMut};
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -165,3 +165,9 @@ where
         (**self).clear()
     }
 }
+
+pub trait MessageProto: Message + 'static {
+    fn message_name(&self) -> &'static str;
+    fn package_name(&self) -> &'static str;
+    fn type_url(&self) -> &'static str;
+}

--- a/tests/src/well_known_types.rs
+++ b/tests/src/well_known_types.rs
@@ -1,3 +1,4 @@
+use prost::MessageProto;
 include!(concat!(env!("OUT_DIR"), "/well_known_types.rs"));
 
 #[test]
@@ -11,4 +12,19 @@ fn test_well_known_types() {
     };
 
     crate::check_message(&msg);
+}
+
+#[test]
+fn test_message_proto() {
+    let msg = Foo {
+        null: ::prost_types::NullValue::NullValue.into(),
+        timestamp: Some(::prost_types::Timestamp {
+            seconds: 99,
+            nanos: 42,
+        }),
+    };
+
+    assert_eq!(msg.message_name(), "Foo");
+    assert_eq!(msg.package_name(), "well_known_types");
+    assert_eq!(msg.type_url(), "type.googleapis.com/well_known_types.Foo");
 }


### PR DESCRIPTION
A new trait `MessageProto` which includes the following info about a message:
 - `package_name` which is taken from the `package` field in the proto file;
 - `message_name` which is the message name itself;
 - `type_url` which is "type.googleapis.com/" + package_name + "." + message_name;

 The prefix "type.googleapis.com" is the default prefix for all protobuf types (see [here](https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/Any)).

 Adding the MessageProto trait will help with the packing and unpacking of messages in the `Any` type, but may be helpful in other situations as well, and can easily be extended to include more proto information in future (e.g. source file etc).

This pull request can address #277 completely as it will allow an external crate to provide all the functionalities without "polluting" the `prost` crate with additional dependencies. For an external crate that provides all the functionality described in #277, see [prost-wkt](https://github.com/fdeantoni/prost-wkt).
