### PR TITLE
Add well-known-type wrappers test

### DIFF
--- a/prost-build/src/extern_paths.rs
+++ b/prost-build/src/extern_paths.rs
@@ -37,7 +37,7 @@ impl ExternPaths {
             extern_paths.insert(".google.protobuf.BoolValue".to_string(), "bool".to_string())?;
             extern_paths.insert(
                 ".google.protobuf.BytesValue".to_string(),
-                "::std::vec::Vec<u8>".to_string(),
+                "::prost::alloc::vec::Vec<u8>".to_string(),
             )?;
             extern_paths.insert(
                 ".google.protobuf.DoubleValue".to_string(),
@@ -49,7 +49,7 @@ impl ExternPaths {
             extern_paths.insert(".google.protobuf.Int64Value".to_string(), "i64".to_string())?;
             extern_paths.insert(
                 ".google.protobuf.StringValue".to_string(),
-                "::std::string::String".to_string(),
+                "::prost::alloc::string::String".to_string(),
             )?;
             extern_paths.insert(
                 ".google.protobuf.UInt32Value".to_string(),

--- a/tests/src/well_known_types.proto
+++ b/tests/src/well_known_types.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 
 package well_known_types;
 
@@ -10,4 +11,22 @@ message Foo {
     google.protobuf.NullValue null = 1;
     // message
     google.protobuf.Timestamp timestamp = 2;
+
+    google.protobuf.DoubleValue double = 3;
+
+    google.protobuf.FloatValue float = 4;
+
+    google.protobuf.Int64Value int64 = 5;
+
+    google.protobuf.UInt64Value uint64 = 6;
+
+    google.protobuf.Int32Value int32 = 7;
+
+    google.protobuf.UInt32Value uint32 = 8;
+
+    google.protobuf.BoolValue bool = 9;
+
+    google.protobuf.StringValue string = 10;
+
+    google.protobuf.BytesValue bytes = 11;
 }

--- a/tests/src/well_known_types.rs
+++ b/tests/src/well_known_types.rs
@@ -8,6 +8,15 @@ fn test_well_known_types() {
             seconds: 99,
             nanos: 42,
         }),
+        double: Some(42.0_f64),
+        float: Some(42.0_f32),
+        int64: Some(42_i64),
+        uint64: Some(42_u64),
+        int32: Some(42_i32),
+        uint32: Some(42_u32),
+        bool: Some(false),
+        string: Some("value".to_owned()),
+        bytes: Some(b"value".to_vec()),
     };
 
     crate::check_message(&msg);

--- a/tests/src/well_known_types.rs
+++ b/tests/src/well_known_types.rs
@@ -15,7 +15,7 @@ fn test_well_known_types() {
         int32: Some(42_i32),
         uint32: Some(42_u32),
         bool: Some(false),
-        string: Some("value".to_owned()),
+        string: Some("value".into()),
         bytes: Some(b"value".to_vec()),
     };
 


### PR DESCRIPTION
Checks that the well-known-type primitive wrappers retain optional-ness.