### PR TITLE
Update from deprecated criterion::Benchmark to BenchmarkGroup

### DIFF
--- a/benches/varint.rs
+++ b/benches/varint.rs
@@ -1,13 +1,14 @@
 use std::mem;
 
 use bytes::Buf;
-use criterion::{Benchmark, Criterion, Throughput};
+use criterion::{Criterion, Throughput};
 use prost::encoding::{decode_varint, encode_varint, encoded_len_varint};
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
 fn benchmark_varint(criterion: &mut Criterion, name: &str, mut values: Vec<u64>) {
     // Shuffle the values in a stable order.
     values.shuffle(&mut StdRng::seed_from_u64(0));
+    let name = format!("varint/{}", name);
 
     let encoded_len = values
         .iter()
@@ -16,53 +17,58 @@ fn benchmark_varint(criterion: &mut Criterion, name: &str, mut values: Vec<u64>)
         .sum::<usize>() as u64;
     let decoded_len = (values.len() * mem::size_of::<u64>()) as u64;
 
-    let encode_values = values.clone();
-    let encode = Benchmark::new("encode", move |b| {
-        let mut buf = Vec::<u8>::with_capacity(encode_values.len() * 10);
-        b.iter(|| {
-            buf.clear();
-            for &value in &encode_values {
-                encode_varint(value, &mut buf);
-            }
-            criterion::black_box(&buf);
-        })
-    })
-    .throughput(Throughput::Bytes(encoded_len));
-
-    let decode_values = values.clone();
-    let decode = Benchmark::new("decode", move |b| {
-        let mut buf = Vec::with_capacity(decode_values.len() * 10);
-        for &value in &decode_values {
-            encode_varint(value, &mut buf);
-        }
-
-        b.iter(|| {
-            let mut buf = &mut buf.as_slice();
-            while buf.has_remaining() {
-                let result = decode_varint(&mut buf);
-                debug_assert!(result.is_ok());
-                criterion::black_box(&result);
-            }
-        })
-    })
-    .throughput(Throughput::Bytes(decoded_len));
-
-    let encoded_len = Benchmark::new("encoded_len", move |b| {
-        b.iter(|| {
-            let mut sum = 0;
-            for &value in &values {
-                sum += encoded_len_varint(value);
-            }
-            criterion::black_box(sum);
-        })
-    })
-    .throughput(Throughput::Bytes(decoded_len));
-
-    let name = format!("varint/{}", name);
     criterion
-        .bench(&name, encode)
-        .bench(&name, decode)
-        .bench(&name, encoded_len);
+        .benchmark_group(&name)
+        .bench_function("encode", {
+            let encode_values = values.clone();
+            move |b| {
+                let mut buf = Vec::<u8>::with_capacity(encode_values.len() * 10);
+                b.iter(|| {
+                    buf.clear();
+                    for &value in &encode_values {
+                        encode_varint(value, &mut buf);
+                    }
+                    criterion::black_box(&buf);
+                })
+            }
+        })
+        .throughput(Throughput::Bytes(encoded_len));
+
+    criterion
+        .benchmark_group(&name)
+        .bench_function("decode", {
+            let decode_values = values.clone();
+
+            move |b| {
+                let mut buf = Vec::with_capacity(decode_values.len() * 10);
+                for &value in &decode_values {
+                    encode_varint(value, &mut buf);
+                }
+
+                b.iter(|| {
+                    let mut buf = &mut buf.as_slice();
+                    while buf.has_remaining() {
+                        let result = decode_varint(&mut buf);
+                        debug_assert!(result.is_ok());
+                        criterion::black_box(&result);
+                    }
+                })
+            }
+        })
+        .throughput(Throughput::Bytes(decoded_len));
+
+    criterion
+        .benchmark_group(&name)
+        .bench_function("encoded_len", move |b| {
+            b.iter(|| {
+                let mut sum = 0;
+                for &value in &values {
+                    sum += encoded_len_varint(value);
+                }
+                criterion::black_box(sum);
+            })
+        })
+        .throughput(Throughput::Bytes(decoded_len));
 }
 
 fn main() {


### PR DESCRIPTION
This gets rid of the warnings generated by the benchmark code.  This
does not completely replecate the old behavior, which created three
benchmarks, all with their own throughput, but given the same name.  I
don't think that same thing is possible anymore with the non-deprecated
APIs.