### PR TITLE
Make DecodeError::new public

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -30,8 +30,9 @@ impl DecodeError {
     /// Creates a new `DecodeError` with a 'best effort' root cause description.
     ///
     /// Meant to be used only by `Message` implementations.
+    #[doc(hidden)]
     #[cold]
-    pub(crate) fn new(description: impl Into<Cow<'static, str>>) -> DecodeError {
+    pub fn new(description: impl Into<Cow<'static, str>>) -> DecodeError {
         DecodeError {
             inner: Box::new(Inner {
                 description: description.into(),


### PR DESCRIPTION
With the release of prost 0.7 `DecodeError::new` is marked as `pub(crate)`. This makes custom implementations of `Message` difficult to create. Since `DecodeError` is already used in a public trait (`Message`) it seems reasonable to be able to construct it externally