### PR TITLE
Remove testing of Rust 1.39

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -46,7 +46,6 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.39.0
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
Master branch doesn't build on Rust 1.39, incoming PRs shouldn't be tested against it. (It did build at one point but if you delete your Cargo.lock you'll see it doesn't anymore)