### PR TITLE
Add support for experimental proto3 optional field presence

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -115,6 +115,7 @@ mod message_graph;
 use std::collections::HashMap;
 use std::default;
 use std::env;
+use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::fs;
 use std::io::{Error, ErrorKind, Result};
@@ -191,6 +192,7 @@ pub struct Config {
     strip_enum_prefix: bool,
     out_dir: Option<PathBuf>,
     extern_paths: Vec<(String, String)>,
+    protoc_args: Vec<OsString>,
 }
 
 impl Config {
@@ -543,6 +545,28 @@ impl Config {
         self
     }
 
+    /// Add an argument to the `protoc` protobuf compilation invocation.
+    ///
+    /// # Example `build.rs`
+    ///
+    /// ```rust,no_run
+    /// # use std::io::Result;
+    /// fn main() -> Result<()> {
+    ///   let mut prost_build = prost_build::Config::new();
+    ///   // Enable a protoc experimental feature.
+    ///   prost_build.protoc_arg("--experimental_allow_proto3_optional");
+    ///   prost_build.compile_protos(&["src/frontend.proto", "src/backend.proto"], &["src"])?;
+    ///   Ok(())
+    /// }
+    /// ```
+    pub fn protoc_arg<S>(&mut self, arg: S) -> &mut Self
+    where
+        S: AsRef<OsStr>,
+    {
+        self.protoc_args.push(arg.as_ref().to_owned());
+        self
+    }
+
     /// Compile `.proto` files into Rust files during a Cargo build with additional code generator
     /// configuration options.
     ///
@@ -595,6 +619,10 @@ impl Config {
         // Set the protoc include after the user includes in case the user wants to
         // override one of the built-in .protos.
         cmd.arg("-I").arg(protoc_include());
+
+        for arg in &self.protoc_args {
+            cmd.arg(arg);
+        }
 
         for proto in protos {
             cmd.arg(proto.as_ref());
@@ -691,6 +719,7 @@ impl default::Default for Config {
             strip_enum_prefix: true,
             out_dir: None,
             extern_paths: Vec::new(),
+            protoc_args: Vec::new(),
         }
     }
 }

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -82,6 +82,11 @@ fn main() {
         .unwrap();
 
     config
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile_protos(&[src.join("proto3_presence.proto")], includes)
+        .unwrap();
+
+    config
         .compile_protos(&[src.join("well_known_types.proto")], includes)
         .unwrap();
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -87,6 +87,12 @@ pub mod groups {
     include!(concat!(env!("OUT_DIR"), "/groups.rs"));
 }
 
+pub mod proto3 {
+    pub mod presence {
+        include!(concat!(env!("OUT_DIR"), "/proto3.presence.rs"));
+    }
+}
+
 use alloc::format;
 use alloc::vec::Vec;
 
@@ -579,5 +585,12 @@ mod tests {
         check_message(&msg);
 
         check_message(&groups::OneofGroup::default());
+    }
+
+    #[test]
+    fn test_proto3_presence() {
+        let msg = proto3::presence::A { b: Some(42) };
+
+        check_message(&msg);
     }
 }

--- a/tests/src/proto3_presence.proto
+++ b/tests/src/proto3_presence.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package proto3.presence;
+
+message A {
+  optional int32 b = 1;
+}


### PR DESCRIPTION
Adds support for the new experimental
[proto3 optional primitive field][1] feature. Since this is an
experimental feature, it requires providing a flag to `protoc`, which is
enabled through a new `prost-build::Config::protoc_arg` API. To use the
new API, mark the primitive field `optional` as with proto2, and then
enable the experimental feature, see `protoc_arg` docs.

[1]: https://github.com/protocolbuffers/protobuf/blob/master/docs/field_presence.md