### PR TITLE
Update bytes to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ no-recursion-limit = []
 std = []
 
 [dependencies]
-bytes = { version = "0.5", default-features = false }
+bytes = { version = "0.6", default-features = false }
 prost-derive = { version = "0.6.1", path = "prost-derive", optional = true }
 
 [dev-dependencies]

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "0.5"
+bytes = "0.6"
 env_logger = { version = "0.7", default-features = false }
 log = "0.4"
 prost = { path = ".." }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -10,7 +10,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2018"
 
 [dependencies]
-bytes = { version = "0.5", default-features = false }
+bytes = { version = "0.6", default-features = false }
 heck = "0.3"
 itertools = "0.9"
 log = "0.4"

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 std = ["prost/std"]
 
 [dependencies]
-bytes = { version = "0.5", default-features = false }
+bytes = { version = "0.6", default-features = false }
 prost = { version = "0.6.1", path = "..", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = { version = "0.5", default-features = false }
+bytes = { version = "0.6", default-features = false }
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }
 

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -18,7 +18,7 @@ std = []
 
 [dependencies]
 anyhow = "1"
-bytes = "0.5"
+bytes = "0.6"
 cfg-if = "0.1"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }

--- a/tests-no-std/Cargo.toml
+++ b/tests-no-std/Cargo.toml
@@ -19,7 +19,7 @@ path = "../tests/src/lib.rs"
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
-bytes = { version = "0.5", default-features = false }
+bytes = { version = "0.6", default-features = false }
 cfg-if = "0.1"
 prost = { path = "..", default-features = false, features = ["prost-derive"] }
 prost-types = { path = "../prost-types", default-features = false }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -16,7 +16,7 @@ std = []
 
 [dependencies]
 anyhow = "1"
-bytes = "0.5"
+bytes = "0.6"
 cfg-if = "0.1"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }


### PR DESCRIPTION
This change updates the `bytes` crate dependencies to version 0.6.

Fixes https://github.com/danburkert/prost/issues/380