### PR TITLE
Update `seanmiddleditch/gha-setup-ninja` to v3

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -61,7 +61,7 @@ jobs:
             default: true
             profile: minimal
       - name: install ninja
-        uses: seanmiddleditch/gha-setup-ninja@v1
+        uses: seanmiddleditch/gha-setup-ninja@v3
       - name: test
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
This commit updates the use of seanmiddleditch/gha-setup-ninja in the CI pipeline to v3 from v1, which should remove the use of set-path, which was deprecated by GitHub.

This should allow builds to proceed in GitHub Actions.