### PR TITLE
deps: require `curl < 0.4.34` to fix MSRV

### DIFF
--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -13,7 +13,9 @@ prost-types = { path = "../prost-types" }
 [build-dependencies]
 anyhow = "1"
 cfg-if = "0.1"
-curl = "0.4"
+# curl 0.4.34 requires Rust 1.40 or higher:
+# https://github.com/alexcrichton/curl-rust/pull/356/files#r498918694
+curl = "0.4, < 0.4.34"
 flate2 = "1.0"
 prost-build = { path = "../prost-build" }
 tar = "0.4"


### PR DESCRIPTION
Builds are failing on unrelated pull requests (e.g., #326) because the
`curl` crate has pushed a new version that depends on Rust 1.40, while
our CI tests against 1.39. We could probably bump to require 1.40 as
well, especially since we want to use the same `#[non_exhaustive]`
attribute, per #43. But a minimal change to unblock development and keep
the current minimum stable Rust version is to just pin `curl < 0.4.34`.

Test Plan:
Running `cargo +1.39.0 test --workspace --all-targets` passes on my
Linux machine.

wchargin-branch: deps-curl-pre-0.4.34
