### PR TITLE
Enable zero-copy support for bytes::Bytes fields

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -991,12 +991,7 @@ pub mod bytes {
         // > last value it sees.
         //
         // [1]: https://developers.google.com/protocol-buffers/docs/encoding#optional
-
-        // NOTE: The use of BufExt::take() currently prevents zero-copy decoding
-        // for bytes fields backed by Bytes when docoding from Bytes. This could
-        // be addressed in the future by specialization.
-        // See also: https://github.com/tokio-rs/bytes/issues/374
-        value.replace_with(buf.take(len));
+        value.replace_with(buf.copy_to_bytes(len));
         Ok(())
     }
 


### PR DESCRIPTION
I just noticed this while poking through the code. Fields of type `Bytes` can now be slices of a greater `Bytes` that is passed to Message::decode

The referenced issue https://github.com/tokio-rs/bytes/issues/374 was implemented as Buf::copy_to_bytes and `Bytes` features the zero-copy implementation https://docs.rs/bytes/1.0.1/src/bytes/bytes.rs.html#526-560