### PR TITLE
Remove the downloading of big test data that's no longer available

### DIFF
--- a/protobuf/benches/dataset.rs
+++ b/protobuf/benches/dataset.rs
@@ -84,9 +84,6 @@ dataset!(google_message1_proto2, proto2::GoogleMessage1);
 dataset!(google_message1_proto3, proto3::GoogleMessage1);
 dataset!(google_message2, proto2::GoogleMessage2);
 dataset!(google_message3_1, GoogleMessage3);
-dataset!(google_message3_2, GoogleMessage3);
-dataset!(google_message3_3, GoogleMessage3);
-dataset!(google_message3_4, GoogleMessage3);
 dataset!(google_message3_5, GoogleMessage3);
 dataset!(google_message4, GoogleMessage4);
 
@@ -95,9 +92,6 @@ criterion_group!(
     google_message1_proto2,
     google_message1_proto3,
     google_message2,
-    google_message3_2,
-    google_message3_3,
-    google_message3_4,
 );
 
 criterion_group! {

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -270,8 +270,5 @@ fn install_datasets(src_dir: &Path, prefix_dir: &Path) -> Result<()> {
         .with_context(|| format!("failed to move {}", dataset.display()))?;
     }
 
-    download_tarball(
-        "https://storage.googleapis.com/protobuf_opensource_benchmark_data/datasets.tar.gz",
-        share_dir,
-    )
+    Ok(())
 }

--- a/protobuf/src/lib.rs
+++ b/protobuf/src/lib.rs
@@ -34,27 +34,6 @@ pub mod benchmarks {
             ))
         }
 
-        pub fn google_message3_2() -> &'static Path {
-            Path::new(concat!(
-                env!("PROTOBUF"),
-                "/share/dataset.google_message3_2.pb"
-            ))
-        }
-
-        pub fn google_message3_3() -> &'static Path {
-            Path::new(concat!(
-                env!("PROTOBUF"),
-                "/share/dataset.google_message3_3.pb"
-            ))
-        }
-
-        pub fn google_message3_4() -> &'static Path {
-            Path::new(concat!(
-                env!("PROTOBUF"),
-                "/share/dataset.google_message3_4.pb"
-            ))
-        }
-
         pub fn google_message3_5() -> &'static Path {
             Path::new(concat!(
                 env!("PROTOBUF"),


### PR DESCRIPTION
Hi! It looks like the build's broken because the benchmarking test data at https://storage.googleapis.com/protobuf_opensource_benchmark_data/datasets.tar.gz isn't there anymore. 


I've [opened an issue with protobuf](https://github.com/protocolbuffers/protobuf/issues/8283) to see if it's been moved somewhere (that URL is still referenced in their repo too), but I figured in the meantime removing its usage from prost would be a good idea.