### PR TITLE
Fix messages with optionals and oneofs

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -237,12 +237,12 @@ impl<'a> CodeGenerator<'a> {
 
             for (idx, oneof) in message.oneof_decl.into_iter().enumerate() {
                 let idx = idx as i32;
-                self.append_oneof(
-                    &fq_message_name,
-                    oneof,
-                    idx,
-                    oneof_fields.remove(&idx).unwrap(),
-                );
+                // optional fields create a synthetic oneof that we want to skip
+                let fields = match oneof_fields.remove(&idx) {
+                    Some(fields) => fields,
+                    None => continue,
+                };
+                self.append_oneof(&fq_message_name, oneof, idx, fields);
             }
 
             self.pop_mod();

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -597,7 +597,10 @@ mod tests {
 
     #[test]
     fn test_proto3_presence() {
-        let msg = proto3::presence::A { b: Some(42) };
+        let msg = proto3::presence::A {
+            b: Some(42),
+            foo: Some(proto3::presence::a::Foo::C(13)),
+        };
 
         check_message(&msg);
     }

--- a/tests/src/proto3_presence.proto
+++ b/tests/src/proto3_presence.proto
@@ -4,4 +4,8 @@ package proto3.presence;
 
 message A {
   optional int32 b = 1;
+
+  oneof foo {
+    int32 c = 2;
+  }
 }


### PR DESCRIPTION
Optional scalar fields create a synthetic oneof, but we don't add those fields to the oneof_fields map since we just want to treat them as optional fields. However, if a message containing an optional scalar field also contained a real oneof, the code would enter the oneof processing logic and panic trying to load the fields of the synthetic oneof. We now just treat a lack of oneof fields as an indication that this oneof was synthetic and skip it.

Closes #430 