### PR TITLE
Add bundled support for Mac aarch64 through Rosetta

### DIFF
--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -42,6 +42,7 @@ fn bundled_protoc() -> Option<PathBuf> {
         ("linux", "x86_64") => "protoc-linux-x86_64",
         ("linux", "aarch64") => "protoc-linux-aarch_64",
         ("macos", "x86_64") => "protoc-osx-x86_64",
+        ("macos", "aarch64") => "protoc-osx-x86_64", // will be translated to aarch64 by Rosetta
         ("windows", _) => "protoc-win32.exe",
         _ => return None,
     };


### PR DESCRIPTION
Enable usage of bundled `protoc` when building for Mac on Apple Silicon (aarch64) by simply re-using the existing x86_64 OS X binary and have Rosetta seamlessly translate it.

One could later replace this with a natively compiled OS X aarch64 binary, but this was a quick easy solution and Rosetta is really quite efficient so likely is good enough for most.

Fix #393