### PR TITLE
Do not force an unnecessary Sized bound

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -369,6 +369,7 @@ pub fn merge_loop<T, M, B>(
 where
     M: FnMut(&mut T, &mut B, DecodeContext) -> Result<(), DecodeError>,
     B: Buf,
+    T: ?Sized,
 {
     let len = decode_varint(buf)?;
     let remaining = buf.remaining();
@@ -1048,7 +1049,7 @@ pub mod message {
         ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
-        M: Message,
+        M: Message + ?Sized,
         B: Buf,
     {
         check_wire_type(WireType::LengthDelimited, wire_type)?;

--- a/src/message.rs
+++ b/src/message.rs
@@ -20,8 +20,7 @@ pub trait Message: Debug + Send + Sync {
     #[doc(hidden)]
     fn encode_raw<B>(&self, buf: &mut B)
     where
-        B: BufMut,
-        Self: Sized;
+        B: BufMut;
 
     /// Decodes a field from a buffer, and merges it into `self`.
     ///
@@ -35,8 +34,7 @@ pub trait Message: Debug + Send + Sync {
         ctx: DecodeContext,
     ) -> Result<(), DecodeError>
     where
-        B: Buf,
-        Self: Sized;
+        B: Buf;
 
     /// Returns the encoded length of the message without a length delimiter.
     fn encoded_len(&self) -> usize;
@@ -47,7 +45,6 @@ pub trait Message: Debug + Send + Sync {
     fn encode<B>(&self, buf: &mut B) -> Result<(), EncodeError>
     where
         B: BufMut,
-        Self: Sized,
     {
         let required = self.encoded_len();
         let remaining = buf.remaining_mut();
@@ -65,7 +62,6 @@ pub trait Message: Debug + Send + Sync {
     fn encode_length_delimited<B>(&self, buf: &mut B) -> Result<(), EncodeError>
     where
         B: BufMut,
-        Self: Sized,
     {
         let len = self.encoded_len();
         let required = len + encoded_len_varint(len as u64);
@@ -107,7 +103,6 @@ pub trait Message: Debug + Send + Sync {
     fn merge<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
     where
         B: Buf,
-        Self: Sized,
     {
         let ctx = DecodeContext::default();
         while buf.has_remaining() {
@@ -122,7 +117,6 @@ pub trait Message: Debug + Send + Sync {
     fn merge_length_delimited<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
     where
         B: Buf,
-        Self: Sized,
     {
         message::merge(
             WireType::LengthDelimited,


### PR DESCRIPTION
This allows users to call `Message` methods on `&(dyn Message)`.