### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,27 +215,29 @@ message AddressBook {
 and the generated Rust code (`tutorial.rs`):
 
 ```rust
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Person {
     #[prost(string, tag="1")]
-    pub name: String,
+    pub name: ::prost::alloc::string::String,
     /// Unique ID number for this person.
     #[prost(int32, tag="2")]
     pub id: i32,
     #[prost(string, tag="3")]
-    pub email: String,
+    pub email: ::prost::alloc::string::String,
     #[prost(message, repeated, tag="4")]
-    pub phones: Vec<person::PhoneNumber>,
+    pub phones: ::prost::alloc::vec::Vec<person::PhoneNumber>,
 }
+/// Nested message and enum types in `Person`.
 pub mod person {
-    #[derive(Clone, Debug, PartialEq, Message)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PhoneNumber {
         #[prost(string, tag="1")]
-        pub number: String,
+        pub number: ::prost::alloc::string::String,
         #[prost(enumeration="PhoneType", tag="2")]
-        pub type_: i32,
+        pub r#type: i32,
     }
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Enumeration)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
     pub enum PhoneType {
         Mobile = 0,
         Home = 1,
@@ -243,10 +245,10 @@ pub mod person {
     }
 }
 /// Our address book file is just one of these.
-#[derive(Clone, Debug, PartialEq, Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AddressBook {
     #[prost(message, repeated, tag="1")]
-    pub people: Vec<Person>,
+    pub people: ::prost::alloc::vec::Vec<Person>,
 }
 ```
 

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -51,10 +51,10 @@
 //! `build.rs` build-script:
 //!
 //! ```rust,no_run
-//! # use std::io::Result;
+//! use std::io::Result;
 //! fn main() -> Result<()> {
-//!   prost_build::compile_protos(&["src/items.proto"], &["src/"])?;
-//!   Ok(())
+//!     prost_build::compile_protos(&["src/items.proto"], &["src/"])?;
+//!     Ok(())
 //! }
 //! ```
 //!


### PR DESCRIPTION
This is mostly to fix #69 by documenting generated enum conversion functions in the README. 

I also wanted to make sure the generated code example was up to date, and it wasn't, so there's a commit for that. 

And while setting up a project to generate the code from the `tutorial` example, I hit a small hiccup in `prost-build`'s documentation, so there's a fix for that :)

Thank you! I'm happy to make any changes ❤️ 