### PR TITLE
Remove Cargo.lock from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 target
-Cargo.lock


### PR DESCRIPTION
Cargo.lock is required to make prost build in NixOS with standard build tools, I could make it myself and include it in nixos' repo but this would be a pain to maintain at each prost update. And it also seems like a good practice to include it in your rust projects, see : https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html