### PR TITLE
prost-build: (docs) adds NixOS related hints

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -112,8 +112,8 @@
 //!
 //! ```bash
 //! $ export PROTOBUF_LOCATION=$(nix-env -q protobuf --out-path --no-name)
-//! $ export PROTOC=$(PROTOBUF_LOCATION)/bin/protoc
-//! $ export PROTOC_INCLUDE=$(PROTOBUF_LOCATION)/include
+//! $ export PROTOC=$PROTOBUF_LOCATION/bin/protoc
+//! $ export PROTOC_INCLUDE=$PROTOBUF_LOCATION/include
 //! $ cargo build
 //! ```
 //!

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -113,7 +113,7 @@
 //! ```bash
 //! $ export PROTOBUF_LOCATION=$(nix-env -q protobuf --out-path --no-name)
 //! $ export PROTOC=$(PROTOBUF_LOCATION)/bin/protoc
-//! $ export PROTOC_INCLUDE=$($PROTOBUF_LOCATION)/include
+//! $ export PROTOC_INCLUDE=$(PROTOBUF_LOCATION)/include
 //! $ cargo build
 //! ```
 //!

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -111,8 +111,9 @@
 //! On NixOS, it is better to specify the location of `PROTOC` and `PROTOC_INCLUDE` explicitly.
 //!
 //! ```bash
-//! $ export PROTOC=/nix/store/<SHA>-protobuf/bin/protoc
-//! $ export PROTOC_INCLUDE=/nix/store/<SHA>-protobuf/include
+//! $ export PROTOBUF_LOCATION=$(nix-env -q protobuf --out-path --no-name)
+//! $ export PROTOC=$(PROTOBUF_LOCATION)/bin/protoc
+//! $ export PROTOC_INCLUDE=$($PROTOBUF_LOCATION)/include
 //! $ cargo build
 //! ```
 //!

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -105,6 +105,20 @@
 //!
 //! If `PROTOC_INCLUDE` is not found in the environment, then the Protobuf include directory bundled
 //! in the prost-build crate is be used.
+//!
+//! ### NixOS related hints
+//!
+//! On NixOS, it is better to specify the location of `PROTOC` and `PROTOC_INCLUDE` explicitly.
+//!
+//! ```bash
+//! $ export PROTOC=/nix/store/<SHA>-protobuf/bin/protoc
+//! $ export PROTOC_INCLUDE=/nix/store/<SHA>-protobuf/include
+//! $ cargo build
+//! ```
+//!
+//! The reason being that if `prost_build::compile_protos` fails to generate the resultant package,
+//! the failure is not obvious until the `include!(concat!(env!("OUT_DIR"), "/resultant.rs"));`
+//! fails with `No such file or directory` error.
 
 mod ast;
 mod code_generator;


### PR DESCRIPTION
On NixOS, it is better to explicitly define Protobuf related
environment variables `PROTOC` and `PROTOC_INCLUDE`.